### PR TITLE
while doing Send/Receive using the new 2.6 Chorus from a repo that wa…

### DIFF
--- a/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
+++ b/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
@@ -50,8 +50,7 @@ namespace Chorus.FileTypeHandlers
                     }
                     catch (ReflectionTypeLoadException ex)
                     {
-                        var typeLoadException = ex as ReflectionTypeLoadException;
-                        var loaderExceptions = typeLoadException.LoaderExceptions;
+                        var loaderExceptions = ex.LoaderExceptions;
                         System.Diagnostics.Debug.Fail("Loading exception!");
                         throw new AggregateException(ex.Message, loaderExceptions);
                     }

--- a/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
+++ b/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -48,15 +48,12 @@ namespace Chorus.FileTypeHandlers
                     {
                         container.ComposeParts(this);
                     }
-                    catch (Exception ex)
+                    catch (ReflectionTypeLoadException ex)
                     {
-                        if (ex is ReflectionTypeLoadException)
-                        {
-                            var typeLoadException = ex as ReflectionTypeLoadException;
-                            var loaderExceptions = typeLoadException.LoaderExceptions;
-                            System.Diagnostics.Debug.Fail("Loading exception!");
-                            throw new AggregateException(ex.Message, loaderExceptions);
-                        }
+                        var typeLoadException = ex as ReflectionTypeLoadException;
+                        var loaderExceptions = typeLoadException.LoaderExceptions;
+                        System.Diagnostics.Debug.Fail("Loading exception!");
+                        throw new AggregateException(ex.Message, loaderExceptions);
                     }
                 }
 			}

--- a/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
+++ b/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
@@ -44,8 +44,21 @@ namespace Chorus.FileTypeHandlers
 
 				using (var container = new CompositionContainer(catalog))
 				{
-					container.ComposeParts(this);
-				}
+                    try
+                    {
+                        container.ComposeParts(this);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is ReflectionTypeLoadException)
+                        {
+                            var typeLoadException = ex as ReflectionTypeLoadException;
+                            var loaderExceptions = typeLoadException.LoaderExceptions;
+                            System.Diagnostics.Debug.Fail("Loading exception!");
+                            throw new AggregateException(ex.Message, loaderExceptions);
+                        }
+                    }
+                }
 			}
 		}
 

--- a/src/LibChorus/Utilities/ini/IniDocument.cs
+++ b/src/LibChorus/Utilities/ini/IniDocument.cs
@@ -187,7 +187,6 @@ namespace Nini.Ini
 				Save(writer);
 				writer.Close();
 			}
-            // File.Replace(tempPath, filePath, null);
             SIL.IO.RobustFile.Replace(tempPath, filePath, null);
 		}
 

--- a/src/LibChorus/Utilities/ini/IniDocument.cs
+++ b/src/LibChorus/Utilities/ini/IniDocument.cs
@@ -187,7 +187,8 @@ namespace Nini.Ini
 				Save(writer);
 				writer.Close();
 			}
-			File.Replace(tempPath, filePath, null);
+            // File.Replace(tempPath, filePath, null);
+            SIL.IO.RobustFile.Replace(tempPath, filePath, null);
 		}
 
 		//added by hatton for Chorus


### PR DESCRIPTION
…s last sync'd with 2.5, we occasionally get an exception, "Failed to set up extensions for the repository: Unable to remove the file to be replaced" (an exception throw from line 174 of HgRepository.cs). Jason suggests changing File.Replace to RobustFile.Replace in the Save method of IniDocument to solve this.

Also, OneStory Editor has ChorusFileType extension DLL that get loaded at run-time and 2.6 has a new behavior that requires the extension to define the class attribute:
[Export(typeof(IChorusFileTypeHandler))] in the FileType handler. Before I knew this was needed, it failed to load the extension DLL and the error was being swallowed, so I added a try...catch around where it fails, so it can throw a more meaningful error message if this wasn't done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/176)
<!-- Reviewable:end -->
