### PR TITLE
Present conflict report HTML as UTF-8

### DIFF
--- a/src/LibChorus/FileTypeHandlers/ConflictPresenter.cs
+++ b/src/LibChorus/FileTypeHandlers/ConflictPresenter.cs
@@ -79,7 +79,7 @@ namespace Chorus.FileTypeHandlers
 		public string GetHtml(string style, string styleSheet)
 		{
 			var builder = new StringBuilder();
-			builder.Append("<html><head>"+styleSheet +"</head>");
+			builder.Append("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">"+styleSheet +"</head>");
 			if (style == "normal")
 			{
 				if (_conflict is UnreadableConflict)


### PR DESCRIPTION
In the absence of any `<meta>` tag specifying an encoding, GeckoFX on Windows defaults to ISO-8859-1 / CP1252, which leads to garbled text when a non-Roman word had a conflict. The data is correctly UTF-8 encoded in the Chorus Notes file, so adding an HTML `<meta>` tag to specify the encoding is enough to solve the issue.

Fixes #97.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/98)
<!-- Reviewable:end -->
