### PR TITLE
Fix refresh timer in history control to turn off properly

### DIFF
--- a/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
+++ b/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
@@ -205,9 +205,10 @@ namespace Chorus.UI.Review.RevisionsInRepository
 				if (_model.GetNeedRefresh())
 				{
 					RefreshRevisions();
-					//enhance, check after app itself is reactivated, or work in background.  It  is noticeably slow.
-					timer1.Enabled = false;//don't check again so long as we're visible
 				}
+				// if it doesn't need refreshing, why keep looking every 500ms?
+				//enhance, check after app itself is reactivated, or work in background.  It  is noticeably slow.
+				timer1.Enabled = false;//don't check again so long as we're visible
 			}
 		}
 	   private void OnRefresh(object sender, EventArgs e)


### PR DESCRIPTION
If something had changed while the control was not visible, it would
refresh once and stop the timer.  But if nothing had changed, the timer
would run forever, calling hg via process.Start() every 500ms while
showing the RevisionsInRepositoryView control.
