### PR TITLE
Stop losing changes to 'their' atomic and immutable elements

### DIFF
--- a/src/LibChorus.TestUtilities/XmlTestHelper.cs
+++ b/src/LibChorus.TestUtilities/XmlTestHelper.cs
@@ -46,6 +46,15 @@ namespace LibChorus.TestUtilities
 			}
 		}
 
+		public static void CreateThreeNodes(string ourXml, string theirXml, string ancestorXml, out XmlNode ourNode, out XmlNode ourParent, out XmlNode theirNode, out XmlNode ancestorNode)
+		{
+			var doc = new XmlDocument();
+			ourParent = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ourXml + "</ParentNode>", doc);
+			ourNode = ourParent.FirstChild;
+			theirNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + theirXml + "</ParentNode>", doc).FirstChild;
+			ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ancestorXml + "</ParentNode>", doc).FirstChild;
+		}
+
 		public static void AssertXPathNotNull(string documentPath, string xpath)
 		{
 			XmlDocument doc = new XmlDocument();
@@ -149,7 +158,7 @@ namespace LibChorus.TestUtilities
 							{
 								MergeStrategies = mergeStrategies
 							};
-			var retval = merger.Merge(eventListener, ourNode, theirNode, ancestorNode).OuterXml;
+			var retval = merger.Merge(eventListener, ourNode.ParentNode, ourNode, theirNode, ancestorNode).OuterXml;
 			Assert.AreSame(eventListener, merger.EventListener); // Make sure it never changes it, while we aren't looking, since at least one Merge method does that very thing.
 
 			CheckMergeResults(retval, eventListener,

--- a/src/LibChorus/FileTypeHandlers/ChorusNotesAnnotationMergingStrategy.cs
+++ b/src/LibChorus/FileTypeHandlers/ChorusNotesAnnotationMergingStrategy.cs
@@ -37,7 +37,7 @@ namespace Chorus.FileTypeHandlers
 		/// </summary>
 		public string MakeMergedEntry(IMergeEventListener eventListener, XmlNode ourEntry, XmlNode theirEntry, XmlNode commonEntry)
 		{
-			return _annotationMerger.Merge(eventListener, ourEntry, theirEntry, commonEntry).OuterXml;
+			return _annotationMerger.Merge(eventListener, ourEntry.ParentNode, ourEntry, theirEntry, commonEntry).OuterXml;
 		}
 
 		/// <summary>

--- a/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesMergingStrategy.cs
+++ b/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesMergingStrategy.cs
@@ -33,7 +33,7 @@ namespace Chorus.FileTypeHandlers
 		/// </summary>
 		public string MakeMergedEntry(IMergeEventListener eventListener, XmlNode ourEntry, XmlNode theirEntry, XmlNode commonEntry)
 		{
-			return _merger.Merge(eventListener, ourEntry, theirEntry, commonEntry).OuterXml;
+			return _merger.Merge(eventListener, ourEntry.ParentNode, ourEntry, theirEntry, commonEntry).OuterXml;
 		}
 
 		/// <summary>

--- a/src/LibChorus/FileTypeHandlers/lift/LiftEntryMergingStrategy.cs
+++ b/src/LibChorus/FileTypeHandlers/lift/LiftEntryMergingStrategy.cs
@@ -26,7 +26,7 @@ namespace Chorus.FileTypeHandlers.lift
 
 		public string MakeMergedEntry(IMergeEventListener listener, XmlNode ourEntry, XmlNode theirEntry, XmlNode commonEntry)
 		{
-			return _entryMerger.Merge(listener, ourEntry, theirEntry, commonEntry).OuterXml;
+			return _entryMerger.Merge(listener, ourEntry.ParentNode, ourEntry, theirEntry, commonEntry).OuterXml;
 		}
 
 		/// <summary>

--- a/src/LibChorus/merge/xml/generic/ImmutableElementMergeService.cs
+++ b/src/LibChorus/merge/xml/generic/ImmutableElementMergeService.cs
@@ -12,7 +12,7 @@ namespace Chorus.merge.xml.generic
 	/// </summary>
 	internal static class ImmutableElementMergeService
 	{
-		internal static void DoMerge(XmlMerger merger, ref XmlNode ours, XmlNode theirs, XmlNode ancestor)
+		internal static void DoMerge(XmlMerger merger, XmlNode ourParent, ref XmlNode ours, XmlNode theirs, XmlNode ancestor)
 		{
 			if (ours == null && theirs == null && ancestor == null)
 				return; // I don't think this is possible, but....
@@ -22,10 +22,10 @@ namespace Chorus.merge.xml.generic
 				// Somebody added it.
 				if (ours == null && theirs != null)
 				{
-						// They added it.
-						merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(merger.MergeSituation.PathToFileInRepository, theirs));
-						ours = theirs;
-						return;
+					// They added it.
+					merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(merger.MergeSituation.PathToFileInRepository, theirs));
+					XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
+					return;
 				}
 				if (theirs == null && ours != null)
 				{
@@ -52,7 +52,7 @@ namespace Chorus.merge.xml.generic
 				{
 					// They win.
 					merger.ConflictOccurred(new BothAddedMainElementButWithDifferentContentConflict(ours.Name, theirs, ours, merger.MergeSituation, merger.MergeStrategies.GetElementStrategy(theirs), merger.MergeSituation.BetaUserId));
-					ours = theirs;
+					XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
 					return;
 				}
 				return;

--- a/src/LibChorus/merge/xml/generic/MergeAtomicElementService.cs
+++ b/src/LibChorus/merge/xml/generic/MergeAtomicElementService.cs
@@ -19,7 +19,7 @@ namespace Chorus.merge.xml.generic
 		/// if <param name="ours"/> is null and <param name="theirs"/> is not null.
 		/// </remarks>
 		/// <returns>'True' if the given elements were 'atomic'. Otherwise 'false'.</returns>
-		internal static void Run(XmlMerger merger, ref XmlNode ours, XmlNode theirs, XmlNode commonAncestor)
+		internal static void Run(XmlMerger merger, XmlNode ourParent, ref XmlNode ours, XmlNode theirs, XmlNode commonAncestor)
 		{
 			if (merger == null)
 				throw new ArgumentNullException("merger"); // Route tested.
@@ -49,7 +49,7 @@ namespace Chorus.merge.xml.generic
 					// They seem to have added a new one.
 					// Route tested (x2).
 					merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(merger.MergeSituation.PathToFileInRepository, theirs));
-					ours = theirs; // They added it.
+					XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs); // They added it.
 				}
 				else
 				{
@@ -77,7 +77,7 @@ namespace Chorus.merge.xml.generic
 								// Route tested.
 								merger.ConflictOccurred(new BothEditedTheSameAtomicElement(ours.Name,
 									ours, theirs, null, merger.MergeSituation, elementStrategy, merger.MergeSituation.BetaUserId));
-								ours = theirs;
+								XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
 							}
 						}
 					}
@@ -111,7 +111,7 @@ namespace Chorus.merge.xml.generic
 																						 commonAncestor,
 																						 merger.MergeSituation, elementStrategy,
 																						 merger.MergeSituation.BetaUserId));
-				ours = theirs;
+				XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
 				return;
 			}
 
@@ -168,7 +168,7 @@ namespace Chorus.merge.xml.generic
 					// They edited it. We did nothing.
 					// Route tested (x2).
 					merger.EventListener.ChangeOccurred(new XmlChangedRecordReport(null, null, theirs.ParentNode, theirs));
-					ours = theirs;
+					XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
 				}
 				else
 				{
@@ -184,7 +184,9 @@ namespace Chorus.merge.xml.generic
 																				   merger.MergeSituation, elementStrategy,
 																				   merger.MergeSituation.BetaUserId));
 					if (merger.MergeSituation.ConflictHandlingMode != MergeOrder.ConflictHandlingModeChoices.WeWin)
-						ours = theirs;
+					{
+						XmlUtilities.ReplaceOursWithTheirs(ourParent, ref ours, theirs);
+					}
 				}
 			}
 

--- a/src/LibChorus/merge/xml/generic/MergeChildrenMethod.cs
+++ b/src/LibChorus/merge/xml/generic/MergeChildrenMethod.cs
@@ -151,7 +151,7 @@ namespace Chorus.merge.xml.generic
 					// Both 'ourChild' and 'theirChild exist. 'ancestorChild' may, or, may not, exist.
 					// There's a corresponding node and it isn't the same as ours...
 					// Route tested: MergeChildrenMethod_DiffOnlyTests.
-					_merger.MergeInner(ref ourChild, theirChild, ancestorChild);
+					_merger.MergeInner(_ours, ref ourChild, theirChild, ancestorChild);
 					resultsChildren[i] = ourChild;
 				}
 				else
@@ -192,7 +192,7 @@ namespace Chorus.merge.xml.generic
 						}
 						else
 						{
-							_merger.MergeInner(ref ourChild, theirChild, ancestorChild);
+							_merger.MergeInner(_ours, ref ourChild, theirChild, ancestorChild);
 							resultsChildren[i] = ourChild;
 						}
 					}

--- a/src/LibChorus/merge/xml/generic/MergeLimitedChildrenService.cs
+++ b/src/LibChorus/merge/xml/generic/MergeLimitedChildrenService.cs
@@ -144,7 +144,7 @@ namespace Chorus.merge.xml.generic
 				merger.ConflictOccurred(new RemovedVsEditedElementConflict(theirChild.Name, theirChild, null, ancestorChild,
 																		   mergeSituation, mergeStrategyForChild,
 																		   mergeSituation.BetaUserId));
-				ours.ReplaceChild(ours.OwnerDocument.ImportNode(theirChild, true), ourChild);
+				XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, theirChild);
 				return ours;
 			}
 			match = mergeStrategyForChild.MergePartnerFinder.GetNodeToMerge(theirChild, ancestor, SetFromChildren.Get(ancestor));
@@ -156,7 +156,7 @@ namespace Chorus.merge.xml.generic
 					// Their delete+add wins, since we did nothing.
 					merger.EventListener.ChangeOccurred(new XmlDeletionChangeReport(pathToFileInRepository, ancestor, ancestorChild));
 					merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(pathToFileInRepository, theirChild));
-					ours.ReplaceChild(ours.OwnerDocument.ImportNode(theirChild, true), ourChild);
+					XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, theirChild);
 					return ours;
 				}
 
@@ -166,9 +166,7 @@ namespace Chorus.merge.xml.generic
 																		   mergeSituation.AlphaUserId));
 				return ours;
 			}
-
-			merger.MergeInner(ref ourChild, theirChild, ancestorChild);
-
+			merger.MergeInner(ours, ref ourChild, theirChild, ancestorChild);
 // Route tested. (UsingWith_NumberOfChildrenAllowed_ZeroOrOne_DoesNotThrowWhenParentHasOneChildNode)
 			return ours;
 		}
@@ -257,7 +255,7 @@ namespace Chorus.merge.xml.generic
 				{
 					merger.ConflictOccurred(new XmlTextBothAddedTextConflict(theirChild.Name, theirChild, ourChild, mergeSituation,
 																			 mergeStrategyForChild, mergeSituation.BetaUserId));
-					ours.ReplaceChild(ours.OwnerDocument.ImportNode(theirChild, true), ourChild);
+					XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, theirChild);
 				}
 			}
 			else
@@ -270,10 +268,10 @@ namespace Chorus.merge.xml.generic
 					{
 						merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(pathToFileInRepository, ourChild));
 						var ourChildReplacement = ourChild;
-						merger.MergeInner(ref ourChildReplacement, theirChild, null);
+						merger.MergeInner(ours, ref ourChildReplacement, theirChild, null);
 						if (!ReferenceEquals(ourChild, ourChildReplacement))
 						{
-							ours.ReplaceChild(ours.OwnerDocument.ImportNode(ourChildReplacement, true), ourChild);
+							XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, ourChildReplacement);
 						}
 					}
 					else
@@ -291,10 +289,10 @@ namespace Chorus.merge.xml.generic
 					{
 						merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(pathToFileInRepository, theirChild));
 						var ourChildReplacement = ourChild;
-						merger.MergeInner(ref ourChildReplacement, theirChild, null);
+						merger.MergeInner(ours, ref ourChildReplacement, theirChild, null);
 						if (!ReferenceEquals(ourChild, ourChildReplacement))
 						{
-							ours.ReplaceChild(ours.OwnerDocument.ImportNode(ourChildReplacement, true), ourChild);
+							XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, ourChildReplacement);
 						}
 					}
 					else
@@ -302,7 +300,7 @@ namespace Chorus.merge.xml.generic
 						merger.ConflictOccurred(new BothAddedMainElementButWithDifferentContentConflict(theirChild.Name, theirChild, ourChild,
 																										mergeSituation, mergeStrategyForChild,
 																										mergeSituation.BetaUserId));
-						ours.ReplaceChild(ours.OwnerDocument.ImportNode(theirChild, true), ourChild);
+						XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, theirChild);
 					}
 				}
 			}
@@ -409,10 +407,10 @@ namespace Chorus.merge.xml.generic
 						if (XmlUtilities.AreXmlElementsEqual(ourChildClone, theirChildClone))
 						{
 							var ourChildReplacement = ourChild;
-							merger.MergeInner(ref ourChildReplacement, theirChild, null);
+							merger.MergeInner(ours, ref ourChildReplacement, theirChild, null);
 							if (!ReferenceEquals(ourChild, ourChildReplacement))
 							{
-								ours.ReplaceChild(ours.OwnerDocument.ImportNode(ourChildReplacement, true), ourChild);
+								XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, ourChildReplacement);
 							}
 						}
 						else
@@ -430,10 +428,10 @@ namespace Chorus.merge.xml.generic
 						if (XmlUtilities.AreXmlElementsEqual(ourChildClone, theirChildClone))
 						{
 							var ourChildReplacement = ourChild;
-							merger.MergeInner(ref ourChildReplacement, theirChild, null);
+							merger.MergeInner(ours, ref ourChildReplacement, theirChild, null);
 							if (!ReferenceEquals(ourChild, ourChildReplacement))
 							{
-								ours.ReplaceChild(ours.OwnerDocument.ImportNode(ourChildReplacement, true), ourChild);
+								XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, ourChildReplacement);
 							}
 						}
 						else
@@ -441,7 +439,7 @@ namespace Chorus.merge.xml.generic
 							merger.ConflictOccurred(new BothAddedMainElementButWithDifferentContentConflict(ourChild.Name, ourChild, theirChild,
 																											mergeSituation, mergeStrategyForChild,
 																											mergeSituation.AlphaUserId));
-							ours.ReplaceChild(ours.OwnerDocument.ImportNode(theirChild, true), ourChild);
+							XmlUtilities.ReplaceOursWithTheirs(ours, ref ourChild, theirChild);
 						}
 					}
 					return ours;
@@ -458,7 +456,7 @@ namespace Chorus.merge.xml.generic
 				{
 					merger.ConflictOccurred(new XmlTextBothAddedTextConflict(theirs.Name, theirs, ours, mergeSituation,
 																			 mainNodeStrategy, mergeSituation.BetaUserId));
-					ours = theirs;
+					XmlUtilities.ReplaceOursWithTheirs(ours.ParentNode, ref ours, theirs);
 				}
 			}
 			return ours;

--- a/src/LibChorus/merge/xml/generic/XmlMerger.cs
+++ b/src/LibChorus/merge/xml/generic/XmlMerger.cs
@@ -33,7 +33,7 @@ namespace Chorus.merge.xml.generic
 			MergeStrategies = new MergeStrategies();
 		}
 
-		public NodeMergeResult Merge(XmlNode ours, XmlNode theirs, XmlNode ancestor)
+		public NodeMergeResult Merge(XmlNode ourParent, XmlNode ours, XmlNode theirs, XmlNode ancestor)
 		{
 			SendMergeHeartbeat();
 			if (ours == null && theirs == null && ancestor == null)
@@ -150,17 +150,17 @@ namespace Chorus.merge.xml.generic
 			}
 
 			// All three nodes exist.
-			MergeInner(ref ours, theirs, ancestor);
+			MergeInner(ourParent, ref ours, theirs, ancestor);
 			result.MergedNode = ours;
 
 			return result;
 		}
 
-		public XmlNode Merge(IMergeEventListener eventListener, XmlNode ours, XmlNode theirs, XmlNode ancestor)
+		public XmlNode Merge(IMergeEventListener eventListener, XmlNode ourParent, XmlNode ours, XmlNode theirs, XmlNode ancestor)
 		{
 			SendMergeHeartbeat();
 			EventListener = eventListener;
-			MergeInner(ref ours, theirs, ancestor);
+			MergeInner(ourParent, ref ours, theirs, ancestor);
 			return ours;
 		}
 
@@ -236,7 +236,7 @@ namespace Chorus.merge.xml.generic
 		/// This method does the actual work for the various public entry points of XmlMerge
 		/// and from the various Method-type classes, as it processes child nodes, if any.
 		/// </summary>
-		internal void MergeInner(ref XmlNode ours, XmlNode theirs, XmlNode ancestor)
+		internal void MergeInner(XmlNode ourParent, ref XmlNode ours, XmlNode theirs, XmlNode ancestor)
 		{
 			SendMergeHeartbeat();
 			_oursContext = ours;
@@ -262,7 +262,7 @@ namespace Chorus.merge.xml.generic
 			// then make sure no changes took place (among a few other things).
 			if (elementStrat.IsImmutable)
 			{
-				ImmutableElementMergeService.DoMerge(this, ref ours, theirs, ancestor);
+				ImmutableElementMergeService.DoMerge(this, ourParent, ref ours, theirs, ancestor);
 				return; // Don't go any further, since it is immutable.
 			}
 
@@ -276,7 +276,7 @@ namespace Chorus.merge.xml.generic
 					DoTextMerge(ref ours, theirs, ancestor, elementStrat);
 					return;
 				}
-				MergeAtomicElementService.Run(this, ref ours, theirs, ancestor);
+				MergeAtomicElementService.Run(this, ourParent, ref ours, theirs, ancestor);
 				return;
 			}
 
@@ -350,7 +350,7 @@ namespace Chorus.merge.xml.generic
 			XmlNode theirNode = XmlUtilities.GetDocumentNodeFromRawXml(theirXml, doc);
 			XmlNode ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(ancestorXml, doc);
 
-			return Merge(ourNode, theirNode, ancestorNode);
+			return Merge(ourNode.ParentNode, ourNode, theirNode, ancestorNode);
 		}
 
 		public NodeMergeResult MergeFiles(string ourPath, string theirPath, string ancestorPath)
@@ -360,7 +360,7 @@ namespace Chorus.merge.xml.generic
 			var ourNode = LoadXmlDocumentAndGetRootNode(ourPath);
 			var theirNode = LoadXmlDocumentAndGetRootNode(theirPath);
 
-			return Merge(ourNode, theirNode, ancestorNode);
+			return Merge(ourNode != null ? ourNode.ParentNode : null, ourNode, theirNode, ancestorNode);
 		}
 
 		private static XmlNode LoadXmlDocumentAndGetRootNode(string pathname)

--- a/src/LibChorusTests/FileHandlers/ChorusNotesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusNotesFileHandlerTests.cs
@@ -230,8 +230,9 @@ namespace LibChorus.Tests.FileHandlers
 				messageStrategy.IsImmutable = true;
 				merger.MergeStrategies.SetStrategy("message", messageStrategy);
 				merger.EventListener = listener;
+				var ourDataNode = XmlUtilities.GetDocumentNodeFromRawXml(ourData.Replace("<?xml version='1.0' encoding='utf-8'?>", null).Trim(), new XmlDocument());
 				var mergeResult = merger.Merge(
-					XmlUtilities.GetDocumentNodeFromRawXml(ourData.Replace("<?xml version='1.0' encoding='utf-8'?>", null).Trim(), new XmlDocument()),
+					ourDataNode.ParentNode, ourDataNode,
 					XmlUtilities.GetDocumentNodeFromRawXml(theirData.Replace("<?xml version='1.0' encoding='utf-8'?>", null).Trim(), new XmlDocument()),
 					XmlUtilities.GetDocumentNodeFromRawXml(commonData.Replace("<?xml version='1.0' encoding='utf-8'?>", null).Trim(), new XmlDocument()));
 				var oldWayResult = mergeResult.MergedNode.OuterXml;

--- a/src/LibChorusTests/merge/xml/generic/MergeAtomicElementServiceTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/MergeAtomicElementServiceTests.cs
@@ -68,25 +68,16 @@ namespace LibChorus.Tests.merge.xml.generic
 			MergeSituation mergeSituation, out XmlNode returnAncestorNode, out ListenerForUnitTests listener)
 		{
 			XmlNode ourNode;
+			XmlNode ourParent;
 			XmlNode theirNode;
 			XmlNode ancestorNode;
-			CreateThreeNodes(ours, out ourNode,
-							 theirs, out theirNode,
-							 common, out ancestorNode);
+			XmlTestHelper.CreateThreeNodes(ours, theirs, common, out ourNode, out ourParent, out theirNode, out ancestorNode);
 			returnAncestorNode = ancestorNode;
 
 			var merger = GetMerger(mergeSituation, out listener);
-			Assert.DoesNotThrow(() => MergeAtomicElementService.Run(merger, ref ourNode, theirNode, ancestorNode));
+			Assert.DoesNotThrow(() => MergeAtomicElementService.Run(merger, ourParent, ref ourNode, theirNode, ancestorNode));
 
 			return ourNode;
-		}
-
-		private static void CreateThreeNodes(string ourXml, out XmlNode ourNode, string theirXml, out XmlNode theirNode, string ancestorXml, out XmlNode ancestorNode)
-		{
-			var doc = new XmlDocument();
-			ourNode = ourXml == null ? null : XmlUtilities.GetDocumentNodeFromRawXml(ourXml, doc);
-			theirNode = theirXml == null ? null : XmlUtilities.GetDocumentNodeFromRawXml(theirXml, doc);
-			ancestorNode = ancestorXml == null ? null : XmlUtilities.GetDocumentNodeFromRawXml(ancestorXml, doc);
 		}
 
 		private static void CreateThreeNodes(XmlDocument doc, XmlNode rootNode,
@@ -178,14 +169,14 @@ namespace LibChorus.Tests.merge.xml.generic
 		{
 			var doc = new XmlDocument();
 			var node = doc.CreateNode(XmlNodeType.Element, "somenode", null);
-			Assert.Throws<ArgumentNullException>(() => MergeAtomicElementService.Run(null, ref node, node, node));
+			Assert.Throws<ArgumentNullException>(() => MergeAtomicElementService.Run(null, node.ParentNode, ref node, node, node));
 		}
 
 		[Test]
 		public void AllNullNodesThrows()
 		{
 			XmlNode node = null;
-			Assert.Throws<ArgumentNullException>(() => MergeAtomicElementService.Run(new XmlMerger(new NullMergeSituation()), ref node, node, node));
+			Assert.Throws<ArgumentNullException>(() => MergeAtomicElementService.Run(new XmlMerger(new NullMergeSituation()), null, ref node, node, node));
 		}
 
 		[Test]
@@ -203,7 +194,7 @@ namespace LibChorus.Tests.merge.xml.generic
 
 			ListenerForUnitTests listener;
 			var merger = GetMerger(out listener, false);
-			Assert.Throws<InvalidOperationException>(() => MergeAtomicElementService.Run(merger, ref ourNode, theirNode, ancestorNode));
+			Assert.Throws<InvalidOperationException>(() => MergeAtomicElementService.Run(merger, ourNode.ParentNode, ref ourNode, theirNode, ancestorNode));
 		}
 
 		#endregion Basic tests


### PR DESCRIPTION
* Fixes FB bug LT-17461
* Change internal api methods to include the parent
  of 'our' node so that 'their' content can be imported
* Refactor test code and add unit tests to new utility code

In the future it might be worth it to switch all xml use to XDocument
classes

(cherry picked from commit 0d8d70077d8e4ccb420922fd5943cdb417ea91f0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/92)
<!-- Reviewable:end -->
