### PR TITLE
Improve exception when failing to set up extensions

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -172,7 +172,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 			catch (Exception error)
 			{
-				throw new ApplicationException(string.Format("Failed to set up extensions for the repository: {0}", error.Message));
+				throw new ApplicationException($"Failed to set up extensions for the repository: {error.Message}", error);
 			}
 		}
 


### PR DESCRIPTION
Setting up extensions can fail in multiple places. Adding the exception we catch as inner exception might help to track down some problems.

In particular I'm trying to track down why we have some tests that fail in the `feature/nuget` branch (that used to have all tests passing until I merged with master) but pass in `master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/198)
<!-- Reviewable:end -->
