### PR TITLE
Fix test failures on chorus master build

### DIFF
--- a/src/ChorusMerge.Tests/ChorusMergeTests.cs
+++ b/src/ChorusMerge.Tests/ChorusMergeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using Chorus.merge;
 using LibChorus.Tests.merge;
@@ -50,7 +51,16 @@ namespace ChorusMerge.Tests
 		{
 			MergeSituation.PushRevisionsToEnvironmentVariables("bob", "-123", "sally", "-456");
 			MergeOrder.PushToEnvironmentVariables(group.Folder.Path);
-			return Program.Main(new[] {group.BobFile.Path, group.AncestorFile.Path, group.SallyFile.Path});
+			// Change error logging to standard out so that tests which simulate errors don't fail the build
+			Program.ErrorWriter = Console.Out;
+			try
+			{
+				return Program.Main(new[] { group.BobFile.Path, group.AncestorFile.Path, group.SallyFile.Path });
+			}
+			finally
+			{
+				Program.ErrorWriter = Console.Error;
+			}
 		}
 
 		[Test]
@@ -80,7 +90,5 @@ namespace ChorusMerge.Tests
 			}
 
 		}
-
-
 	}
 }

--- a/src/ChorusMerge/ChorusMerge.csproj
+++ b/src/ChorusMerge/ChorusMerge.csproj
@@ -28,7 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
+    <Prefer32Bit>true</Prefer32Bit>
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -41,7 +41,7 @@
     <DebugSymbols>True</DebugSymbols>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
+    <Prefer32Bit>true</Prefer32Bit>
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugMono|AnyCPU' ">
@@ -84,6 +84,7 @@
     <LangVersion>6</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -96,7 +97,8 @@
     <LangVersion>6</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>  
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ChorusMerge/Program.cs
+++ b/src/ChorusMerge/Program.cs
@@ -1,9 +1,14 @@
 //#define RUNINDEBUGGER
 using System;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Chorus.FileTypeHandlers;
 using Chorus.merge;
 using Chorus.merge.xml.generic;
+
+// Allow redirecting Console.Error for unit tests (Avoid spurious build failures)
+[assembly: InternalsVisibleTo("ChorusMerge.Tests")]
 
 namespace ChorusMerge
 {
@@ -23,6 +28,8 @@ namespace ChorusMerge
 	/// </remarks>
 	public class Program
 	{
+		internal static TextWriter ErrorWriter = Console.Error;
+
 		public static int Main(string[] args)
 		{
 			try
@@ -66,8 +73,8 @@ namespace ChorusMerge
 			}
 			catch (Exception e)
 			{
-				Console.Error.WriteLine("ChorusMerge Error: " + e.Message);
-				Console.Error.WriteLine(e.StackTrace);
+				ErrorWriter.WriteLine("ChorusMerge Error: " + e.Message);
+				ErrorWriter.WriteLine(e.StackTrace);
 				return 1;
 			}
 			return 0;//no error


### PR DESCRIPTION
Invert the Prefer32bit option

* Prefer32bit for ChorusMerge unless x64 is the Platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/146)
<!-- Reviewable:end -->
