### PR TITLE
Call a wrapper for ChorusMerge.exe on Linux

### DIFF
--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -791,12 +791,15 @@ namespace Chorus.sync
 		/// <returns>false if nothing needed to be merged, true if the merge was done. Throws exception if there is an error.</returns>
 		private bool MergeTwoChangeSets(Revision head, Revision theirHead)
 		{
-			string chorusMergeFilePath = Path.Combine(ExecutionEnvironment.DirectoryOfExecutingAssembly, "ChorusMerge.exe");
 #if MONO
+			// We need to use a shell script wrapper on Linux to ensure the correct mono is called.
+			string chorusMergeFilePath = Path.Combine(ExecutionEnvironment.DirectoryOfExecutingAssembly, "chorusmerge");
 			// The replace is only useful for use with the MonoDevelop environment whcih doesn't honor $(Configuration) in the csproj files.
 			// When this is exported as an environment var it needs escaping to prevent the shell from replacing it with an empty string.
 			// When MonoDevelop is fixed this can be removed.
 			chorusMergeFilePath = chorusMergeFilePath.Replace("$(Configuration)", "\\$(Configuration)");
+#else
+			string chorusMergeFilePath = Path.Combine(ExecutionEnvironment.DirectoryOfExecutingAssembly, "ChorusMerge.exe");
 #endif
 			using (new ShortTermEnvironmentalVariable("HGMERGE", '"' + chorusMergeFilePath + '"'))
 			{


### PR DESCRIPTION
This is needed to ensure that the proper mono is used to execute it.
This fixes https://jira.sil.org/browse/WS-168.
