### PR TITLE
Remove unnecessary ini modification from merge module

### DIFF
--- a/src/Installer/ChorusMergeModule.wxs
+++ b/src/Installer/ChorusMergeModule.wxs
@@ -16,13 +16,6 @@ http://blogs.msdn.com/robmen/archive/2003/10/04/56479.aspx -->
 		<Directory Id="mercurial" Name="mercurial">
 		  <Component Id="mercurial.ini" Guid="FA715224-9B87-44a4-B6D3-18EC40712266">
 			<File Id="mercurial.ini" Name="mercurial.ini" Source="..\..\mercurial\mercurial.ini" />
-			<IniFile Id="mercurial.ini_extension_fixutf8"
-				   Action="addLine"
-				   Directory="mercurial"
-				   Section="extensions"
-				   Name="mercurial.ini"
-				   Key="fixutf8"
-				   Value="[#fixutf8.py]" />
 		  </Component>
 		  <!-- This will be filled in by the generated fragment GeneratedMercurial.wxs -->
 		</Directory>


### PR DESCRIPTION
* Delete the section from the merge module source which is
  unnecessary after recent Chorus modifications and which is
  also invalid (due to cross component linking) in new Wix versions.