### PR TITLE
Fix text clipping issue from WS-46

### DIFF
--- a/src/Chorus/UI/Settings/SendReceiveSettings.Designer.cs
+++ b/src/Chorus/UI/Settings/SendReceiveSettings.Designer.cs
@@ -1,4 +1,4 @@
-﻿using Palaso.UI.WindowsForms.SettingProtection;
+﻿﻿using Palaso.UI.WindowsForms.SettingProtection;
 
 namespace Chorus.UI.Settings
 {
@@ -276,7 +276,7 @@ namespace Chorus.UI.Settings
 			this.settingsProtectionButton.Location = new System.Drawing.Point(14, 388);
 			this.settingsProtectionButton.Margin = new System.Windows.Forms.Padding(0);
 			this.settingsProtectionButton.Name = "settingsProtectionButton";
-			this.settingsProtectionButton.Size = new System.Drawing.Size(258, 37);
+			this.settingsProtectionButton.Size = new System.Drawing.Size(258, 47); // increase V space to fix text clipping issue: WS-46
 			this.settingsProtectionButton.TabIndex = 0;
 			//
 			// pictureBox3
@@ -303,7 +303,7 @@ namespace Chorus.UI.Settings
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this._cancelButton;
-			this.ClientSize = new System.Drawing.Size(508, 434);
+			this.ClientSize = new System.Drawing.Size(508, 439); // increase V space to fix text clipping issue: WS-46
 			this.Controls.Add(this.pictureBox3);
 			this.Controls.Add(this._okButton);
 			this.Controls.Add(this._cancelButton);

--- a/src/Chorus/UI/Sync/SyncStartControl.Designer.cs
+++ b/src/Chorus/UI/Sync/SyncStartControl.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+﻿﻿using System.Threading;
 using Palaso.UI.WindowsForms.SettingProtection;
 
 namespace Chorus.UI.Sync
@@ -135,7 +135,7 @@ namespace Chorus.UI.Sync
 			this._tableLayoutPanel.Location = new System.Drawing.Point(22, 13);
 			this._tableLayoutPanel.Name = "_tableLayoutPanel";
 			this._tableLayoutPanel.RowCount = 9;
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F)); // increase V space to fix text clipping issue: WS-46
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
@@ -144,7 +144,7 @@ namespace Chorus.UI.Sync
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
 			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F)); // increase V space to fix text clipping issue: WS-46
 			this._tableLayoutPanel.Size = new System.Drawing.Size(342, 351);
 			this._tableLayoutPanel.TabIndex = 0;
 			//
@@ -252,7 +252,7 @@ namespace Chorus.UI.Sync
 			this._settingsButton.Margin = new System.Windows.Forms.Padding(0);
 			this._settingsButton.Name = "_settingsButton";
 			this._settingsButton.Padding = new System.Windows.Forms.Padding(3, 0, 0, 0);
-			this._settingsButton.Size = new System.Drawing.Size(110, 22);
+			this._settingsButton.Size = new System.Drawing.Size(110, 25);  // increase V space to fix text clipping issue: WS-46
 			this._settingsButton.TabIndex = 5;
 			//
 			// l10NSharpExtender1
@@ -274,7 +274,7 @@ namespace Chorus.UI.Sync
 			this.commitMessageLabel.Multiline = true;
 			this.commitMessageLabel.Name = "commitMessageLabel";
 			this.commitMessageLabel.ReadOnly = true;
-			this.commitMessageLabel.Size = new System.Drawing.Size(336, 14);
+			this.commitMessageLabel.Size = new System.Drawing.Size(336, 25);  // increase V space to fix text clipping issue: WS-46
 			this.commitMessageLabel.TabIndex = 3;
 			this.commitMessageLabel.TabStop = false;
 			this.commitMessageLabel.Text = "Label this point in the project history (Optional) :";


### PR DESCRIPTION
On Send Receive Dialog:
a) 'Label this point in the project history'
b) the 'g' descender in 'Settings" button
On Send Receive Settings Dialog:
'Settings Protection' button
