### PR TITLE
Work around bug in Mono 3 greedy pattern matching

### DIFF
--- a/build/build.mono.proj
+++ b/build/build.mono.proj
@@ -36,7 +36,7 @@
 		/>
 	</ItemGroup>
 	<Target Name="Clean">
-		<Exec Command="find $(RootDir)/. -name obj -type d -print0 | xargs -0 rm -rf" WorkingDirectory="$(RootDir)" />
+		<Exec Command="find $(RootDir)/src %5c( -name obj -o -name bin -o -name test-results %5c) -type d -print0 | xargs -0 rm -rf" WorkingDirectory="$(RootDir)" />
 		<Delete Files="@(ExistingObjectFiles)" />
 	</Target>
 
@@ -84,7 +84,7 @@
 		<Delete Files="@(ExistingPackageBuildFiles)" />
 	</Target>
 	<ItemGroup>
-		<Source Include="$(RootDir)/src/**/*" Exclude="$(RootDir)/src/**/obj/**/*;$(RootDir)/src/**/bin/**/*;$(RootDir)/src/**/test-results/**/*" />
+		<Source Include="$(RootDir)/src/**/*"/>
 		<Source Include="$(RootDir)/lib/DebugMono/**" Exclude="$(RootDir)/lib/DebugMono/Palaso*" />
 		<Source Include="$(RootDir)/lib/ReleaseMono/**" Exclude="$(RootDir)/lib/ReleaseMono/Palaso*" />
 		<Source Include="$(RootDir)/lib/common/**" />
@@ -98,7 +98,7 @@
 		<Source Include="$(RootDir)/externals/**" />
 		<Source Include="$(RootDir)/*" />
 	</ItemGroup>
-	<Target Name="SourcePackage" DependsOnTargets="PackageClean;SetAssemblyVersion">
+	<Target Name="SourcePackage" DependsOnTargets="Clean;PackageClean;SetAssemblyVersion">
 		<CreateProperty Value="$(OutputDir)/$(ApplicationNameLC)-$(Version).tar.gz">
 			<Output TaskParameter="Value" PropertyName="SourcePackageFileName" />
 		</CreateProperty>


### PR DESCRIPTION
With Mono 3, the DirectoryScanner is selecting too many files (or
not excluding enough files) when using "$(RootDir)/src/**/subdir/**/*"
pattern. This works around this (based on previous work on clean
target work around). It would be nice to fix the real problem,
but there will be someone that uses the system mono and not
our custom mono to build.
