### PR TITLE
Fix ChorusHub URLs to be backwards compatible

### DIFF
--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -71,7 +71,7 @@ namespace Chorus.ChorusHub
 
 		public static bool IsChorusHubInfo(string parameters)
 		{
-			return parameters.StartsWith("ChorusHubServerInfo");
+			return parameters.StartsWith("ChorusHubInfo");
 		}
 
 		public bool ServerIsCompatibleWithThisClient
@@ -81,7 +81,7 @@ namespace Chorus.ChorusHub
 
 		public override string ToString()
 		{
-			return string.Format("ChorusHubServerInfo?version={0}&address={1}&port={2}&hostname={3}", VersionOfThisCode, _ipAddress, _port, HostName);
+			return string.Format("ChorusHubInfo?version={0}&address={1}&port={2}&hostname={3}", VersionOfThisCode, _ipAddress, _port, HostName);
 		}
 
 		public string ServiceUri


### PR DESCRIPTION
The url changed but nothing else did.  Revert the format of the
url so that it maintains backwards compatibility.
