### PR TITLE
Prevent crash copying nodes to other XML documents (LT-20282)

### DIFF
--- a/src/LibChorus.TestUtilities/XmlTestHelper.cs
+++ b/src/LibChorus.TestUtilities/XmlTestHelper.cs
@@ -32,7 +32,7 @@ namespace LibChorus.TestUtilities
 				XmlWriterSettings settings = new XmlWriterSettings();
 				settings.Indent = true;
 				settings.ConformanceLevel = ConformanceLevel.Fragment;
-				XmlWriter writer = XmlTextWriter.Create(Console.Out, settings);
+				var writer = XmlWriter.Create(Console.Out, settings);
 				doc.WriteContentTo(writer);
 				writer.Flush();
 				if (nodes != null && nodes.Count > 1)
@@ -48,11 +48,10 @@ namespace LibChorus.TestUtilities
 
 		public static void CreateThreeNodes(string ourXml, string theirXml, string ancestorXml, out XmlNode ourNode, out XmlNode ourParent, out XmlNode theirNode, out XmlNode ancestorNode)
 		{
-			var doc = new XmlDocument();
-			ourParent = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ourXml + "</ParentNode>", doc);
+			ourParent = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ourXml + "</ParentNode>", new XmlDocument());
 			ourNode = ourParent.FirstChild;
-			theirNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + theirXml + "</ParentNode>", doc).FirstChild;
-			ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ancestorXml + "</ParentNode>", doc).FirstChild;
+			theirNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + theirXml + "</ParentNode>", new XmlDocument()).FirstChild;
+			ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml("<ParentNode>" + ancestorXml + "</ParentNode>", new XmlDocument()).FirstChild;
 		}
 
 		public static void AssertXPathNotNull(string documentPath, string xpath)
@@ -65,7 +64,7 @@ namespace LibChorus.TestUtilities
 				XmlWriterSettings settings = new XmlWriterSettings();
 				settings.Indent = true;
 				settings.ConformanceLevel = ConformanceLevel.Fragment;
-				XmlWriter writer = XmlTextWriter.Create(Console.Out, settings);
+				var writer = XmlWriter.Create(Console.Out, settings);
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
@@ -84,7 +83,7 @@ namespace LibChorus.TestUtilities
 													Indent = true,
 													ConformanceLevel = ConformanceLevel.Fragment
 												};
-				XmlWriter writer = XmlTextWriter.Create(Console.Out, settings);
+				var writer = XmlWriter.Create(Console.Out, settings);
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
@@ -104,7 +103,7 @@ namespace LibChorus.TestUtilities
 				return;
 
 			var settings = new XmlWriterSettings { Indent = true, ConformanceLevel = ConformanceLevel.Fragment };
-			var writer = XmlTextWriter.Create(Console.Out, settings);
+			var writer = XmlWriter.Create(Console.Out, settings);
 			doc.WriteContentTo(writer);
 			writer.Flush();
 			if (nodes != null && nodes.Count > 1)
@@ -133,7 +132,7 @@ namespace LibChorus.TestUtilities
 					Indent = true,
 					ConformanceLevel = ConformanceLevel.Fragment
 				};
-				var writer = XmlTextWriter.Create(Console.Out, settings);
+				var writer = XmlWriter.Create(Console.Out, settings);
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
@@ -148,10 +147,9 @@ namespace LibChorus.TestUtilities
 			int expectedConflictCount, List<Type> expectedConflictTypes,
 			int expectedChangesCount, List<Type> expectedChangeTypes)
 		{
-			var doc = new XmlDocument();
-			var ourNode = XmlUtilities.GetDocumentNodeFromRawXml(ourXml, doc);
-			var theirNode = XmlUtilities.GetDocumentNodeFromRawXml(theirXml, doc);
-			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(ancestorXml, doc);
+			var ourNode = XmlUtilities.GetDocumentNodeFromRawXml(ourXml, new XmlDocument());
+			var theirNode = XmlUtilities.GetDocumentNodeFromRawXml(theirXml, new XmlDocument());
+			var ancestorNode = XmlUtilities.GetDocumentNodeFromRawXml(ancestorXml, new XmlDocument());
 
 			var eventListener = new ListenerForUnitTests();
 			var merger = new XmlMerger(mergeSituation)

--- a/src/LibChorus/merge/xml/generic/MergeLimitedChildrenService.cs
+++ b/src/LibChorus/merge/xml/generic/MergeLimitedChildrenService.cs
@@ -212,7 +212,8 @@ namespace Chorus.merge.xml.generic
 					merger.ConflictOccurred(new RemovedVsEditedElementConflict(theirChild.Name, theirChild, null, ancestorChild,
 																			   mergeSituation, mergeStrategyForChild,
 																			   mergeSituation.BetaUserId));
-					ours.AppendChild(theirChild);
+					// ReSharper disable once PossibleNullReferenceException -- if ours.OwnerDocument is null, we have other problems
+					ours.AppendChild(ours.OwnerDocument.ImportNode(theirChild, true));
 				}
 			}
 			return ours;
@@ -227,7 +228,8 @@ namespace Chorus.merge.xml.generic
 			{
 				// they added child.
 				merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(pathToFileInRepository, theirChild));
-				ours.AppendChild(theirChild);
+				// ReSharper disable once PossibleNullReferenceException -- if ours.OwnerDocument is null, we have other problems
+				ours.AppendChild(ours.OwnerDocument.ImportNode(theirChild, true));
 				return ours;
 			}
 			if (theirChild == null)
@@ -389,7 +391,8 @@ namespace Chorus.merge.xml.generic
 					if (ourChild == null)
 					{
 						merger.EventListener.ChangeOccurred(new XmlAdditionChangeReport(pathToFileInRepository, theirChild));
-						ours.AppendChild(theirChild);
+						// ReSharper disable once PossibleNullReferenceException -- if ours.OwnerDocument is null, we have other problems
+						ours.AppendChild(ours.OwnerDocument.ImportNode(theirChild, true));
 						return ours;
 					}
 					if (theirChild == null)


### PR DESCRIPTION
- Import "their" nodes into "our" document before trying to Append them
- Create separate XmlDocuments for theirs, ours, and ancestor for tests
- Test all fixed Appends
- Clean up some tests

Resolves https://jira.sil.org/browse/LT-20282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/219)
<!-- Reviewable:end -->
