### PR TITLE
Make history display grid read-only

### DIFF
--- a/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
+++ b/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
@@ -24,6 +24,10 @@ namespace Chorus.UI.Review.RevisionsInRepository
 			_model = model;
 			_model.ProgressDisplay = new NullProgress();
 			InitializeComponent();
+			// Don't let double clicks try to start editing a cell in the grid -- it's
+			// supposed to be a read-only display of the history.  (Linux WeSay is prone
+			// to crash on a double click if the grid is not read-only.)
+			_historyGrid.ReadOnly = true;
 			UpdateDisplay();
 			_showAdvanced.Visible=false;
 


### PR DESCRIPTION
This fixes a crash in WeSay: https://jira.sil.org/browse/WS-116.
