### PR TITLE
Remove empty Dispose() method

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgNormalTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgNormalTransport.cs
@@ -46,10 +46,5 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 			_repo.CloneFromSource(_targetLabel, _targetUri);
 		}
-
-		public void Dispose()
-		{
-			// how do we clean up here?  Do we need to do anything?
-		}
 	}
 }


### PR DESCRIPTION
We shouldn't have an empty Dispose() method around unless we have
to implement IDisposable because that makes things more confusing
and suggests that we have to dispose objects of this class.