### PR TITLE
Fix problem with missing extensions on USB clones.

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
@@ -27,6 +27,8 @@ namespace Chorus.VcsDrivers.Mercurial
 				targetDirectory = local.CloneLocalWithoutUpdate(targetDirectory);
 				File.WriteAllText(Path.Combine(targetDirectory, "~~Folder has an invisible repository.txt"), "In this folder, there is a (possibly hidden) folder named '.hg' that contains the actual data of this Chorus repository. Depending on your Operating System settings, that leading '.' might make the folder invisible to you. But Chorus clients (WeSay, FLEx, OneStory, etc.) can see it and can use this folder to perform Send/Receive operations.");
 
+				var cloneRepo = new HgRepository(targetDirectory, progress);
+				cloneRepo.CheckAndUpdateHgrc();
 				if (alsoDoCheckout)
 				{
 					// string userIdForCLone = string.Empty; /* don't assume it's this user... a repo on a usb key probably shouldn't have a user default */

--- a/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Chorus.VcsDrivers;
 using Chorus.VcsDrivers.Mercurial;
 using Ionic.Zip;
+using LibChorus.TestUtilities;
 using NUnit.Framework;
 using Palaso.Progress;
 using Palaso.TestUtilities;
@@ -134,6 +136,22 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				var exception = Assert.Throws<ApplicationException>(() => hgRepo.AddAndCheckinFile(parentFile.Path));
 				Assert.That(exception.Message.Contains("Unable to recover") && !exception.Message.Contains("unresolved merge"),
 					String.Format("Repository should have conflict in retrying the merge, but not have an incomplete merge: {0}", exception.Message));
+			}
+		}
+
+		[Test]
+		public void CloneToUsbWithoutUpdate_CreatesExtensionSectionInHgrc()
+		{
+			using(var repo = new RepositorySetup("source"))
+			using(var f = new TemporaryFolder("clonetest"))
+			{
+				// The MakeCloneFromLocalToLocal with false on alsoDoCheckout is the core of the usb clone operation.
+				// We need to make sure that the extensions are used in the clone
+				HgHighLevel.MakeCloneFromLocalToLocal(repo.ProjectFolder.Path, f.Path, false, new NullProgress());
+				var hgFolderPath = Path.Combine(f.Path, ".hg");
+				Assert.IsTrue(Directory.Exists(hgFolderPath));
+				var hgrcLines = File.ReadAllLines(Path.Combine(hgFolderPath, "hgrc"));
+				CollectionAssert.Contains(hgrcLines, "[extensions]", "no extensions in bare clone");
 			}
 		}
 	}


### PR DESCRIPTION
Backward compatibility testing revealed that the extensions were not
being set properly in a USB clone using Mercurial 3.

* If a MakeCloneFromLocalToLocal is called with alsoDoCheckout
  set to false make sure we still get extensions into the hgrc file.
* Add test to minimally verify this.