### PR TITLE
Consistently perform update when cloning or pushing to a USB drive

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgHighLevel.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using SIL.Code;
+﻿using SIL.Code;
 using SIL.Progress;
 
 namespace Chorus.VcsDrivers.Mercurial
@@ -36,13 +35,10 @@ namespace Chorus.VcsDrivers.Mercurial
 			{
 				// Make a backward compatibile clone if cloning to USB (http://mercurial.selenic.com/wiki/UpgradingMercurial) 
 				targetDirectory = local.CloneLocalWithoutUpdate(targetDirectory, cloningFromUsb ? null : "--config format.dotencode=false --pull");
-				File.WriteAllText(Path.Combine(targetDirectory, "~~Folder has an invisible repository.txt"), "In this folder, there is a (possibly hidden) folder named '.hg' that contains the actual data of this Chorus repository. Depending on your Operating System settings, that leading '.' might make the folder invisible to you. But Chorus clients (WeSay, FLEx, OneStory, etc.) can see it and can use this folder to perform Send/Receive operations.");
 
-				if (cloningFromUsb)
-				{
-					var clone = new HgRepository(targetDirectory, progress);
-					clone.Update();
-				}
+				var clone = new HgRepository(targetDirectory, cloningFromUsb, progress);
+				clone.Update();
+
 				return targetDirectory;
 			}
 		}

--- a/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
+++ b/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
@@ -74,7 +74,7 @@ namespace LibChorus.Tests.sync
 		}
 
 		[Test]
-		public void SyncNow_UsbGetsBackwardCompatibleBareCloneWithReadme()
+		public void SyncNow_UsbGetsBackwardCompatibleClone()
 		{
 			Synchronizer synchronizer = Synchronizer.FromProjectConfiguration(_project, _progress);
 			SyncOptions options = new SyncOptions();
@@ -90,8 +90,6 @@ namespace LibChorus.Tests.sync
 			// SUT backward compatible clone has no dotencode in the requires file
 			var requiresLines = File.ReadAllLines(Path.Combine(projectDir, ".hg", "requires"));
 			CollectionAssert.DoesNotContain(requiresLines, "dotencode");
-			// SUT bare clone should get this text file
-			Assert.IsTrue(File.Exists(projectDir.CombineForPath(projectDir, "~~Folder has an invisible repository.txt")));
 		}
 
 		[Test]


### PR DESCRIPTION
When we push to a USB drive, we perform an update, populating the working directory. This behavior was inconsistent with when we clone to a USB drive. This inconsistency is causing problems with WeSay. I updated the code that clones to a USB drive so that it also performs an update. The alternative is to make both the push and clone to a USB drive not perform updates. From comments in Synchronizer.SendToOneOther(), performing an update on a USB is desirable, so I felt it was better to make the clone also perform an update.