### PR TITLE
Fix a crash in XmlBothDeletionChangeReport

### DIFF
--- a/src/LibChorus/FileTypeHandlers/xml/XmlDeletionChangeReport.cs
+++ b/src/LibChorus/FileTypeHandlers/xml/XmlDeletionChangeReport.cs
@@ -29,7 +29,7 @@ namespace Chorus.FileTypeHandlers.xml
 		}
 		public override string GetFullHumanReadableDescription()
 		{
-			return string.Format("Deleted a <{0}>", _parentNode.Name);
+			return string.Format("Deleted a <{0}>", ParentNode.Name);
 		}
 
 		public XmlNode ParentNode
@@ -48,7 +48,6 @@ namespace Chorus.FileTypeHandlers.xml
 
 	public class XmlBothDeletionChangeReport : ChangeReport, IXmlChangeReport
 	{
-		private readonly XmlNode _parentNode;
 		private readonly XmlNode _childNode;
 		//  private readonly XmlNode _deletedNode;
 
@@ -70,7 +69,7 @@ namespace Chorus.FileTypeHandlers.xml
 		}
 		public override string GetFullHumanReadableDescription()
 		{
-			return string.Format("Both deleted the <{0}>", _parentNode.Name);
+			return string.Format("Both deleted the <{0}>", ChildNode.Name);
 		}
 
 		public XmlNode ParentNode

--- a/src/LibChorusTests/FileHandlers/xml/XmlDeletionChangeReportTests.cs
+++ b/src/LibChorusTests/FileHandlers/xml/XmlDeletionChangeReportTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Chorus.FileTypeHandlers.xml;
+using Chorus.merge;
+using Chorus.merge.xml.generic;
+
+namespace LibChorus.Tests.FileHandlers.xml
+{
+	[TestFixture]
+	public class XmlDeletionChangeReportTests
+	{
+		[Test]
+		public void XmlDeletionChangeReport_ReportsCorrectChangeWithoutCrashing()
+		{
+			// Setup
+			var merger = new XmlMerger(new NullMergeSituation());
+
+			// Exercise
+			var result = merger.Merge("<r></r>", "<r><s><t>hello</t></s></r>", "<r><s><t>hello</t></s></r>");
+
+			// Verify
+			Assert.That(result.Changes.Select(x => x.GetType()), Is.EqualTo(new[] { typeof(XmlDeletionChangeReport) }));
+			Assert.That(result.Changes[0].ToString(), Is.EqualTo("Deleted a <s>"));
+			Assert.That(result.Changes[0].ActionLabel, Is.EqualTo("Deleted"));
+		}
+
+		[Test]
+		public void XmlBothDeletionChangeReport_ReportsCorrectChangeWithoutCrashing()
+		{
+			// Setup
+			var merger = new XmlMerger(new NullMergeSituation());
+
+			// Exercise
+			var result = merger.Merge("<r></r>", "<r></r>", "<r><s><t>hello</t></s></r>");
+
+			// Verify
+			Assert.That(result.Changes.Select(x => x.GetType()), Is.EqualTo(new[] { typeof(XmlBothDeletionChangeReport) }));
+			Assert.That(result.Changes[0].ToString(), Is.EqualTo("Both deleted the <s>"));
+			Assert.That(result.Changes[0].ActionLabel, Is.EqualTo("Deleted"));
+		}
+	}
+}
+

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Model\InternetCloneSettingsModelTests.cs" />
     <Compile Include="FileHandlers\ChorusFileTypeHandlerCollectionTests.cs" />
     <Compile Include="notes\EmbeddedMessageContentHandlerRepositoryTests.cs" />
+    <Compile Include="FileHandlers\xml\XmlDeletionChangeReportTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibChorus.TestUtilities\LibChorus.TestUtilities.csproj">
@@ -234,6 +235,7 @@
   <ItemGroup>
     <Folder Include="merge\text\" />
     <Folder Include="Model\" />
+    <Folder Include="FileHandlers\xml\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
Also fix the reported message to report the actual reported node
(as the message states) instead of the parent node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/109)
<!-- Reviewable:end -->
