### PR TITLE
Avoid too-long filename (LT-18093)

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -221,7 +221,6 @@ namespace Chorus.VcsDrivers.Mercurial
 			return commonBases;
 		}
 
-
 		private MultiMap<string, string> GetRemoteRevisions(int offset, int quantity)
 		{
 			const int totalNumOfAttempts = 2;
@@ -309,6 +308,20 @@ namespace Chorus.VcsDrivers.Mercurial
 			throw new HgResumeOperationFailed(String.Format("Failed to get remote revisions for {0}", _apiServer.ProjectId));
 		}
 
+		/// <summary>
+		/// Gets a Bundle ID based on the hashes of the available base revisions (branches) and the Tip.
+		/// This Bundle ID is presently used exclusively for the name of a file in which BundleStorageManager stores the Transaction ID (GUID)
+		/// REVIEW (Hasso) 2017.02: are all these revisions necessary? The ID file is deleted immediately following a successful pull (I have not
+		/// investigated pushes). In testing with FLExBridge, the last Revision is included in the folder path (probably similar for other clients).
+		/// Therefore, we could probably get away with using only tip, or perhaps tip and a single revision.
+		/// LT-18093: After users have synced a given project over the internet with a certain number of versions of the FLEx model, we will have
+		/// more base revisions than we can list in a filepath under 260 characters.
+		/// </summary>
+		private static string GetBundleIdFilenameBase(IEnumerable<string> baseRevisions, string tip)
+		{
+			return string.Join("_", baseRevisions.Select(rev => rev.Substring(0, 8))) + '-' + tip;
+		}
+
 		public void Push()
 		{
 			var baseRevisions = GetCommonBaseHashesWithRemoteRepo();
@@ -320,9 +333,8 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 
 			// create a bundle to push
-			var tip = _repo.GetTip().Number.Hash;
-			var bundleId = string.Join("_", baseRevisions.Select(rev => rev.Number.Hash)) + '-' +  tip; // REVIEW (Hasso) 2017.02: how much of this is necessary? It's too long when used as a filename. (see also line 639)
-			var bundleHelper = new PushStorageManager(PathToLocalStorage, bundleId);
+			var bundleHelper = new PushStorageManager(PathToLocalStorage,
+				GetBundleIdFilenameBase(baseRevisions.Select(rev => rev.Number.Hash), _repo.GetTip().Number.Hash));
 			var bundleFileInfo = new FileInfo(bundleHelper.BundlePath);
 			if (bundleFileInfo.Length == 0)
 			{
@@ -636,8 +648,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				throw new HgResumeOperationFailed(errorMessage);
 			}
 
-			var bundleId = string.Join("_", baseRevisions) + '-' + localTip;
-			var bundleHelper = new PullStorageManager(PathToLocalStorage, bundleId);
+			var bundleHelper = new PullStorageManager(PathToLocalStorage, GetBundleIdFilenameBase(baseRevisions, localTip));
 			var req = new HgResumeApiParameters
 					  {
 						  RepoId = _apiServer.ProjectId,

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -320,12 +320,8 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 
 			// create a bundle to push
-			string tip = _repo.GetTip().Number.Hash;
-			string bundleId = "";
-			foreach (var revision in baseRevisions)
-			{
-				bundleId += String.Format("{0}-{1}", revision.Number.Hash, tip);
-			}
+			var tip = _repo.GetTip().Number.Hash;
+			var bundleId = string.Join("_", baseRevisions.Select(rev => rev.Number.Hash)) + '-' +  tip; // REVIEW (Hasso) 2017.02: how much of this is necessary? It's too long when used as a filename. (see also line 639)
 			var bundleHelper = new PushStorageManager(PathToLocalStorage, bundleId);
 			var bundleFileInfo = new FileInfo(bundleHelper.BundlePath);
 			if (bundleFileInfo.Length == 0)
@@ -626,7 +622,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		public bool Pull(string[] baseRevisions)
 		{
 			var tipRevision = _repo.GetTip();
-			string localTip = "0";
+			var localTip = "0";
 			string errorMessage;
 			if (tipRevision != null)
 			{
@@ -640,12 +636,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				throw new HgResumeOperationFailed(errorMessage);
 			}
 
-			string bundleId = "";
-			foreach (var revision in baseRevisions)
-			{
-				bundleId += revision + "_" + localTip + '-';
-			}
-			bundleId = bundleId.TrimEnd('-');
+			var bundleId = string.Join("_", baseRevisions) + '-' + localTip;
 			var bundleHelper = new PullStorageManager(PathToLocalStorage, bundleId);
 			var req = new HgResumeApiParameters
 					  {


### PR DESCRIPTION
Omit blatantly redundant parts of a150-character filename.
TODO in a follow-up: remove further name parts to get a fixed-length
name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/113)
<!-- Reviewable:end -->
