### PR TITLE
Handle whole file deletion vs changed robustly

### DIFF
--- a/src/ChorusMerge.Tests/ChorusMergeTests.cs
+++ b/src/ChorusMerge.Tests/ChorusMergeTests.cs
@@ -53,7 +53,7 @@ namespace ChorusMerge.Tests
 			return Program.Main(new[] {group.BobFile.Path, group.AncestorFile.Path, group.SallyFile.Path});
 		}
 
-		[Test, Ignore("re-enable, after ini file fix is in.")]
+		[Test]
 		public void Main_Utf8FilePaths_FileNamesOk()
 		{
 			using (var e = new TemporaryFolder("ChorusMergeTest"))

--- a/src/LibChorus/LibChorus.csproj
+++ b/src/LibChorus/LibChorus.csproj
@@ -319,7 +319,6 @@
 	<Compile Include="VcsDrivers\Mercurial\HgExceptions.cs" />
 	<Compile Include="VcsDrivers\Mercurial\HgHighLevel.cs" />
 	<Compile Include="sync\CommitCop.cs" />
-	<Compile Include="Utilities\ProcessOutputReader.cs" />
 	<Compile Include="Utilities\FailureSimulator.cs" />
 	<Compile Include="merge\IChangeReport.cs" />
 	<Compile Include="merge\MergeOrder.cs" />
@@ -381,6 +380,7 @@
 	<Compile Include="Properties\AssemblyInfo.cs" />
 	<Compile Include="VcsDrivers\Mercurial\Revision.cs" />
 	<Compile Include="VcsDrivers\Mercurial\HgRunner.cs" />
+    <Compile Include="Utilities\HgProcessOutputReader.cs" />
   </ItemGroup>
   <ItemGroup>
 	<BootstrapperPackage Include="Microsoft.Net.Framework.2.0">

--- a/src/LibChorus/Utilities/ExecutionResult.cs
+++ b/src/LibChorus/Utilities/ExecutionResult.cs
@@ -8,8 +8,8 @@ namespace Chorus.Utilities
 		public int ExitCode;
 		public string StandardError;
 		public string StandardOutput;
-		public bool DidTimeOut { get { return ExitCode == ProcessOutputReader.kTimedOut; } }
-		public bool UserCancelled { get { return ExitCode == ProcessOutputReader.kCancelled; } }
+		public bool DidTimeOut { get { return ExitCode == HgProcessOutputReader.kTimedOut; } }
+		public bool UserCancelled { get { return ExitCode == HgProcessOutputReader.kCancelled; } }
 
 		public ExecutionResult()
 		{

--- a/src/LibChorus/Utilities/HgProcessOutputReader.cs
+++ b/src/LibChorus/Utilities/HgProcessOutputReader.cs
@@ -2,13 +2,18 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
+using Chorus.merge.xml.generic;
 using Palaso.Progress;
 using ThreadState=System.Threading.ThreadState;
 
 namespace Chorus.Utilities
 {
-	public class ProcessOutputReader
+	/// <summary>
+	/// This class interacts with the output (and possibly input) when we launch an hg process
+	/// </summary>
+	public class HgProcessOutputReader
 	{
 		private Thread _outputReader;
 		private Thread _errorReader;
@@ -21,6 +26,13 @@ namespace Chorus.Utilities
 			get { return _standardOutput; }
 		}
 		private string _standardError = "";
+		private string _rootDirectory;
+
+		public HgProcessOutputReader(string fromDirectory)
+		{
+			_rootDirectory = fromDirectory;
+		}
+
 		public const int kCancelled = 98;
 		public const int kTimedOut = 99;
 		/// <summary>
@@ -92,6 +104,56 @@ namespace Chorus.Utilities
 
 		}
 
+		/// <summary>
+		/// This method will detect changed vs deleted file conflicts in the output coming from mercurial.
+		/// It produces a conflict for that situation and tells mercurial to keep the changed file.
+		/// <note>The default response for mercurial is to keep the changed, but on some user systems (Windows 8?)
+		/// mercurial will pause waiting for input instead of using the default answer.</note>
+		/// </summary>
+		private bool HandleChangedVsDeletedFiles(string line, StreamWriter standardInput)
+		{
+			// The two situations we are dealing with are:
+			//
+			// local changed [filename] which remote deleted
+			// use (c)hanged version or (d)elete?
+			//		and
+			// remote changed [filename] which local deleted
+			// use (c)hanged version or leave (d)eleted?
+
+			string changedVsDeletedFile = null;
+			var match = Regex.Match(line, @"local changed (.*) which remote deleted");
+			if(match.Captures.Count > 0)
+			{
+				changedVsDeletedFile = match.Groups[1].Value;
+			}
+			else
+			{
+				match = Regex.Match(line, @"remote changed (.*) which local deleted");
+				if(match.Captures.Count > 0)
+				{
+					changedVsDeletedFile = match.Groups[1].Value;
+				}
+			}
+			if(changedVsDeletedFile != null)
+			{
+				var conflictPath = Path.Combine(_rootDirectory, changedVsDeletedFile);
+				var conflictReport = new FileChangedVsFileDeletedConflict(conflictPath);
+				using(var chorusNoteCreator = new ChorusNotesMergeEventListener(ChorusNotesMergeEventListener.GetChorusNotesFilePath(conflictPath)))
+				{
+					chorusNoteCreator.ConflictOccurred(conflictReport);
+				}
+				return true;
+			}
+			// Send hg the response it might be waiting for:
+			if(line.Contains(@"(c)hanged") && line.Contains(@"(d)elete"))
+			{
+				standardInput.WriteLine('c');
+				return true;
+			}
+			// This input line was not related to a Changed vs Deleted File situation
+			return false;
+		}
+
 		private void ReadStream(object args)
 		{
 			var result = new StringBuilder();
@@ -104,7 +166,8 @@ namespace Chorus.Utilities
 			   if (s != null)
 			   {
 				   // Eat up any heartbeat lines from the stream, also remove warnings about dotencode
-				   if (s != Properties.Resources.MergeHeartbeat && s != DotEncodeWarning)
+				   if (s != Properties.Resources.MergeHeartbeat && s != DotEncodeWarning
+						&& !HandleChangedVsDeletedFiles(s, readerArgs.Proc.StandardInput))
 				   {
 					   result.AppendLine(s.Trim());
 				   }

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -556,7 +556,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 
 			ExecutionResult result = ExecuteErrorsOk(b.ToString(), _pathToRepository, secondsBeforeTimeout, _progress);
-			if (ProcessOutputReader.kCancelled == result.ExitCode)
+			if (HgProcessOutputReader.kCancelled == result.ExitCode)
 			{
 				_progress.WriteWarning("User Cancelled");
 				return result;

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRunner.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRunner.cs
@@ -8,6 +8,7 @@ using System.Net.Mime;
 using System.Threading;
 using Chorus.Utilities;
 using Palaso.Progress;
+using Palaso.Reporting;
 
 namespace Chorus.VcsDrivers.Mercurial
 {
@@ -56,6 +57,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			process.StartInfo.EnvironmentVariables["HGENCODINGMODE"] = "strict";
 			process.StartInfo.RedirectStandardError = true;
 			process.StartInfo.RedirectStandardOutput = true;
+			process.StartInfo.RedirectStandardInput = true;
 			process.StartInfo.UseShellExecute = false;
 			process.StartInfo.CreateNoWindow = true;
 			process.StartInfo.WorkingDirectory = fromDirectory;
@@ -67,6 +69,10 @@ namespace Chorus.VcsDrivers.Mercurial
 			//The fixutf8 extension's job is to get hg to talk in this encoding
 			process.StartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
 			process.StartInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
+			if(!String.IsNullOrEmpty(debug))
+			{
+				Logger.WriteEvent("Running hg command: hg --debug {0}", commandLine);
+			}
 			try
 			{
 				process.Start();
@@ -91,7 +97,7 @@ namespace Chorus.VcsDrivers.Mercurial
 					throw error;
 				}
 			}
-			var processReader = new ProcessOutputReader();
+			var processReader = new HgProcessOutputReader(fromDirectory);
 			if(secondsBeforeTimeOut > TimeoutSecondsOverrideForUnitTests)
 				secondsBeforeTimeOut = TimeoutSecondsOverrideForUnitTests;
 

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgWrappingTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgWrappingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Chorus.VcsDrivers.Mercurial;
+using Chorus.sync;
 using LibChorus.TestUtilities;
 using NUnit.Framework;
 using Palaso.Progress;
@@ -463,6 +464,54 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				var bundleFilePath = setup.RootFolder.GetNewTempFile(false).Path;
 				File.WriteAllText(bundleFilePath, "bogus bundle file contents");
 				Assert.That(setup.Repository.Unbundle(bundleFilePath), Is.False);
+			}
+		}
+
+		[Test]
+		public void FileDeletedLocallyAndChangedRemotelyKeepsChanged()
+		{
+			using(var localRepo = new RepositorySetup("unbundleTests"))
+			{
+				var localFilePath = localRepo.ProjectFolder.GetNewTempFile(true).Path;
+				localRepo.AddAndCheckinFile(localFilePath, "file to change and delete");
+				using(var remoteRepo = new RepositorySetup("remote", localRepo))
+				{
+					remoteRepo.CheckinAndPullAndMerge();
+					var remoteFilePath = Path.Combine(remoteRepo.ProjectFolder.Path, Path.GetFileName(localFilePath));
+					Assert.That(File.Exists(remoteFilePath)); // Make sure that we have a file to delete.
+					File.Delete(remoteFilePath);
+					remoteRepo.SyncWithOptions( new SyncOptions { CheckinDescription = "delete file", DoMergeWithOthers = false, DoPullFromOthers = false, DoSendToOthers = false});
+					Assert.That(!File.Exists(remoteFilePath)); // Make sure we actually got rid of it.
+					localRepo.ChangeFileAndCommit(localFilePath, "new file contents", "changed the file");
+					localRepo.CheckinAndPullAndMerge(remoteRepo);
+					Assert.That(File.Exists(localFilePath), Is.True, "Did not keep changed file.");
+					var chorusNotesPath = localFilePath + ".ChorusNotes";
+					Assert.That(File.Exists(chorusNotesPath), "Did not record conflict");
+					AssertThatXmlIn.File(chorusNotesPath).HasAtLeastOneMatchForXpath("//annotation[@class='mergeconflict']");
+				}
+			}
+		}
+
+		[Test]
+		public void FileDeletedRemotelyAndChangedLocallyKeepsChanged()
+		{
+			using(var localRepo = new RepositorySetup("unbundleTests"))
+			{
+				var localFilePath = localRepo.ProjectFolder.GetNewTempFile(true).Path;
+				localRepo.AddAndCheckinFile(localFilePath, "file to change and delete");
+				using(var remoteRepo = new RepositorySetup("remote", localRepo))
+				{
+					remoteRepo.CheckinAndPullAndMerge();
+					var remoteFilePath = Path.Combine(remoteRepo.ProjectFolder.Path, Path.GetFileName(localFilePath));
+					remoteRepo.ChangeFileAndCommit(remoteFilePath, "new contents", "changed file");
+					File.Delete(localFilePath);
+					localRepo.SyncWithOptions(new SyncOptions { CheckinDescription = "delete file", DoMergeWithOthers = false, DoPullFromOthers = false, DoSendToOthers = false });
+					localRepo.CheckinAndPullAndMerge(remoteRepo);
+					Assert.That(File.Exists(localFilePath), Is.True, "Did not keep changed file.");
+					var chorusNotesPath = localFilePath + ".ChorusNotes";
+					Assert.That(File.Exists(chorusNotesPath), "Did not record conflict");
+					AssertThatXmlIn.File(chorusNotesPath).HasAtLeastOneMatchForXpath("//annotation[@class='mergeconflict']");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* Detect and respond to Hg information about file deletion vs change conflicts which could block a merge.
* Create new conflict for this situation.
* Rename ProcessOutputReader to HgProcessOutputReader  to accurately reflect its purpose