### PR TITLE
Make server and internet clone models more UI independent 

### DIFF
--- a/src/Chorus.Tests/Chorus.Tests.csproj
+++ b/src/Chorus.Tests/Chorus.Tests.csproj
@@ -135,10 +135,8 @@
     <Compile Include="ChorusSystemTests.cs" />
     <Compile Include="ChorusSystemUsage.cs" />
     <Compile Include="clone\ClonerTests.cs" />
-    <Compile Include="UI\Clone\GetCloneFromInternetModelTest.cs" />
     <Compile Include="UI\Clone\GetSharedProjectModelTests.cs" />
     <Compile Include="UI\Clone\TargetFolderControlTests.cs" />
-    <Compile Include="UI\Misc\ServerSettingsModelTests.cs" />
     <Compile Include="UI\Misc\ServerSettingsDialogTests.cs" />
     <Compile Include="UI\Misc\ReadinessPanelTests.cs" />
     <Compile Include="UI\notes\AnnotationModelTests.cs" />

--- a/src/Chorus.Tests/UI/Misc/ServerSettingsDialogTests.cs
+++ b/src/Chorus.Tests/UI/Misc/ServerSettingsDialogTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows.Forms;
 using Chorus.UI.Misc;
 using NUnit.Framework;
+using Chorus.Model;
 
 namespace Chorus.Tests.UI.Clone
 {

--- a/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
@@ -50,7 +50,8 @@ namespace Chorus.Tests
 			Directory.Delete(_pathToTestRoot, true);
 		}
 
-		[Test, Category("KnownMonoIssue")]
+		[Test]
+		[Platform(Exclude="Linux", Reason = "Known mono issue")]
 		public void AfterSyncLogNotEmpty()
 		{
 			_model.Sync(false);
@@ -64,7 +65,7 @@ namespace Chorus.Tests
 					Assert.Fail("Gave up waiting.");
 				}
 			}
-				 Assert.IsNotEmpty(_progress.Text);
+			Assert.IsNotEmpty(_progress.Text);
 		}
 
 		[Test]
@@ -110,7 +111,8 @@ namespace Chorus.Tests
 			Assert.IsNotNull(results.ErrorEncountered);
 		}
 
-		[Test, Category("KnownMonoIssue")]
+		[Test]
+		[Platform(Exclude="Linux", Reason = "Known mono issue")]
 		public void Sync_Cancelled_ResultsHaveCancelledEqualsTrue()
 		{
 			_model = new SyncControlModel(_project, SyncUIFeatures.Minimal, null);

--- a/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
@@ -96,17 +96,17 @@ namespace Chorus.Tests
 			_model.AddMessagesDisplay(progress);
 			SyncResults results = null;
 			_model.SynchronizeOver += new EventHandler((sender, e) => results = (sender as SyncResults));
-		   _model.Sync(true);
-		   var start = DateTime.Now;
-		   while (results == null)
-		   {
-			   Thread.Sleep(100);
-			   Application.DoEvents(); //else the background worker may starve
-			   if ((DateTime.Now.Subtract(start).Minutes > 1))
-			   {
-				   Assert.Fail("Gave up waiting.");
-			   }
-		   }
+			_model.Sync(true);
+			var start = DateTime.Now;
+			while (results == null)
+			{
+				Thread.Sleep(100);
+				Application.DoEvents(); //else the background worker may starve
+				if ((DateTime.Now.Subtract(start).Minutes > 1))
+				{
+					Assert.Fail("Gave up waiting.");
+				}
+			}
 			Assert.IsFalse(results.Succeeded);
 			Assert.IsNotNull(results.ErrorEncountered);
 		}
@@ -195,11 +195,6 @@ namespace Chorus.Tests
 												 _pathToTestRoot.CombineForPath(".hg"));
 											 _model.AsyncLocalCheckIn("testing", null);
 										 });
-		}
-
-		private void _model_SynchronizeOver(object sender, EventArgs e)
-		{
-			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/Chorus/Chorus.csproj
+++ b/src/Chorus/Chorus.csproj
@@ -230,7 +230,6 @@
     <Compile Include="UI\Clone\GetCloneFromUsbDialog.Designer.cs">
       <DependentUpon>GetCloneFromUsbDialog.cs</DependentUpon>
     </Compile>
-    <Compile Include="UI\Misc\ServerSettingsModel.cs" />
     <Compile Include="UI\Misc\TroubleshootingView.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
@@ -1,103 +1,28 @@
 ﻿using System;
-using System.IO;
 using System.Media;
 using System.Threading;
-using Chorus.UI.Misc;
-using Chorus.Utilities;
-using Chorus.VcsDrivers;
-using Chorus.VcsDrivers.Mercurial;
 using L10NSharp;
 using SIL.Progress;
 using SIL.Reporting;
+using Chorus.Model;
+using Chorus.Utilities;
+using Chorus.VcsDrivers.Mercurial;
 
 namespace Chorus.UI.Clone
 {
-	public class GetCloneFromInternetModel : ServerSettingsModel
+	public class GetCloneFromInternetModel : InternetCloneSettingsModel
 	{
 		private bool _showCloneSpecificSettings;
-		private MultiProgress _progress;
 
-
-		public GetCloneFromInternetModel(string parentDirectoryToPutCloneIn)
-		{
-			_showCloneSpecificSettings = true;
-			ParentDirectoryToPutCloneIn = parentDirectoryToPutCloneIn;
-			_progress = new MultiProgress();
-		}
-		public GetCloneFromInternetModel()
+		public GetCloneFromInternetModel(): base()
 		{
 			_showCloneSpecificSettings = false;
-			_progress = new MultiProgress();
 		}
 
-		public string ParentDirectoryToPutCloneIn { get; set; }
-
-
-		public override void InitFromUri(string url)
+		public GetCloneFromInternetModel(string parentDirectoryToPutCloneIn): base(parentDirectoryToPutCloneIn)
 		{
-			base.InitFromUri(url);
-			LocalFolderName = UrlHelper.GetValueFromQueryStringOfRef(url, @"localFolder", string.Empty);
+			_showCloneSpecificSettings = true;
 		}
-
-		public bool ReadyToDownload
-		{
-			get
-			{
-				return HaveNeededAccountInfo && HaveWellFormedTargetLocation && TargetLocationIsUnused;
-			}
-		}
-
-		public bool TargetLocationIsUnused
-		{
-			get
-			{
-				try
-				{
-					// the target location is "unused" if either the Target Destination doesn't exist OR
-					//  if it has nothing in it (I tried Clone once and it failed because the repo spec
-					//  was wrong, but since it had created the Target Destination folder, it wouldn't
-					//  try again-rde)
-					return Directory.Exists(ParentDirectoryToPutCloneIn) &&
-						   (!Directory.Exists(TargetDestination)
-						   || (Directory.GetFiles(TargetDestination, "*.*", SearchOption.AllDirectories).Length == 0));
-				}
-				catch (Exception)
-				{
-					return false;
-				}
-			}
-		}
-
-		public bool HaveWellFormedTargetLocation
-		{
-			get
-			{
-				return (!string.IsNullOrEmpty(LocalFolderName) && LocalFolderName.LastIndexOfAny(Path.GetInvalidPathChars()) == -1);
-			}
-		}
-
-		public string LocalFolderName { get; set; }
-
-		public string TargetDestination
-		{
-			get
-			{
-				if(string.IsNullOrEmpty(LocalFolderName))
-				{
-					return "";
-				}
-				return Path.Combine(ParentDirectoryToPutCloneIn, LocalFolderName);
-			}
-		}
-
-
-		public bool TargetHasProblem
-		{
-			get {
-				return !HaveWellFormedTargetLocation || !TargetLocationIsUnused;
-			}
-		}
-
 
 		public bool ShowCloneOnlyControls
 		{
@@ -125,25 +50,11 @@ namespace Chorus.UI.Clone
 		///<summary>
 		///</summary>
 		///<returns>true of successful; false if failed</returns>
-		public bool SetRepositoryAddress()
+		public override bool SetRepositoryAddress()
 		{
 			try
 			{
-				var repo = new HgRepository(TargetDestination, _progress);
-				var name = new Uri(URL).Host;
-				if (String.IsNullOrEmpty(name)) //This happens for repos on the local machine
-				{
-					name = @"LocalRepository";
-				}
-				if (name.ToLower().Contains(@"languagedepot"))
-					name = @"LanguageDepot";
-
-				var address = RepositoryAddress.Create(name, URL);
-
-				//this will also remove the "default" one that hg puts in, which we don't really want.
-				repo.SetKnownRepositoryAddresses(new[] { address });
-				repo.SetIsOneDefaultSyncAddresses(address, true);
-				return true;
+				return base.SetRepositoryAddress();
 			}
 			catch (Exception error)
 			{
@@ -152,20 +63,16 @@ namespace Chorus.UI.Clone
 			}
 		}
 
-		public void DoClone()
+		public override void DoClone()
 		{
 			try
 			{
-				//review: do we need to get these out of the DoWorkEventArgs instead?
-				var actualCloneLocation = HgRepository.Clone(new HttpRepositoryPath(URL, URL, false), TargetDestination, _progress);
-				LocalFolderName = Path.GetFileName(actualCloneLocation.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+				base.DoClone();
 				using (SoundPlayer player = new SoundPlayer(Properties.Resources.finishedSound))
 				{
 					player.PlaySync();
 				}
-
 			}
-
 			catch (Exception error)
 			{
 				using (SoundPlayer player = new SoundPlayer(Properties.Resources.errorSound))
@@ -198,29 +105,6 @@ namespace Chorus.UI.Clone
 		public void Click_FixSettingsButton()
 		{
 			_progress.CancelRequested = false;
-		}
-
-		public void CleanUpAfterErrorOrCancel()
-		{
-			if (Directory.Exists(TargetDestination))
-			{
-				Directory.Delete(TargetDestination, true);
-			}
-		}
-
-		public void AddMessageProgress(IProgress p)
-		{
-			_progress.AddMessageProgress(p);
-		}
-
-		public void AddStatusProgress(IProgress p)
-		{
-			_progress.AddStatusProgress(p);
-		}
-
-		public void AddProgress(IProgress p)
-		{
-			_progress.Add(p);
 		}
 	}
 }

--- a/src/Chorus/UI/Misc/ReadinessPanel.cs
+++ b/src/Chorus/UI/Misc/ReadinessPanel.cs
@@ -6,6 +6,7 @@ using Chorus.Utilities;
 using Chorus.VcsDrivers.Mercurial;
 using SIL.Code;
 using SIL.Progress;
+using Chorus.Model;
 
 namespace Chorus.UI.Misc
 {

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
+using Chorus.Model;
 
 
 namespace Chorus.UI.Misc

--- a/src/Chorus/UI/Misc/ServerSettingsDialog.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Forms;
+using Chorus.Model;
 
 namespace Chorus.UI.Misc
 {

--- a/src/Chorus/UI/Settings/SendReceiveSettings.cs
+++ b/src/Chorus/UI/Settings/SendReceiveSettings.cs
@@ -7,6 +7,7 @@ using Chorus.VcsDrivers.Mercurial;
 using L10NSharp;
 using SIL.Code;
 using SIL.Progress;
+using Chorus.Model;
 
 namespace Chorus.UI.Settings
 {

--- a/src/ChorusHubTests/ChorusHubTests.cs
+++ b/src/ChorusHubTests/ChorusHubTests.cs
@@ -14,7 +14,7 @@ using SIL.TestUtilities;
 namespace ChorusHubTests
 {
 	[TestFixture]
-	[System.ComponentModel.Category("KnownMonoIssue")] // cross-process comms doesn't work in mono.
+	[NUnit.Framework.Category("KnownMonoIssue")] // cross-process comms doesn't work in mono.
 	public class ChorusHubClientTests
 	{
 		private string _originalPath;

--- a/src/LibChorus/LibChorus.csproj
+++ b/src/LibChorus/LibChorus.csproj
@@ -379,6 +379,8 @@
     <Compile Include="VcsDrivers\Mercurial\Revision.cs" />
     <Compile Include="VcsDrivers\Mercurial\HgRunner.cs" />
     <Compile Include="Utilities\HgProcessOutputReader.cs" />
+    <Compile Include="Model\ServerSettingsModel.cs" />
+    <Compile Include="Model\InternetCloneSettingsModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
@@ -481,4 +483,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Model\" />
+  </ItemGroup>
 </Project>

--- a/src/LibChorus/Model/InternetCloneSettingsModel.cs
+++ b/src/LibChorus/Model/InternetCloneSettingsModel.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.IO;
+using SIL.Progress;
+using Chorus.Model;
+using Chorus.Utilities;
+using Chorus.VcsDrivers;
+using Chorus.VcsDrivers.Mercurial;
+
+namespace Chorus.Model
+{
+	public class InternetCloneSettingsModel : ServerSettingsModel
+	{
+		protected MultiProgress _progress;
+
+		public InternetCloneSettingsModel()
+		{
+			_progress = new MultiProgress();
+		}
+
+		public InternetCloneSettingsModel(string parentDirectoryToPutCloneIn)
+		{
+			ParentDirectoryToPutCloneIn = parentDirectoryToPutCloneIn;
+			_progress = new MultiProgress();
+		}
+
+		public string ParentDirectoryToPutCloneIn { get; set; }
+
+		public override void InitFromUri(string url)
+		{
+			base.InitFromUri(url);
+			LocalFolderName = UrlHelper.GetValueFromQueryStringOfRef(url, @"localFolder", string.Empty);
+		}
+
+		public bool ReadyToDownload
+		{
+			get
+			{
+				return HaveNeededAccountInfo && HaveWellFormedTargetLocation && TargetLocationIsUnused;
+			}
+		}
+
+		public bool TargetLocationIsUnused
+		{
+			get
+			{
+				try
+				{
+					// the target location is "unused" if either the Target Destination doesn't exist OR
+					//  if it has nothing in it (I tried Clone once and it failed because the repo spec
+					//  was wrong, but since it had created the Target Destination folder, it wouldn't
+					//  try again-rde)
+					return Directory.Exists(ParentDirectoryToPutCloneIn) &&
+						(!Directory.Exists(TargetDestination) ||
+							(Directory.GetFiles(TargetDestination, "*.*", SearchOption.AllDirectories).Length == 0));
+				}
+				catch (Exception)
+				{
+					return false;
+				}
+			}
+		}
+
+		public bool HaveWellFormedTargetLocation
+		{
+			get
+			{
+				return (!string.IsNullOrEmpty(LocalFolderName) && LocalFolderName.LastIndexOfAny(Path.GetInvalidPathChars()) == -1);
+			}
+		}
+
+		public string LocalFolderName { get; set; }
+
+		public string TargetDestination
+		{
+			get
+			{
+				if(string.IsNullOrEmpty(LocalFolderName))
+				{
+					return "";
+				}
+				return Path.Combine(ParentDirectoryToPutCloneIn, LocalFolderName);
+			}
+		}
+
+
+		public bool TargetHasProblem
+		{
+			get {
+				return !HaveWellFormedTargetLocation || !TargetLocationIsUnused;
+			}
+		}
+
+		///<summary>
+		///</summary>
+		///<returns>true of successful; false if failed</returns>
+		public virtual bool SetRepositoryAddress()
+		{
+			var repo = new HgRepository(TargetDestination, _progress);
+			var name = new Uri(URL).Host;
+			if (String.IsNullOrEmpty(name)) //This happens for repos on the local machine
+			{
+				name = @"LocalRepository";
+			}
+			if (name.ToLower().Contains(@"languagedepot"))
+				name = @"LanguageDepot";
+
+			var address = RepositoryAddress.Create(name, URL);
+
+			//this will also remove the "default" one that hg puts in, which we don't really want.
+			repo.SetKnownRepositoryAddresses(new[] { address });
+			repo.SetIsOneDefaultSyncAddresses(address, true);
+			return true;
+		}
+
+		public virtual void DoClone()
+		{
+			//review: do we need to get these out of the DoWorkEventArgs instead?
+			var actualCloneLocation = HgRepository.Clone(new HttpRepositoryPath(URL, URL, false), TargetDestination, _progress);
+			LocalFolderName = Path.GetFileName(actualCloneLocation.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+		}
+
+		public void CleanUpAfterErrorOrCancel()
+		{
+			if (Directory.Exists(TargetDestination))
+			{
+				Directory.Delete(TargetDestination, true);
+			}
+		}
+
+		public void AddMessageProgress(IProgress p)
+		{
+			_progress.AddMessageProgress(p);
+		}
+
+		public void AddStatusProgress(IProgress p)
+		{
+			_progress.AddStatusProgress(p);
+		}
+
+		public void AddProgress(IProgress p)
+		{
+			_progress.Add(p);
+		}
+	}
+}

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -10,7 +10,7 @@ using SIL.Code;
 using SIL.Network;
 using SIL.Progress;
 
-namespace Chorus.UI.Misc
+namespace Chorus.Model
 {
 	public class ServerSettingsModel
 	{
@@ -95,13 +95,10 @@ namespace Chorus.UI.Misc
 				{
 					return CustomUrl;
 				}
-				else
-				{
-					return "http://" +
-						   HttpUtilityFromMono.UrlEncode((string)AccountName) + ":" +
-						   HttpUtilityFromMono.UrlEncode((string)Password) + "@" + SelectedServerPath + "/" +
-						   HttpUtilityFromMono.UrlEncode(ProjectId);
-				}
+				return "http://" +
+					HttpUtilityFromMono.UrlEncode((string)AccountName) + ":" +
+					HttpUtilityFromMono.UrlEncode((string)Password) + "@" + SelectedServerPath + "/" +
+					HttpUtilityFromMono.UrlEncode(ProjectId);
 			}
 		}
 
@@ -112,21 +109,17 @@ namespace Chorus.UI.Misc
 			get
 			{
 				if (!NeedProjectDetails)
-				{
 					return true;
-				}
-				else
+
+				try
 				{
-					try
-					{
-						return !string.IsNullOrEmpty(ProjectId) &&
-							   !string.IsNullOrEmpty(AccountName) &&
-							   !string.IsNullOrEmpty(Password);
-					}
-					catch (Exception)
-					{
-						return false;
-					}
+					return !string.IsNullOrEmpty(ProjectId) &&
+						!string.IsNullOrEmpty(AccountName) &&
+						!string.IsNullOrEmpty(Password);
+				}
+				catch (Exception)
+				{
+					return false;
 				}
 			}
 		}
@@ -201,18 +194,11 @@ namespace Chorus.UI.Misc
 				{
 					Uri uri;
 					if (Uri.TryCreate(URL, UriKind.Absolute, out uri) && !String.IsNullOrEmpty(uri.Host))
-					{
 						return uri.Host;
-					}
-					else
-					{
-						return "custom";
-					}
+					return "custom";
 				}
-				else
-				{
-					return SelectedServerLabel.Replace(" ","");
-				}
+
+				return SelectedServerLabel.Replace(" ","");
 			}
 		}
 

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -210,6 +210,8 @@
     <Compile Include="VcsDrivers\Mercurial\RetrieveVersionTests.cs" />
     <Compile Include="VcsDrivers\Mercurial\Utf8Tests.cs" />
     <Compile Include="VcsDrivers\RepositoryAddressTests.cs" />
+    <Compile Include="Model\ServerSettingsModelTests.cs" />
+    <Compile Include="Model\InternetCloneSettingsModelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibChorus.TestUtilities\LibChorus.TestUtilities.csproj">
@@ -236,6 +238,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="merge\text\" />
+    <Folder Include="Model\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
@@ -1,19 +1,19 @@
 ﻿using System.IO;
-using Chorus.UI.Clone;
 using NUnit.Framework;
 using SIL.TestUtilities;
+using Chorus.Model;
 
-namespace Chorus.Tests.UI.Clone
+namespace LibChorus.Tests.Model
 {
 	[TestFixture]
-	public class GetCloneFromInternetModelTest
+	public class InternetCloneSettingsModelTests
 	{
 		[Test]
 		public void InitFromUri_GivenCompleteUri_AllPropertiesCorrect()
 		{
 			using (var testFolder = new TemporaryFolder("clonetest"))
 			{
-				var model = new GetCloneFromInternetModel(testFolder.Path);
+				var model = new InternetCloneSettingsModel(testFolder.Path);
 				model.InitFromUri("http://john:myPassword@hg-languagedepot.org/tpi?localFolder=tokPisin");
 				Assert.AreEqual("tokPisin", model.LocalFolderName);
 				Assert.IsTrue(model.ReadyToDownload);
@@ -26,7 +26,7 @@ namespace Chorus.Tests.UI.Clone
 		{
 			using (var testFolder = new TemporaryFolder("clonetest"))
 			{
-				var model = new GetCloneFromInternetModel(testFolder.Path);
+				var model = new InternetCloneSettingsModel(testFolder.Path);
 				model.AccountName = "account";
 				model.Password = "password";
 				model.ProjectId = "id";
@@ -39,7 +39,7 @@ namespace Chorus.Tests.UI.Clone
 		{
 			using (var testFolder = new TemporaryFolder("clonetest"))
 			{
-				var model = new GetCloneFromInternetModel(testFolder.Path);
+				var model = new InternetCloneSettingsModel(testFolder.Path);
 				model.LocalFolderName = "SomeFolder";
 				// Ideally would call model to start the clone - but that's in the dialog for now so fake it instead.
 				Directory.CreateDirectory(model.TargetDestination);

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.IO;
-using Chorus.UI.Misc;
-using Chorus.VcsDrivers;
-using Chorus.VcsDrivers.Mercurial;
 using NUnit.Framework;
 using SIL.Progress;
 using SIL.TestUtilities;
+using Chorus.Model;
+using Chorus.VcsDrivers;
+using Chorus.VcsDrivers.Mercurial;
 
-namespace Chorus.Tests.UI.Misc
+namespace LibChorus.Tests.Model
 {
 	[TestFixture]
 	public class ServerSettingsModelTests


### PR DESCRIPTION
- move ServerSettingsModel to LibChorus
- add new InternetCloneSettingsModel in LibChorus that has most of
  the previous functionality of GetCloneFromInternetModel but is
  strictly UI independent (it has a progress object, but that is
  UI agnostic)
- derive GetCloneFromInternetModel from InternetCloneSettingsModel
  and wrap a few methods that catch errors and display UI to the
  user.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/75)
<!-- Reviewable:end -->
