### PR TITLE
Fully eliminate the dotencode extension in USB clones

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
@@ -34,7 +34,8 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			using (new ConsoleProgress("Trying to Create repository clone at {0}", targetDirectory))
 			{
-				targetDirectory = local.CloneLocalWithoutUpdate(targetDirectory, cloningFromUsb ? null : "--config format.dotencode=False");
+				// Make a backward compatibile clone if cloning to USB (http://mercurial.selenic.com/wiki/UpgradingMercurial) 
+				targetDirectory = local.CloneLocalWithoutUpdate(targetDirectory, cloningFromUsb ? null : "--config format.dotencode=false --pull");
 				File.WriteAllText(Path.Combine(targetDirectory, "~~Folder has an invisible repository.txt"), "In this folder, there is a (possibly hidden) folder named '.hg' that contains the actual data of this Chorus repository. Depending on your Operating System settings, that leading '.' might make the folder invisible to you. But Chorus clients (WeSay, FLEx, OneStory, etc.) can see it and can use this folder to perform Send/Receive operations.");
 
 				if (cloningFromUsb)

--- a/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
+++ b/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
@@ -74,7 +74,7 @@ namespace LibChorus.Tests.sync
 		}
 
 		[Test]
-		public void SyncNow_UsbGetsBareCloneWithReadme()
+		public void SyncNow_UsbGetsBackwardCompatibleBareCloneWithReadme()
 		{
 			Synchronizer synchronizer = Synchronizer.FromProjectConfiguration(_project, _progress);
 			SyncOptions options = new SyncOptions();
@@ -85,11 +85,15 @@ namespace LibChorus.Tests.sync
 			WriteTestFile("version two");
 
 			synchronizer.SyncNow(options);
-			string dir = Path.Combine(UsbKeyRepositorySource.RootDirForUsbSourceDuringUnitTest, "foo project");
-			Assert.IsTrue(Directory.Exists(dir));
-			Assert.IsTrue(File.Exists(dir.CombineForPath(dir, "~~Folder has an invisible repository.txt")));
-
+			var projectDir = Path.Combine(UsbKeyRepositorySource.RootDirForUsbSourceDuringUnitTest, "foo project");
+			Assert.IsTrue(Directory.Exists(projectDir));
+			// SUT backward compatible clone has no dotencode in the requires file
+			var requiresLines = File.ReadAllLines(Path.Combine(projectDir, ".hg", "requires"));
+			CollectionAssert.DoesNotContain(requiresLines, "dotencode");
+			// SUT bare clone should get this text file
+			Assert.IsTrue(File.Exists(projectDir.CombineForPath(projectDir, "~~Folder has an invisible repository.txt")));
 		}
+
 		[Test]
 		public void SyncNow_AlreadySetupFauxUsbAvailable_UsbGetsSync()
 		{


### PR DESCRIPTION
* Add the extra --pull parameter required in Hg 3 to make a backward
  compatible clone
* Add unit test to verify that the clone has had the dotencode
  requirement eliminated