### PR TITLE
Rename LanguageForge in server settings drop down (#102)

### DIFF
--- a/src/Chorus/UI/Misc/ServerSettingsModel.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsModel.cs
@@ -23,7 +23,7 @@ namespace Chorus.UI.Misc
 			Servers.Add(languageDepotLabel, "resumable.languagedepot.org");
 			Servers.Add("LanguageDepot.org [Safe Mode]", "hg-public.languagedepot.org");
 			Servers.Add("LanguageDepot.org [private]", "hg-private.languagedepot.org");
-			Servers.Add("LanguageForge", "hg.languageforge.org");
+			Servers.Add("LanguageDepot.org [test server]", "hg.languageforge.org");
 
 			Servers.Add(LocalizationManager.GetString("Messages.CustomLocation", "Custom Location..."), "");
 			SelectedServerLabel = languageDepotLabel;


### PR DESCRIPTION
That removes some confusion for users since hg.languageforge.org
is a test server. Send/Receive with languageforge is done through
the regular LanguageDepot.org servers.
(cherry picked from commit 8972314387eb360de1ecdb379f916f3a72510274)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/104)

<!-- Reviewable:end -->
