### PR TITLE
Always add eol extension

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -186,9 +186,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				//NB: this is REQUIRED because we are now, in the hgrunner, saying that we will be getting utf8 output. If we made this extension optional, we'd have to know to not say that.
 
 				var extensions = new Dictionary<string, string>();
-#if !MONO
-				extensions.Add("eol", ""); //for converting line endings on windows machines
-#endif
+				extensions.Add("eol", ""); //for converting line endings
 				extensions.Add("hgext.graphlog", ""); //for more easily readable diagnostic logs
 				extensions.Add("convert", ""); //for catastrophic repair in case of repo corruption
 				string fixUtfFolder = FileLocator.GetDirectoryDistributedWithApplication(false, "MercurialExtensions", "fixutf8");


### PR DESCRIPTION
Previously we did this only on Windows, but it makes sense on
Linux as well and helps with line ending normalization when tests
check in a hg repo for unit testing purposes (like LfMerge does).

To normalize line endings in the hg repo, add the extension `eol`
to the `.hgrc` file and tell eol to always normalize line endings:

    [eol]
    only-consistent = False
    [extensions]
    eol =

To have an effect the hg repo also needs a `.hgeol` file:

    [repository]
    native = LF
    [patterns]
    ** = native

If there is no `.hgeol` file in the hg repo the behavior won't
change and no line ending normalization will happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/111)
<!-- Reviewable:end -->
