### PR TITLE
bug fix for CHR-30

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -442,16 +442,15 @@ namespace Chorus.VcsDrivers.Mercurial
 			} while (req.StartOfWindow < req.BundleSize);
 		}
 
-		private static string CalculateEstimatedTimeRemaining(int bundleSize, int chunkSize, int startOfWindow)
+		internal static string CalculateEstimatedTimeRemaining(int bundleSize, int chunkSize, int startOfWindow)
 		{
 			if (startOfWindow < 80000)
 			{
 				return ""; // wait until we've transferred 80K before calculating an ETA
 			}
-			int secondsRemaining = TargetTimeInSeconds*(bundleSize - startOfWindow)/chunkSize;
+			int secondsRemaining = (bundleSize - startOfWindow)/chunkSize*TargetTimeInSeconds;
 			if (secondsRemaining < 60)
 			{
-				//secondsRemaining = (secondsRemaining/5+1)*5;
 				return "(less than 1 minute)";
 			}
 			int minutesRemaining = secondsRemaining/60;

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
@@ -769,6 +769,26 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			}
 		}
 
+        // regression test for bug http://jira.palaso.org/issues/browse/CHR-30
+	    [Test]
+	    public void CalculateEstimatedTimeRemaining_VeryLargeBundleSize_DoesNotThrow()
+	    {
+	        const int largeBundleSize = 2147000000; // 2 GB
+	        const int chunkSize = 5000;
+	        const int startOfWindow = 100000;
+            Assert.DoesNotThrow(() => HgResumeTransport.CalculateEstimatedTimeRemaining(largeBundleSize, chunkSize, startOfWindow));
+	    }
+
+        [Test]
+        public void CalculateEstimatedTimeRemaining_ExpectedTimeRemainingString()
+        {
+            const int bundleSize = 5000000;
+            const int chunkSize = 100000;
+            const int startOfWindow = 100000;
+            Assert.That(HgResumeTransport.CalculateEstimatedTimeRemaining(bundleSize, chunkSize, startOfWindow), Is.EqualTo("(about 4 minutes)"));
+        }
+
+
 
 		private class BranchTestAdjunct : ISychronizerAdjunct
 		{


### PR DESCRIPTION
see: http://jira.palaso.org/issues/browse/CHR-30

This fixes an issue encountered by one of our users who received a crash in chorus while trying to push up their FLEx project to LD for the very first time.  The repo size being pushed up was about 450 MB.  There was an arithmetic overflow exception thrown in the resumable transport code when calculating the time remaining.

This pull request fixes the bug (for bundle sizes < 2GB) and adds a regression test.
