### PR TITLE
Fix file access issue in multi-threaded Sync

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -160,17 +160,19 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			try
 			{
-				EnsureChorusMergeAddedToHgrc();
-				EnsureCacertsIsSet();
-				var extensions = HgExtensions;
-				EnsureTheseExtensionsAndFormatSet(extensions);
-				_hgrcUpdateNeeded = false;
+				lock(_pathToRepository) // Avoid crash if two threads try to Sync simultaneously
+				{
+					EnsureChorusMergeAddedToHgrc();
+					EnsureCacertsIsSet();
+					var extensions = HgExtensions;
+					EnsureTheseExtensionsAndFormatSet(extensions);
+					_hgrcUpdateNeeded = false;
+				}
 			}
 			catch (Exception error)
 			{
 				throw new ApplicationException(string.Format("Failed to set up extensions for the repository: {0}", error.Message));
 			}
-
 		}
 
 		private static Dictionary<string, string> HgExtensions


### PR DESCRIPTION
* AsyncLocalCheckIn_NoHgLockWarningWithMultipleWorkers
  revealed an issue with multi threaded access of the hgrc
  file. This will fix the flaky test and any real user problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/150)
<!-- Reviewable:end -->
