### PR TITLE
Pass relative file paths when validating files

### DIFF
--- a/src/LibChorus/sync/CommitCop.cs
+++ b/src/LibChorus/sync/CommitCop.cs
@@ -1,7 +1,9 @@
 using System;
+using System.IO;
 using System.Text;
 using Chorus.FileTypeHandlers;
 using Chorus.VcsDrivers.Mercurial;
+using Palaso.Code;
 using Palaso.Progress;
 
 namespace Chorus.sync
@@ -17,7 +19,7 @@ namespace Chorus.sync
 	/// You only need to use it explicitly if you're directly committing using calls to the HgRepository.
 	///
 	/// NB: as of 2 Nov 2009, this cannot handle merge situations (because it seems to me backing out
-	/// of a merge would mean losing more data than necessary & we need some other more general
+	/// of a merge would mean losing more data than necessary and we need some other more general
 	/// merge-failure handling mechanism, anyhow).
 	///
 	/// </summary>
@@ -28,7 +30,7 @@ namespace Chorus.sync
 	///          validationResult = commitCop.ValidationResult;
 	///    }
 	/// </example>
-	public class CommitCop:IDisposable
+	public class CommitCop: IDisposable
 	{
 		private readonly HgRepository _repository;
 		private readonly ChorusFileTypeHandlerCollection _handlerCollection;
@@ -49,27 +51,40 @@ namespace Chorus.sync
 			var files = _repository.GetFilesInRevisionFromQuery(null, "status --change tip");
 			var builder = new StringBuilder();
 
-			foreach (var file in files)
+			var oldWorkDir = Directory.GetCurrentDirectory();
+			Directory.SetCurrentDirectory(_repository.PathToRepo);
+			try
 			{
-				if (file.ActionThatHappened == FileInRevision.Action.Modified
-					|| file.ActionThatHappened == FileInRevision.Action.Added)
+				foreach (var file in files)
 				{
-					foreach (var handler in _handlerCollection.Handlers)
+					if (file.ActionThatHappened == FileInRevision.Action.Modified
+						|| file.ActionThatHappened == FileInRevision.Action.Added)
 					{
-						if (handler.CanValidateFile(file.FullPath))
+						foreach (var handler in _handlerCollection.Handlers)
 						{
-							_progress.WriteVerbose("Validating {0}", file);
-							var result = handler.ValidateFile(file.FullPath, _progress);
-							if (!string.IsNullOrEmpty(result))
+							var relativeFilePath = file.FullPath.Substring(_repository.PathToRepo.Length)
+								.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+							if (handler.CanValidateFile(relativeFilePath))
 							{
-								_progress.WriteVerbose("Validation Failed: {0}", result);
-								builder.AppendFormat("Validation failed on {0}\r\n", file.FullPath);
-								builder.Append(result+"\r\n");
+								Require.That(file.FullPath.StartsWith(_repository.PathToRepo, StringComparison.InvariantCulture));
+								_progress.WriteVerbose("Validating {0}", relativeFilePath);
+								var result = handler.ValidateFile(relativeFilePath, _progress);
+								if (!string.IsNullOrEmpty(result))
+								{
+									_progress.WriteVerbose("Validation Failed: {0}", result);
+									builder.AppendFormat("Validation failed on {0}{1}", file.FullPath,
+										Environment.NewLine);
+									builder.AppendLine(result);
+								}
+								break;
 							}
-							break;
 						}
 					}
 				}
+			}
+			finally
+			{
+				Directory.SetCurrentDirectory(oldWorkDir);
 			}
 			_validationResult = builder.ToString();
 		}


### PR DESCRIPTION
If we pass the full path we might get wrong validation failures.
This happened with flexbridge, when the path to the hg root directory
contained the string "Other".

This change passes a relative path (i.e. where the root path is
stripped) to the handler's VaalidateFile() method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/95)
<!-- Reviewable:end -->
