### PR TITLE
Don't modify SourcesToTry when iterating over them

### DIFF
--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -329,7 +329,7 @@ namespace Chorus.sync
 		private bool PullFromOthers(HgRepository repo,  List<RepositoryAddress> sourcesToTry, Dictionary<RepositoryAddress, bool> connectionAttempt)
 		{
 			bool didGetFromAtLeastOneSource = false;
-			foreach (RepositoryAddress source in sourcesToTry)
+			foreach (RepositoryAddress source in new List<RepositoryAddress>(sourcesToTry)) // LT-18276: apparently possible to modify sourcesToTry
 			{
 				ThrowIfCancelPending();
 


### PR DESCRIPTION
LT-18276, which we cannot reproduce

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/118)
<!-- Reviewable:end -->
