### PR TITLE
Inform users about corrupt USB Repos instead of crashing

### DIFF
--- a/src/Chorus.Tests/UI/Clone/GetCloneFromUsbDialogTests.cs
+++ b/src/Chorus.Tests/UI/Clone/GetCloneFromUsbDialogTests.cs
@@ -52,5 +52,36 @@ namespace Chorus.Tests.UI.Clone
 				}
 			}
 		}
+
+		[Test, Ignore("Run by hand only")]
+		public void LaunchDialog_SimulatedUsb_USBHasInvalidRepo()
+		{
+			using (var targetComputer = new TemporaryFolder("clonetest-targetComputer"))
+			using (var usb = new TemporaryFolder("clonetest-Usb"))
+			{
+				var badRepoDir = usb.Combine("badrepo");
+				CreateInvalidRepoInDir(badRepoDir);
+				//ok, the point here is that we already haved something called "repo1"
+				Directory.CreateDirectory(targetComputer.Combine("repo1"));
+
+				using (var dlg = new GetCloneFromUsbDialog(targetComputer.Path))
+				{
+					var drives = new List<IUsbDriveInfo>();
+					drives.Add(new UsbDriveInfoForTests(usb.Path));
+
+					//don't look at the actual drives, look at our simulations
+					dlg.Model.DriveInfoRetriever = new RetrieveUsbDriveInfoForTests(drives);
+
+					if (DialogResult.OK != dlg.ShowDialog())
+						return;
+				}
+			}
+		}
+
+		private void CreateInvalidRepoInDir(string badRepoDir)
+		{
+			Directory.CreateDirectory(badRepoDir);
+			Directory.CreateDirectory(Path.Combine(badRepoDir, ".hg"));
+		}
 	}
 }

--- a/src/Chorus/UI/Clone/CloneFromUsb.cs
+++ b/src/Chorus/UI/Clone/CloneFromUsb.cs
@@ -90,24 +90,39 @@ namespace Chorus.UI.Clone
 			var last = File.GetLastWriteTime(path);
 			item.SubItems.Add(last.ToShortDateString() + " " + last.ToShortTimeString());
 			item.ImageIndex = 0;
-			string projectWithExistingRepo = GetProjectWithExistingRepo(path);
-			if (projectWithExistingRepo != null)
+			if (!IsValidRepository(path))
 			{
-				item.ToolTipText = string.Format(ProjectInUseTemplate, projectWithExistingRepo);
+				item.ToolTipText = string.Format(InvalidRepositoryTemplate, projectName);
 				item.ForeColor = DisabledItemForeColor;
 				item.ImageIndex = 1;
 			}
-			else if (ExistingProjects != null && ExistingProjects.Contains(projectName))
-			{
-				item.ToolTipText = ProjectWithSameNameExists;
-				item.ForeColor = DisabledItemForeColor;
-				item.ImageIndex = 2;
-			}
 			else
 			{
-				item.ToolTipText = path;
+				var projectWithExistingRepo = GetProjectWithExistingRepo(path);
+				if (projectWithExistingRepo != null)
+				{
+					item.ToolTipText = string.Format(ProjectInUseTemplate, projectWithExistingRepo);
+					item.ForeColor = DisabledItemForeColor;
+					item.ImageIndex = 1;
+				}
+				else if (ExistingProjects != null && ExistingProjects.Contains(projectName))
+				{
+					item.ToolTipText = ProjectWithSameNameExists;
+					item.ForeColor = DisabledItemForeColor;
+					item.ImageIndex = 2;
+				}
+				else
+				{
+					item.ToolTipText = path;
+				}
 			}
 			return item;
+		}
+
+		private bool IsValidRepository(string path)
+		{
+			var repo = new HgRepository(path, new NullProgress());
+			return !string.IsNullOrEmpty(repo.Identifier);
 		}
 
 		private string GetProjectWithExistingRepo(string path)
@@ -146,6 +161,15 @@ namespace Chorus.UI.Clone
 		public static string ProjectInUseTemplate
 		{
 			get { return LocalizationManager.GetString("Messages.RepositoryInUse","The project {0} is already using this repository."); }
+		}
+
+		/// <summary>
+		/// This is a property rather than a constant string to facilitate eventual localization.
+		/// It is the tooltip that shows when a repo is disabled because it is already in use.
+		/// </summary>
+		public static string InvalidRepositoryTemplate
+		{
+			get { return LocalizationManager.GetString("Messages.InvalidRepository", "The folder {0} can not be used for Send/Receive. It may be corrupt."); }
 		}
 
 		/// <summary>


### PR DESCRIPTION
With this change corrupt repositories on a USB drive appear as follows:

![image](https://cloud.githubusercontent.com/assets/2295227/21731144/8c52a984-d418-11e6-8fdc-d1d5a74ff8f1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/110)
<!-- Reviewable:end -->
