### PR TITLE
Abort service start if another Hub is running

### DIFF
--- a/src/ChorusHub/ChorusHub.cs
+++ b/src/ChorusHub/ChorusHub.cs
@@ -1,5 +1,7 @@
-﻿using System.ServiceProcess;
+﻿using System.Diagnostics;
+using System.ServiceProcess;
 using System.Timers;
+using Chorus.ChorusHub;
 
 namespace ChorusHub
 {
@@ -25,8 +27,15 @@ namespace ChorusHub
 		{
 			if (!_running)
 			{
+				var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();
+				if(chorusHubServerInfo != null)
+				{
+					EventLog.WriteEntry(string.Format("Only one ChorusHub can be run on a network but there is already one running on {0}", chorusHubServerInfo.HostName), EventLogEntryType.Error);
+					Stop();
+					return;
+				}
 				_chorusHubServer = new ChorusHubServer();
-				EventLog.WriteEntry("Chorus Hub Service is starting....");
+				EventLog.WriteEntry("Chorus Hub Service is starting....", EventLogEntryType.Information);
 				_running = _chorusHubServer.Start(true);
 				_serviceTimer = new Timer
 				{
@@ -35,7 +44,7 @@ namespace ChorusHub
 				_serviceTimer.Elapsed += ServiceTimerOnElapsed;
 				_serviceTimer.Start();
 			}
-			EventLog.WriteEntry("Chorus Hub Service started.");
+			EventLog.WriteEntry("Chorus Hub Service started.", EventLogEntryType.Information);
 		}
 
 		protected override void OnStop()

--- a/src/ChorusHub/ChorusHubServer.cs
+++ b/src/ChorusHub/ChorusHubServer.cs
@@ -33,7 +33,7 @@ namespace ChorusHub
 					_hgServer = new HgServeRunner(ChorusHubOptions.RootDirectory, ChorusHubOptions.MercurialPort);
 					if(!_hgServer.Start())
 					{
-						EventLog.WriteEntry("Application", "ChorusHub: Failed to start Hg Server", EventLogEntryType.Error);
+						EventLog.WriteEntry("ChorusHub", "Failed to start Hg Server", EventLogEntryType.Error);
 						return false;
 					}
 				}
@@ -59,7 +59,7 @@ namespace ChorusHub
 			{
 				var logEntryMessage = string.Format("ChorusHub failed to start: {0}{1}{2}{1}{3}", error.Message, Environment.NewLine,
 					error.StackTrace, error.InnerException);
-				EventLog.WriteEntry("Application", logEntryMessage, EventLogEntryType.Error);
+				EventLog.WriteEntry("ChorusHub", logEntryMessage, EventLogEntryType.Error);
 				return false;
 			}
 		}


### PR DESCRIPTION
* Abort the service startup if another ChorusHub is detected on the
  network.
* Improve the logging so that all failures are listed as ChorusHub