### PR TITLE
Ensure that an existing target repo on a USB drive is "bare" after sync

### DIFF
--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -291,18 +291,12 @@ namespace Chorus.sync
 						repo.Push(address, resolvedUri);
 					}
 
-					// For LAN, it could be safe and desirable to do an update... for now we assume it is.
-					// For me (RandyR) including the shared network folder
-					// failed to do the update and killed the process, which left a 'wlock' file
-					// in the shared folder's '.hg' folder. No more S/Rs could then be done,
-					// because the repo was locked.
-					// For now, at least, it is not a requirement to do the update on the shared folder.
-					// JDH Oct 2010: added this back in if it doesn't look like a shared folder
 					// For USB, we do not wish to do an update, since it can cause problems if the working
-					// files are available to the user
+					// files are available to the user.
+					// The update is only done for tests, since only tests now use "DirectoryRepositorySource".
 					if (address is DirectoryRepositorySource && ((DirectoryRepositorySource) address).LooksLikeLocalDirectory)
 					{
-						// passes false to avoid updating the hgrc on a usb send to preserve backward compatibility
+						// passes false to avoid updating the hgrc on a send to preserve backward compatibility
 						var otherRepo = new HgRepository(resolvedUri, false, _progress);
 						otherRepo.Update();
 					}

--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -291,16 +291,16 @@ namespace Chorus.sync
 						repo.Push(address, resolvedUri);
 					}
 
-					// For usb, it's safe and desireable to do an update (bring into the directory
-					// the latest files from the repo) for LAN, it could be... for now we assume it is.
+					// For LAN, it could be safe and desirable to do an update... for now we assume it is.
 					// For me (RandyR) including the shared network folder
 					// failed to do the update and killed the process, which left a 'wlock' file
 					// in the shared folder's '.hg' folder. No more S/Rs could then be done,
 					// because the repo was locked.
 					// For now, at least, it is not a requirement to do the update on the shared folder.
 					// JDH Oct 2010: added this back in if it doesn't look like a shared folder
-					if (address is UsbKeyRepositorySource  ||
-						(address is DirectoryRepositorySource && ((DirectoryRepositorySource)address).LooksLikeLocalDirectory))
+					// For USB, we do not wish to do an update, since it can cause problems if the working
+					// files are available to the user
+					if (address is DirectoryRepositorySource && ((DirectoryRepositorySource) address).LooksLikeLocalDirectory)
 					{
 						// passes false to avoid updating the hgrc on a usb send to preserve backward compatibility
 						var otherRepo = new HgRepository(resolvedUri, false, _progress);


### PR DESCRIPTION
Chorus purposefully clones a "bare" repo to a USB drive. Unfortunately, when pushing to an existing USB repo, Chorus performs an update, causing the repo to no longer be "bare". This pull request corrects this inconsistency by no longer performing the update to a USB repo when pushing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/81)
<!-- Reviewable:end -->
