### PR TITLE
Fix FlexBridge crash discovered in PNG

### DIFF
--- a/src/Chorus/ChorusHubClient.cs
+++ b/src/Chorus/ChorusHubClient.cs
@@ -48,6 +48,7 @@ namespace Chorus
 			var channel = factory.CreateChannel();
 			try
 			{
+				((IContextChannel)channel).OperationTimeout = TimeSpan.FromMinutes(15);
 				var jsonStrings = channel.GetRepositoryInformation(finalUrl);
 				_repositoryNames = ImitationHubJSONService.ParseJsonStringsToChorusHubRepoInfos(jsonStrings);
 			}
@@ -89,6 +90,7 @@ namespace Chorus
 			var channel = factory.CreateChannel();
 			try
 			{
+				((IContextChannel)channel).OperationTimeout = TimeSpan.FromMinutes(15);
 				var doWait = channel.PrepareToReceiveRepository(directoryName, repositoryId);
 				return doWait;
 			}

--- a/src/Chorus/UI/Clone/GetCloneFromChorusHubDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromChorusHubDialog.cs
@@ -236,8 +236,9 @@ namespace Chorus.UI.Clone
 #if !MONO // See https://bugzilla.xamarin.com/show_bug.cgi?id=4269. Remove #if when using mono that fixes this.
 			Thread.CurrentThread.Name = @"GetRepositoryInformation";
 #endif
+			Application.UseWaitCursor = true;
+			Cursor.Current = Cursors.WaitCursor;
 			var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();
-
 			if (chorusHubServerInfo == null || !chorusHubServerInfo.ServerIsCompatibleWithThisClient)
 			{
 				e.Result = null;
@@ -250,6 +251,8 @@ namespace Chorus.UI.Clone
 				results[1] = client.GetRepositoryInformation(_model.ProjectFilter);
 				e.Result = results;
 			}
+			Application.UseWaitCursor = false;
+			Cursor.Current = Cursors.Default;
 		}
 
 		public string PathToNewlyClonedFolder


### PR DESCRIPTION
* Increase timeout waiting for ChorusHub server
  to return information about projects to 15m
* Add wait cursor for the Clone dialog when waiting
  for this response.

In the future we should cache this information in ChorusHubServer
to avoid such a long response time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/152)
<!-- Reviewable:end -->
