### PR TITLE
Avoid adding the type attribute to collation during PreMerge

### DIFF
--- a/src/LibChorus/FileTypeHandlers/ldml/LdmlFileHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/ldml/LdmlFileHandler.cs
@@ -353,28 +353,30 @@ namespace Chorus.FileTypeHandlers.ldml
 				return;
 
 			// Add optional key attr and default value on 'collation' element that has no 'type' attr.
-			XElement defaultCollation;
+			XElement ourDocDefaultCollation = GetDefaultCollationNode(ourDoc);
+			XElement theirDocDefaultCollation = GetDefaultCollationNode(theirDoc);
 			if (commonDoc != null)
 			{
-				defaultCollation = GetDefaultCollationNode(commonDoc);
-				if (defaultCollation != null)
+				XElement commonDocDefaultCollation = GetDefaultCollationNode(commonDoc);
+				if (commonDocDefaultCollation != null)
 				{
-					defaultCollation.Add(new XAttribute("type", "standard"));
-					commonDoc.Save(mergeOrder.pathToCommonAncestor);
-					addedCollationAttr = true;
+					if (ourDocDefaultCollation != null || theirDocDefaultCollation != null)
+					{
+						// add type attribute to the commonDoc only when we are certain it will also be added to at least one modified document
+						commonDocDefaultCollation.Add(new XAttribute("type", "standard"));
+						commonDoc.Save(mergeOrder.pathToCommonAncestor);
+					}
 				}
 			}
-			defaultCollation = GetDefaultCollationNode(ourDoc);
-			if (defaultCollation != null)
+			if (ourDocDefaultCollation != null)
 			{
-				defaultCollation.Add(new XAttribute("type", "standard"));
+				ourDocDefaultCollation.Add(new XAttribute("type", "standard"));
 				ourDoc.Save(mergeOrder.pathToOurs);
 				addedCollationAttr = true;
 			}
-			defaultCollation = GetDefaultCollationNode(theirDoc);
-			if (defaultCollation != null)
+			if (theirDocDefaultCollation != null)
 			{
-				defaultCollation.Add(new XAttribute("type", "standard"));
+				theirDocDefaultCollation.Add(new XAttribute("type", "standard"));
 				theirDoc.Save(mergeOrder.pathToTheirs);
 				addedCollationAttr = true;
 			}


### PR DESCRIPTION
* Account for collation nodes deleted from ancestor file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/164)
<!-- Reviewable:end -->
