### PR TITLE
WS-289: Enable excluding some USB devices

### DIFF
--- a/src/Chorus/UI/UsbDriveLocator.cs
+++ b/src/Chorus/UI/UsbDriveLocator.cs
@@ -62,8 +62,14 @@ namespace Chorus.UI
 			{
 				var usbRoots = new Palaso.UsbDrive.RetrieveUsbDriveInfo().GetDrives()
 					.Select(u => u.RootDirectory.FullName);
+				// In Balsa, the boot device (SD Card or USB Stick) shows up as one of the
+				// drives and it shouldn't be used for S/R.  Balsa will be changed to
+				// include a .chorus-hidden file in the root paritions that should not be
+				// used for S/R.  A user can include this file in USB attached drive that
+				// they don't want Chorus to use.
 				var usbDrives = System.IO.DriveInfo.GetDrives()
-					.Where(d => usbRoots.Contains(d.RootDirectory.FullName));
+					.Where(d => usbRoots.Contains(d.RootDirectory.FullName) &&
+								d.RootDirectory.GetFiles(".chorus-hidden").Count() == 0);
 				lock (_usbDrives)
 				{
 					_usbDrives.Clear();


### PR DESCRIPTION
In Balsa, the computer could be running off of a USB device and it
should not be considered for S/R.  Currently the SyncStartModel only
allows one possible USB device to be connected while initiating a
S/R via USB.  This change allows the user (or Balsa distribution
creator) to put a .chorus-hidden file in the root directory of
USB devices that should not be considered for S/R.
