### PR TITLE
Use Environment var for timeout to fix problems described in LT-19898

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -146,6 +146,12 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			_mercurialTwoCompatible = true;
 			_hgrcUpdateNeeded = updateHgrc;
+			var timeoutOverride = Environment.GetEnvironmentVariable("CHORUS_LOCAL_TIMEOUT_SECONDS");
+			int timeoutValue;
+			if (int.TryParse(timeoutOverride, out timeoutValue))
+			{
+				SecondsBeforeTimeoutOnLocalOperation = timeoutValue;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
  If a user does a Send/Receive with a very large amount of
  binary files the local commit its self could take more then
  the 15 minute time out.

* Add an Environment variable override option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/205)
<!-- Reviewable:end -->
