### PR TITLE
Sign ChorusHubInstaller

### DIFF
--- a/build/Chorus.proj
+++ b/build/Chorus.proj
@@ -185,6 +185,11 @@
 
 	</Target>
 
+	<Target Name="SignChorusHub" DependsOnTargets="ChorusHubInstaller">
+		<Message Text="Attempting to sign ChorusHubInstaller.msi" Importance="high" />
+		<Exec Command='sign "$(RootDir)\output\Release\ChorusHubInstaller.msi" ' />
+	</Target>
+
 	<Target Name="MakeWixForDistFiles" Condition="'$(OS)'=='Windows_NT'">
 		<MakeWixForDirTree
 			DirectoryReferenceId="mercurial"


### PR DESCRIPTION
It is confusing to users to download/install ChorusHubInstaller.msi
without it being signed.  Create a new "SignChorusHub" target that
will be run by the Team City build
"ChorusHub master Windows Service Installer-sans publish"

I have tested this change by pointing the above mentioned build
to this change in my fork of this repo.  See build 2.4.14 of that build.