### PR TITLE
Always write timestamps with time zones

### DIFF
--- a/src/LibChorus/FileTypeHandlers/lift/LiftMerger.cs
+++ b/src/LibChorus/FileTypeHandlers/lift/LiftMerger.cs
@@ -234,7 +234,7 @@ namespace Chorus.FileTypeHanders.lift
 
 		internal static void AddDateCreatedAttribute(XmlNode elementNode)
 		{
-			AddAttribute(elementNode, "dateCreated", DateTime.Now.ToString(LiftUtils.LiftTimeFormatNoTimeZone));
+			AddAttribute(elementNode, "dateCreated", DateTime.Now.ToString(LiftUtils.LiftTimeFormatWithTimeZone));
 		}
 
 		internal static void AddAttribute(XmlNode element, string name, string value)

--- a/src/LibChorus/FileTypeHandlers/lift/LiftUtils.cs
+++ b/src/LibChorus/FileTypeHandlers/lift/LiftUtils.cs
@@ -6,7 +6,9 @@ namespace Chorus.FileTypeHandlers.lift
 {
 	public static class LiftUtils
 	{
+		[Obsolete("Use LiftTimeFormatWithTimeZone instead, as LiftTimeFormatNoTimeZone produces incorrect results when used with DateTime.Now")]
 		static public string LiftTimeFormatNoTimeZone = "yyyy-MM-ddTHH:mm:ssZ";
+		static public string LiftTimeFormatWithTimeZone = "yyyy-MM-ddTHH:mm:ssK";
 
 		public static string GetId(XmlNode e)
 		{

--- a/src/LibChorus/merge/xml/generic/ChorusNotesMergeEventListener.cs
+++ b/src/LibChorus/merge/xml/generic/ChorusNotesMergeEventListener.cs
@@ -18,7 +18,9 @@ namespace Chorus.merge.xml.generic
 		private FileStream _readerStream;
 		private TempFile _tempFile;
 		private string _path;
+		[Obsolete("Use TimeFormatWithTimeZone instead, as TimeFormatNoTimeZone produces incorrect results when used with DateTime.Now")]
 		static public string TimeFormatNoTimeZone = "yyyy-MM-ddTHH:mm:ssZ";
+		static public string TimeFormatWithTimeZone = "yyyy-MM-ddTHH:mm:ssK";
 		private const int FormatVersionNumber = 0;
 
 		/// <summary>

--- a/src/LibChorus/merge/xml/generic/Conflict.cs
+++ b/src/LibChorus/merge/xml/generic/Conflict.cs
@@ -44,7 +44,9 @@ namespace Chorus.merge.xml.generic
 	/// </summary>
 	public abstract class Conflict : IConflict, IEquatable<Conflict>
 	{
+		[Obsolete("Use TimeFormatWithTimeZone instead, as TimeFormatNoTimeZone produces incorrect results when used with DateTime.Now")]
 		static public string TimeFormatNoTimeZone = @"yyyy-MM-ddTHH:mm:ssZ";
+		static public string TimeFormatWithTimeZone = @"yyyy-MM-ddTHH:mm:ssK";
 
 		private ContextDescriptor _context = new NullContextDescriptor();
 	   // protected string _shortDataDescription;
@@ -152,7 +154,7 @@ namespace Chorus.merge.xml.generic
 			writer.WriteAttributeString(@"author", string.Empty, Author);
 			writer.WriteAttributeString(@"status", string.Empty, @"open");
 			writer.WriteAttributeString(@"guid", string.Empty, Guid.ToString());//nb: ok to have the same guid with the conflict, as they are in 1-1 relation and eventually we'll remove the one on conflict
-			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(TimeFormatNoTimeZone));
+			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(TimeFormatWithTimeZone));
 			writer.WriteString(GetFullHumanReadableDescription());
 
 			//we embed this xml inside the CDATA section so that it pass a more generic schema without
@@ -192,7 +194,7 @@ namespace Chorus.merge.xml.generic
 			//writer.WriteAttributeString("pathToUnitOfConflict", string.Empty, PathToUnitOfConflict);
 			writer.WriteAttributeString(@"type", string.Empty, Description);
 			writer.WriteAttributeString(@"guid", string.Empty, Guid.ToString());
-			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(TimeFormatNoTimeZone));
+			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(TimeFormatWithTimeZone));
 		  //  writer.WriteAttributeString("shortDataDescription", _shortDataDescription);
 			writer.WriteAttributeString(@"whoWon", _whoWon);
 			writer.WriteAttributeString(@"htmlDetails", HtmlDetails);
@@ -627,7 +629,7 @@ namespace Chorus.merge.xml.generic
 			writer.WriteAttributeString(@"author", string.Empty, "merger");
 			writer.WriteAttributeString(@"status", string.Empty, @"open");
 			writer.WriteAttributeString(@"guid", string.Empty, Guid.ToString());
-			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(Conflict.TimeFormatNoTimeZone));
+			writer.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(Conflict.TimeFormatWithTimeZone));
 			writer.WriteString(GetFullHumanReadableDescription());
 
 			//we embed the conflict xml inside the CDATA section so that it pass a more generic schema without
@@ -640,7 +642,7 @@ namespace Chorus.merge.xml.generic
 				embeddedWriter.WriteAttributeString(@"relativeFilePath", string.Empty, RelativeFilePath);
 				embeddedWriter.WriteAttributeString(@"type", string.Empty, Description);
 				embeddedWriter.WriteAttributeString(@"guid", string.Empty, Guid.ToString());
-				embeddedWriter.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(Conflict.TimeFormatNoTimeZone));
+				embeddedWriter.WriteAttributeString(@"date", string.Empty, DateTime.UtcNow.ToString(Conflict.TimeFormatWithTimeZone));
 
 				if(Context != null)
 				{

--- a/src/LibChorus/merge/xml/generic/XmlUtilities.cs
+++ b/src/LibChorus/merge/xml/generic/XmlUtilities.cs
@@ -358,7 +358,7 @@ namespace Chorus.merge.xml.generic
 
 		internal static void AddDateCreatedAttribute(XmlNode elementNode)
 		{
-			AddAttribute(elementNode, "dateCreated", DateTime.Now.ToString(LiftUtils.LiftTimeFormatNoTimeZone));
+			AddAttribute(elementNode, "dateCreated", DateTime.Now.ToString(LiftUtils.LiftTimeFormatWithTimeZone));
 		}
 
 		internal static void AddAttribute(XmlNode element, string name, string value)

--- a/src/LibChorus/notes/Annotation.cs
+++ b/src/LibChorus/notes/Annotation.cs
@@ -18,7 +18,9 @@ namespace Chorus.notes
     {
 		public static readonly string Open = "open";
 		public static readonly string Closed = "closed";
+		[Obsolete("Use TimeFormatWithTimeZone instead, as TimeFormatNoTimeZone produces incorrect results when used with DateTime.Now")]
 		public static string TimeFormatNoTimeZone = "yyyy-MM-ddTHH:mm:ssZ";
+		public static string TimeFormatWithTimeZone = "yyyy-MM-ddTHH:mm:ssK";
         internal readonly XElement _element;
         private AnnotationClass _class;
 

--- a/src/LibChorus/notes/Message.cs
+++ b/src/LibChorus/notes/Message.cs
@@ -19,7 +19,7 @@ namespace Chorus.notes
 		public Message(string author, string status, string contents)
 		{
 			var s = String.Format("<message author='{0}' status ='{1}' date='{2}' guid='{3}'>{4}</message>",
-								  SecurityElement.Escape(author), SecurityElement.Escape(status), DateTime.Now.ToString(Annotation.TimeFormatNoTimeZone),
+								  SecurityElement.Escape(author), SecurityElement.Escape(status), DateTime.Now.ToString(Annotation.TimeFormatWithTimeZone),
 								  System.Guid.NewGuid(), SecurityElement.Escape(contents));
 			_element = XElement.Parse(s);
 		}


### PR DESCRIPTION
In some cases, `TimeFormatNoTimeZone` was lying, writing out a local time with a "Z" suffix, which means "This is UTC". This results in loss of data, since the *actual* time of the original event (conflict, message, etc.) can no longer be retrieved. If it's important to write out local time rather than UTC in a timestamp, then that timestamp should carry the actual time zone it was created in, rather than a false Z suffix.

To ensure that other code calling the Chorus library won't break, I haven't removed the `TimeFormatNoTimeZone` constant (though I was tempted to). Instead, I have marked it Obsolete and suggested the correct constant (`TimeFormatWithTimeZone`) be used instead.

This change passes all Chorus unit tests that I'm aware of, but I was not able to test it with every piece of software that might use Chorus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/125)
<!-- Reviewable:end -->
