### PR TITLE
Fix LT-20017: Sanitize HtmlDetails

### DIFF
--- a/src/LibChorusTests/FileHandlers/LargeFileIntegrationTestService.cs
+++ b/src/LibChorusTests/FileHandlers/LargeFileIntegrationTestService.cs
@@ -15,10 +15,10 @@ namespace LibChorus.Tests.FileHandlers
 {
 	/// <summary>
 	/// Static class that tests (integration, not unit, since it involves so many units)
-	/// to make sure a given file extension is, or is not, included in a respository,
+	/// to make sure a given file extension is, or is not, included in a repository,
 	/// when committed by the Synchronizer class.
 	///
-	/// No filtering for large files is done at the respository commit level.
+	/// No filtering for large files is done at the repository commit level.
 	/// </summary>
 	public static class LargeFileIntegrationTestService
 	{

--- a/src/LibChorusTests/merge/xml/generic/ConflictIOTest.cs
+++ b/src/LibChorusTests/merge/xml/generic/ConflictIOTest.cs
@@ -74,6 +74,18 @@ namespace LibChorus.Tests.merge.xml.generic
 		}
 
 		[Test]
+		public void ConflictWithInvalidUtf8DetailsWorks()
+		{
+			var conflict = new DemoConflict(new NullMergeSituation());
+			conflict.Context = new ContextDescriptor("testLabel", "testPath");
+			conflict.HtmlDetails = "Bad\uDBFFegg"; // Unmatched low surrogate
+			var annotationXml = XmlTestHelper.WriteConflictAnnotation(conflict);
+			Conflict.RegisterContextClass(typeof(DemoConflict));
+			var regurgitated = Conflict.CreateFromChorusNotesAnnotation(annotationXml);
+			Assert.That(regurgitated.HtmlDetails, Is.StringContaining("Badegg"));// the /uDB80 should have dropped
+		}
+
+		[Test]
 		public void CreateFromConflictElement_ProducesDifferentConflictReports()
 		{
 			//Setup


### PR DESCRIPTION
* Drop any invalid UTF8 sequences before writing the
  HtmlDetails of a conflict to ChorusNotes
* Fix some misspellings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/206)
<!-- Reviewable:end -->
