### PR TITLE
increase resumable timeout to 30 seconds, target time to 7 seconds, and maximum chunk size to 20MB

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -29,7 +29,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		private readonly IApiServer _apiServer;
 
 		private const int InitialChunkSize = 5000;
-		private const int MaximumChunkSize = 20000000;
+		private const int MaximumChunkSize = 20000000; // 20MB
 		private const int TimeoutInSeconds = 30;
 		private const int TargetTimeInSeconds = 7;
 		internal const string RevisionCacheFilename = "revisioncache.db";

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -29,9 +29,9 @@ namespace Chorus.VcsDrivers.Mercurial
 		private readonly IApiServer _apiServer;
 
 		private const int InitialChunkSize = 5000;
-		private const int MaximumChunkSize = 250000;
-		private const int TimeoutInSeconds = 15;
-		private const int TargetTimeInSeconds = TimeoutInSeconds / 3;
+		private const int MaximumChunkSize = 20000000;
+		private const int TimeoutInSeconds = 30;
+		private const int TargetTimeInSeconds = 7;
 		internal const string RevisionCacheFilename = "revisioncache.db";
 		internal int RevisionRequestQuantity = 200;
 
@@ -595,8 +595,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			{
 				responseTimeInMilliseconds = 1;
 			}
-
-			long newChunkSize = TargetTimeInSeconds*1000*chunkSize/responseTimeInMilliseconds;
+			long newChunkSize = (long) ((float) chunkSize / responseTimeInMilliseconds * TargetTimeInSeconds * 1000);
 
 			if (newChunkSize > MaximumChunkSize)
 			{

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
@@ -406,8 +406,8 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				Assert.That(() => transport.Push(), Throws.Exception.TypeOf<UserCancelledException>());
 				e.Progress.CancelRequested = false;
 				transport.Push();
-				Assert.That(e.Progress.AllMessages, Contains.Item("Resuming push operation at 126KB sent"));
-				Assert.That(e.Progress.AllMessages, Contains.Item("Resuming push operation at 249KB sent"));
+				Assert.That(e.Progress.AllMessages, Contains.Item("Resuming push operation at 175KB sent"));
+				Assert.That(e.Progress.AllMessages, Contains.Item("Resuming push operation at 346KB sent"));
 				Assert.That(e.Progress.AllMessages, Contains.Item("Finished sending"));
 			}
 		}
@@ -462,7 +462,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				e.CloneRemoteFromLocal();
 				e.LocalAddAndCommitLargeFile();
 				var serverMessage = "The server is down for scheduled maintenance";
-				e.ApiServer.AddServerUnavailableResponse(4, serverMessage);
+				e.ApiServer.AddServerUnavailableResponse(2, serverMessage);
 				var transport = provider.Transport;
 				transport.Push();
 				Assert.That(e.Progress.AllMessages, Contains.Item("Server temporarily unavailable: " + serverMessage));
@@ -810,7 +810,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
             const int bundleSize = 5000000;
             const int chunkSize = 100000;
             const int startOfWindow = 100000;
-            Assert.That(HgResumeTransport.CalculateEstimatedTimeRemaining(bundleSize, chunkSize, startOfWindow), Is.EqualTo("(about 4 minutes)"));
+            Assert.That(HgResumeTransport.CalculateEstimatedTimeRemaining(bundleSize, chunkSize, startOfWindow), Is.EqualTo("(about 5 minutes)"));
         }
 
 


### PR DESCRIPTION
This PR does 3 three things:

- Increases the timeout variable to 30 seconds
- Increases the target time variable to 7 seconds
- Increases the maximum chunk size variable to 20MB

Increasing the timeout to 30 seconds should help reduce the number of "pull timeout, retrying..." messages that chorus users see on bigger projects.

Increasing the target time variable and the chunk size variable should allow for increased data transfer performance

This change was previously discussed here: #107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/122)
<!-- Reviewable:end -->
