### PR TITLE
Fix the display of merge conflict details

### DIFF
--- a/src/Chorus/UI/Notes/AnnotationEditorView.cs
+++ b/src/Chorus/UI/Notes/AnnotationEditorView.cs
@@ -18,6 +18,7 @@ namespace Chorus.UI.Notes
 			_model.UpdateContent += OnUpdateContent;
 			_model.UpdateStates += OnUpdateStates;
 			InitializeComponent();
+			_existingMessagesDisplay.Navigating += _existingMessagesDisplay_Navigating;
 			Visible = model.IsVisible;
 			ModalDialogMode = true;
 			_newMessage.Font = model.FontForNewMessage;
@@ -127,6 +128,14 @@ namespace Chorus.UI.Notes
 		{
 			WebBrowser x = sender as WebBrowser;
 			x.Document.BackColor = this.BackColor;
+		}
+
+		private void _existingMessagesDisplay_Navigating(object sender, WebBrowserNavigatingEventArgs e)
+		{
+			if (e.Url.Scheme == "about" || e.Url.Scheme == "file")
+				return;
+			e.Cancel = true;
+			_model.HandleLinkClicked(e.Url);
 		}
 
 		private void _closeButton_VisibleChanged(object sender, EventArgs e)

--- a/src/Chorus/UI/Notes/ConflictDetailsForm.Designer.cs
+++ b/src/Chorus/UI/Notes/ConflictDetailsForm.Designer.cs
@@ -21,6 +21,9 @@
 					components.Dispose();
 			}
 			_conflictDisplay = null;
+			if (_tempPath != null)
+				System.IO.File.Delete(_tempPath);
+			_tempPath = null;
 			base.Dispose(disposing);
 		}
 

--- a/src/Chorus/UI/Notes/ConflictDetailsForm.cs
+++ b/src/Chorus/UI/Notes/ConflictDetailsForm.cs
@@ -5,6 +5,8 @@ namespace Chorus.notes
 {
 	public partial class ConflictDetailsForm : Form
 	{
+		string _tempPath;
+
 		public ConflictDetailsForm()
 		{
 			InitializeComponent();
@@ -13,7 +15,15 @@ namespace Chorus.notes
 		public void SetDocumentText(string text)
 		{
 			_conflictDisplay.IsWebBrowserContextMenuEnabled = false;
-			_conflictDisplay.DocumentText = text;
+			// It would be nice to avoid writing a temp file and then loading it,
+			// but the Linux gecko didn't display anything with the code that sent
+			// the html text directly to the embedded browser. In the interest of
+			// keeping the code the same for all platforms, the approach below is
+			// now used.
+			if (_tempPath == null)
+				_tempPath = Palaso.IO.TempFile.WithExtension("htm").Path;
+			System.IO.File.WriteAllText(_tempPath, text);
+			_conflictDisplay.Url = new Uri(_tempPath);
 			_conflictDisplay.WebBrowserShortcutsEnabled = true;
 		}
 


### PR DESCRIPTION
This was broken on both Linux and Windows by the fix for WS-139 (which
deleted too much code), and was already broken on Linux in the same way
as WS-139.
