### PR TITLE
A 'moved' ChorusMerge on a machine breaks S/R

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -250,16 +250,13 @@ namespace Chorus.VcsDrivers.Mercurial
 			var chorusMergeLoc = SurroundWithQuotes(ExecutionEnvironment.ChorusMergeFilePath());
 			var uiSection = doc.Sections.GetOrCreate("ui");
 
-			if(uiSection.GetValue("merge") != mergetoolname)
-			{
-				uiSection.Set("merge", mergetoolname);
-				var mergeToolsSection = doc.Sections.GetOrCreate("merge-tools");
-				// If the premerge is allowed to happen Mercurial will occasionally think it did a good enough job and not
-				// call our mergetool. This has data corrupting results for us so we tell mercurial to skip it.
-				mergeToolsSection.Set(String.Format("{0}.premerge", mergetoolname), "False");
-				mergeToolsSection.Set(String.Format("{0}.executable", mergetoolname), chorusMergeLoc);
-				doc.SaveAndThrowIfCannot();
-			}
+			uiSection.Set("merge", mergetoolname);
+			var mergeToolsSection = doc.Sections.GetOrCreate("merge-tools");
+			// If the premerge is allowed to happen Mercurial will occasionally think it did a good enough job and not
+			// call our mergetool. This has data corrupting results for us so we tell mercurial to skip it.
+			mergeToolsSection.Set(string.Format("{0}.premerge", mergetoolname), "False");
+			mergeToolsSection.Set(string.Format("{0}.executable", mergetoolname), chorusMergeLoc);
+			doc.SaveAndThrowIfCannot();
 		}
 
 		public bool GetFileIsInRepositoryFromFullPath(string fullPath)


### PR DESCRIPTION
 Certain unexpected user scenarios can result in
 the location of ChorusMerge to change after the
 information is stored in the hgrc file.

* Reset the mergetool values before every S/R

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/100)
<!-- Reviewable:end -->
