### PR TITLE
Fix ServerSettingsModel.InitFromUri to use UrlDecode

### DIFF
--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -54,9 +54,9 @@ namespace Chorus.Model
 		public virtual void InitFromUri(string url)
 		{
 			SetServerLabelFromUrl(url);
-			Password = UrlHelper.GetPassword(url);
-			AccountName = UrlHelper.GetUserName(url);
-			ProjectId = UrlHelper.GetPathAfterHost(url);
+			Password = HttpUtilityFromMono.UrlDecode(UrlHelper.GetPassword(url));
+			AccountName = HttpUtilityFromMono.UrlDecode(UrlHelper.GetUserName(url));
+			ProjectId = HttpUtilityFromMono.UrlDecode(UrlHelper.GetPathAfterHost(url));
 			CustomUrl = UrlHelper.GetPathOnly(url);
 			//CustomUrlSelected = true;
 		}

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Security.Principal;
 using NUnit.Framework;
 using SIL.Progress;
 using SIL.TestUtilities;
@@ -18,7 +19,23 @@ namespace LibChorus.Tests.Model
 			m.InitFromUri("http://joe:pass@hg-public.languagedepot.org/tpi");
 			Assert.AreEqual("joe",m.AccountName);
 		}
-		[Test]
+        [Test]
+        public void InitFromUri_CredentialsOriginallySetFromModelWithSpecialCharacters_AbleToRoundTripCredentialsBackFromURIOK()
+        {
+            var m = new ServerSettingsModel();
+            const string accountName = "joe@user.com";
+            const string password = "pass@with%specials&";
+            const string projectId = "projectId";
+            m.AccountName = accountName;
+            m.Password = password;
+            m.ProjectId = projectId;
+            var urlWithEncodedChars = m.URL;
+            m.InitFromUri(urlWithEncodedChars);
+            Assert.AreEqual(accountName, m.AccountName);
+            Assert.AreEqual(password, m.Password);
+            Assert.AreEqual(projectId, m.ProjectId);
+        }
+        [Test]
 		public void InitFromUri_FullTypicalLangDepot_PasswordCorrect()
 		{
 			var m = new ServerSettingsModel();

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -19,25 +19,27 @@ namespace LibChorus.Tests.Model
 			m.InitFromUri("http://joe:pass@hg-public.languagedepot.org/tpi");
 			Assert.AreEqual("joe",m.AccountName);
 		}
-        [Test]
-        public void InitFromUri_CredentialsOriginallySetFromModelWithSpecialCharacters_AbleToRoundTripCredentialsBackFromURIOK()
-        {
-            var model = new ServerSettingsModel();
-            const string accountName = "joe@user.com";
-            const string password = "pass@with%specials&";
-            const string projectId = "projectId";
-            model.AccountName = accountName;
-            model.Password = password;
-            model.ProjectId = projectId;
-            var urlWithEncodedChars = model.URL;
 
-            var newModel = new ServerSettingsModel();
-            newModel.InitFromUri(urlWithEncodedChars);
-            Assert.AreEqual(accountName, newModel.AccountName);
-            Assert.AreEqual(password, newModel.Password);
-            Assert.AreEqual(projectId, newModel.ProjectId);
-        }
-        [Test]
+		[Test]
+		public void InitFromUri_CredentialsOriginallySetFromModelWithSpecialCharacters_AbleToRoundTripCredentialsBackFromURIOK()
+		{
+			var model = new ServerSettingsModel();
+			const string accountName = "joe@user.com";
+			const string password = "pass@with%specials&";
+			const string projectId = "projectId";
+			model.AccountName = accountName;
+			model.Password = password;
+			model.ProjectId = projectId;
+			var urlWithEncodedChars = model.URL;
+
+			var newModel = new ServerSettingsModel();
+			newModel.InitFromUri(urlWithEncodedChars);
+			Assert.AreEqual(accountName, newModel.AccountName);
+			Assert.AreEqual(password, newModel.Password);
+			Assert.AreEqual(projectId, newModel.ProjectId);
+		}
+
+		[Test]
 		public void InitFromUri_FullTypicalLangDepot_PasswordCorrect()
 		{
 			var m = new ServerSettingsModel();

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -22,18 +22,20 @@ namespace LibChorus.Tests.Model
         [Test]
         public void InitFromUri_CredentialsOriginallySetFromModelWithSpecialCharacters_AbleToRoundTripCredentialsBackFromURIOK()
         {
-            var m = new ServerSettingsModel();
+            var model = new ServerSettingsModel();
             const string accountName = "joe@user.com";
             const string password = "pass@with%specials&";
             const string projectId = "projectId";
-            m.AccountName = accountName;
-            m.Password = password;
-            m.ProjectId = projectId;
-            var urlWithEncodedChars = m.URL;
-            m.InitFromUri(urlWithEncodedChars);
-            Assert.AreEqual(accountName, m.AccountName);
-            Assert.AreEqual(password, m.Password);
-            Assert.AreEqual(projectId, m.ProjectId);
+            model.AccountName = accountName;
+            model.Password = password;
+            model.ProjectId = projectId;
+            var urlWithEncodedChars = model.URL;
+
+            var newModel = new ServerSettingsModel();
+            newModel.InitFromUri(urlWithEncodedChars);
+            Assert.AreEqual(accountName, newModel.AccountName);
+            Assert.AreEqual(password, newModel.Password);
+            Assert.AreEqual(projectId, newModel.ProjectId);
         }
         [Test]
 		public void InitFromUri_FullTypicalLangDepot_PasswordCorrect()


### PR DESCRIPTION
This fixes a bug in the Chorus Internet Settings Dialog which was reported to me by a WeSay user.  The previous code would allow a situation whereby the user has a password with a special character in it like % that when saved into the password field and then the dialog is re-opened, the password has "grown" in length.  This is caused by the password field not being properly url decoded when extracted from the URL.

A regression test is also accompanied.

You can test this bug in the latest version of either Fieldworks, WeSay or any other app using the Chorus Internet Settings Dialog box.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/83)
<!-- Reviewable:end -->
