### PR TITLE
Allow specifying annotation GUID in constructor

### DIFF
--- a/src/LibChorus/notes/Annotation.cs
+++ b/src/LibChorus/notes/Annotation.cs
@@ -29,10 +29,15 @@ namespace Chorus.notes
         }
 
 		public Annotation(string annotationClass, string refUrl, string path)
+			: this(annotationClass, refUrl, System.Guid.NewGuid(), path)
+		{
+		}
+
+		public Annotation(string annotationClass, string refUrl, Guid guid, string path)
         {
 			refUrl = UrlHelper.GetEscapedUrl(refUrl);
 			_element = XElement.Parse(String.Format("<annotation class='{0}' ref='{1}' guid='{2}'/>",
-				annotationClass, refUrl, System.Guid.NewGuid().ToString()));
+				annotationClass, refUrl, guid.ToString()));
 
 			_class = GetAnnotationClass();
 			AnnotationFilePath = path; //TODO: this awkward, and not avail in the XElement constructor


### PR DESCRIPTION
This is needed for Language Forge Send/Receive, where comments created in Language Forge will have pre-existing GUIDs and we will want to create Annotations with the same GUID. This way, the annotation in Chorus Notes and the comment in Language Forge will be trackable as being the same object, and if the comment is resolved in FLEx then the corresponding comment in Language Forge can be marked as closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/112)
<!-- Reviewable:end -->
