### PR TITLE
Adjust HgResumeTransport behavior on two edge cases

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -250,8 +250,8 @@ namespace Chorus.VcsDrivers.Mercurial
 							var msg = String.Format("Server temporarily unavailable: {0}",
 							Encoding.UTF8.GetString(response.Content));
 							_progress.WriteError(msg);
-							//Server returned unavailable - continue to retry.
-							continue;
+							//Server returned unavailable
+							break;
 						}
 						if (response.HttpStatus == HttpStatusCode.OK && response.Content.Length > 0)
 						{

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
@@ -509,26 +509,6 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		}
 
 		[Test]
-		public void Pull_GetRevisionServerResponseServerNotAvailable_NotAvailableMessageButRetriesAndSucceeds()
-		{
-			using(var e = new TestEnvironment("hgresumetest", ApiServerType.Dummy))
-			using(var provider = GetTransportProviderForTest(e))
-			{
-				e.LocalAddAndCommit();
-				var serverMessage = "The server is down for scheduled maintenance";
-				e.ApiServer.AddResponse(ApiResponses.NotAvailable(serverMessage));
-				var revisionResponse = ApiResponses.Custom(HttpStatusCode.OK);
-				revisionResponse.Content = Encoding.UTF8.GetBytes((e.Local.Repository.GetTip().Number.Hash + ":").ToArray());
-				e.ApiServer.AddResponse(revisionResponse);
-				e.ApiServer.AddResponse(ApiResponses.PullNoChange());
-				var transport = provider.Transport;
-				transport.Pull();
-				Assert.That(e.Progress.AllMessages, Contains.Item("Server temporarily unavailable: " + serverMessage));
-				Assert.That(e.Progress.AllMessages, Has.Member("No changes"));
-			}
-		}
-
-		[Test]
 		public void Pull_GetRevisionServerResponseServerNotAvailable_NotAvailableMessageAndFails()
 		{
 			using(var e = new TestEnvironment("hgresumetest", ApiServerType.Dummy))


### PR DESCRIPTION
Fixed two questionable behaviors while searching the code for
why some users of LanguageDepot have seen no-op merges happen
during their Send/Receives
- Count a ServiceUnavailable response as a timeout when
  retrieving revisions instead of logging and returning
  an empty map.
- If the server indicates that changes happened in the middle
  of a pull operation rebuild the local cache of revisions before
  restarting the pull.
