### PR TITLE
Increase resumable MaxChunkSize to 20MB

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -29,9 +29,9 @@ namespace Chorus.VcsDrivers.Mercurial
 		private readonly IApiServer _apiServer;
 
 		private const int InitialChunkSize = 5000;
-		private const int MaximumChunkSize = 250000;
-		private const int TimeoutInSeconds = 15;
-		private const int TargetTimeInSeconds = TimeoutInSeconds / 3;
+		private const int MaximumChunkSize = 20000000;
+		private const int TimeoutInSeconds = 30;
+		private const int TargetTimeInSeconds = 5;
 		internal const string RevisionCacheFilename = "revisioncache.db";
 		internal int RevisionRequestQuantity = 200;
 
@@ -595,8 +595,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			{
 				responseTimeInMilliseconds = 1;
 			}
-
-			long newChunkSize = TargetTimeInSeconds*1000*chunkSize/responseTimeInMilliseconds;
+			long newChunkSize = (long) ((float) chunkSize / responseTimeInMilliseconds * TargetTimeInSeconds * 1000);
 
 			if (newChunkSize > MaximumChunkSize)
 			{

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
@@ -462,7 +462,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				e.CloneRemoteFromLocal();
 				e.LocalAddAndCommitLargeFile();
 				var serverMessage = "The server is down for scheduled maintenance";
-				e.ApiServer.AddServerUnavailableResponse(4, serverMessage);
+				e.ApiServer.AddServerUnavailableResponse(2, serverMessage);
 				var transport = provider.Transport;
 				transport.Push();
 				Assert.That(e.Progress.AllMessages, Contains.Item("Server temporarily unavailable: " + serverMessage));


### PR DESCRIPTION
This PR increases the ResumableTransport MaxChunkSize to 20MB.  This should improve performance of Resumable and result in more realistic time estimations.

This change was previously discussed here:  https://github.com/sillsdev/chorus/pull/107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/121)
<!-- Reviewable:end -->
