### PR TITLE
Watch for FLEx changing Notes files (LT-20074)

### DIFF
--- a/src/Chorus.Tests/ChorusSystemUsage.cs
+++ b/src/Chorus.Tests/ChorusSystemUsage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -225,6 +225,11 @@ namespace Chorus.Tests
 
 		public void NotifyOfDeletion(Annotation annotation)
 		{
+		}
+
+		public void NotifyOfStaleList()
+		{
+
 		}
 
 		#endregion

--- a/src/Chorus/UI/Notes/Bar/NotesBarModel.cs
+++ b/src/Chorus/UI/Notes/Bar/NotesBarModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Chorus.notes;
@@ -133,6 +133,11 @@ namespace Chorus.UI.Notes.Bar
 		}
 
 		public void NotifyOfDeletion(Annotation annotation)
+		{
+			_reloadPending = true;
+		}
+
+		public void NotifyOfStaleList()
 		{
 			_reloadPending = true;
 		}

--- a/src/Chorus/UI/Notes/Browser/NotesInProjectViewModel.cs
+++ b/src/Chorus/UI/Notes/Browser/NotesInProjectViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -294,6 +294,12 @@ namespace Chorus.UI.Notes.Browser
 			//NB: this notification would come from the repository, not the view
 			_reloadPending=true;
 			SaveChanges();
+		}
+
+		public void NotifyOfStaleList()
+		{
+			_reloadPending = true;
+			ReloadMessagesNow();
 		}
 
 

--- a/src/LibChorus/notes/AnnotationIndex.cs
+++ b/src/LibChorus/notes/AnnotationIndex.cs
@@ -79,6 +79,11 @@ namespace Chorus.notes
 			_keyToObjectsMap.RemoveKeyItemPair(key, annotation);
 		}
 
+		public void NotifyOfStaleList()
+		{
+			// Can we do anything useful here?
+		}
+
 		public IEnumerable<Annotation> GetMatches(Func<string, bool> predicateOnKey, IProgress progress)
 		{
 			foreach (var x in _keyToObjectsMap)

--- a/src/LibChorus/notes/IAnnotationRepositoryObserver.cs
+++ b/src/LibChorus/notes/IAnnotationRepositoryObserver.cs
@@ -11,5 +11,6 @@ namespace Chorus.notes
 		void NotifyOfAddition(Annotation annotation);
 		void NotifyOfModification(Annotation annotation);
 		void NotifyOfDeletion(Annotation annotation);
+		void NotifyOfStaleList();
 	}
 }

--- a/src/LibChorusTests/notes/MultiSourceAnnotationRepositoryTests.cs
+++ b/src/LibChorusTests/notes/MultiSourceAnnotationRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -180,6 +180,11 @@ namespace LibChorus.Tests.notes
 		}
 
 		public void NotifyOfDeletion(Annotation annotation)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void NotifyOfStaleList()
 		{
 			throw new NotImplementedException();
 		}


### PR DESCRIPTION
Changes to notes made in FLEx show up in View Conflicts app, and as a result, changes made there won't overwrite ones from FLEx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/209)
<!-- Reviewable:end -->
