### PR TITLE
Ignore whitespace in ServerSettingsControl text boxes

### DIFF
--- a/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
@@ -98,6 +98,8 @@
 			this._projectId.TabIndex = 0;
 			this.toolTip1.SetToolTip(this._projectId, "Usually the Ethnologue code, e.g. \'tpi\'");
 			this._projectId.TextChanged += new System.EventHandler(this._projectId_TextChanged);
+			this._projectId.KeyDown += new System.Windows.Forms.KeyEventHandler(this._textbox_KeyDown);
+			this._projectId.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this._textbox_KeyPress);
 			//
 			// _accountName
 			//
@@ -111,6 +113,8 @@
 			this._accountName.TabIndex = 1;
 			this.toolTip1.SetToolTip(this._accountName, "This is your account on the server, which must already be set up.");
 			this._accountName.TextChanged += new System.EventHandler(this._accountName_TextChanged);
+			this._accountName.KeyDown += new System.Windows.Forms.KeyEventHandler(this._textbox_KeyDown);
+			this._accountName.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this._textbox_KeyPress);
 			//
 			// _password
 			//
@@ -124,6 +128,8 @@
 			this._password.TabIndex = 2;
 			this.toolTip1.SetToolTip(this._password, "This is the password belonging to this account, as it was set up on the server.");
 			this._password.TextChanged += new System.EventHandler(this._password_TextChanged);
+			this._password.KeyDown += new System.Windows.Forms.KeyEventHandler(this._textbox_KeyDown);
+			this._password.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this._textbox_KeyPress);
 			//
 			// _showCharacters
 			//

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -76,20 +76,47 @@ namespace Chorus.UI.Misc
 
 		private void _customUrl_TextChanged(object sender, EventArgs e)
 		{
-			Model.CustomUrl = _customUrl.Text.Trim();
+			Model.CustomUrl = _customUrl.Text;
 			UpdateDisplay();
 		}
 
 		private void _projectId_TextChanged(object sender, EventArgs e)
 		{
-			Model.ProjectId = _projectId.Text.Trim();
+			Model.ProjectId = _projectId.Text;
 			UpdateDisplay();
 		}
 
 		private void _accountName_TextChanged(object sender, EventArgs e)
 		{
-			Model.AccountName = _accountName.Text.Trim();
+			Model.AccountName = _accountName.Text;
 			UpdateDisplay();
+		}
+
+		bool _spaceForTextBox;
+
+		/// <summary>
+		/// Record whether the incoming character was from the space bar key.
+		/// </summary>
+		private void _textbox_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
+		{
+			if (e.KeyCode == Keys.Space)
+				_spaceForTextBox = true;
+		}
+
+		/// <summary>
+		/// If the incoming character is a space, ignore it.
+		/// </summary>
+		private void _textbox_KeyPress(object sender, System.Windows.Forms.KeyPressEventArgs e)
+		{
+			if (_spaceForTextBox)
+			{
+				e.Handled = true;
+				_spaceForTextBox = false;
+			}
+			else if (Char.IsWhiteSpace(e.KeyChar))
+			{
+				e.Handled = true;
+			}
 		}
 
 		private void _password_TextChanged(object sender, EventArgs e)


### PR DESCRIPTION
The existing code to strip whitespace had interesting behavior
in Mono.  See https://jira.sil.org/browse/WS-201.  The new code
follows a pattern suggested in MSDN.
