### PR TITLE
Increase Chorus version number to 2.5

### DIFF
--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -10,7 +10,7 @@
 		<Message Text="BuildCounter: $(BuildCounter)" Importance="high"/>
 
 		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies).     -->
-		<CreateProperty Value="2.4.$(BuildCounter).0">
+		<CreateProperty Value="2.5.$(BuildCounter).0">
 			<Output PropertyName="Version" TaskParameter="Value"/>
 		</CreateProperty>
 


### PR DESCRIPTION
During the introduction of the strong name and no strong name
build version downgrades of the chorus libraries happened.
This causes issues upgrading applications that use the chorus merge
module.

* Increase the version of Chorus to 2.5 so that freshly built
  installers will not have downgrade issues for chorus assemblies