### PR TITLE
Replace deprecated NUnit asserts

### DIFF
--- a/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
+++ b/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
@@ -35,7 +35,7 @@ namespace Chorus.Tests.UI.Clone
 
 				var extantRepoIdentifiers = GetSharedProjectModel.ExtantRepoIdentifiers(parentFolder.Path, null);
 				Assert.AreEqual(1, extantRepoIdentifiers.Count);
-				Assert.IsTrue(extantRepoIdentifiers.ContainsKey(repo.Identifier));
+				Assert.That(extantRepoIdentifiers, Does.ContainKey(repo.Identifier));
 				Assert.That(extantRepoIdentifiers[repo.Identifier], Is.EqualTo("childFolder"));
 			}
 		}
@@ -56,7 +56,7 @@ namespace Chorus.Tests.UI.Clone
 
 				var extantRepoIdentifiers = GetSharedProjectModel.ExtantRepoIdentifiers(parentFolder.Path, "otherRepositories");
 				Assert.AreEqual(1, extantRepoIdentifiers.Count);
-				Assert.IsTrue(extantRepoIdentifiers.ContainsKey(repo.Identifier));
+				Assert.That(extantRepoIdentifiers, Does.ContainKey(repo.Identifier));
 				Assert.That(extantRepoIdentifiers[repo.Identifier], Is.EqualTo("childFolder"));
 			}
 		}

--- a/src/Chorus.Tests/UI/Clone/TargetFolderControlTests.cs
+++ b/src/Chorus.Tests/UI/Clone/TargetFolderControlTests.cs
@@ -41,7 +41,7 @@ namespace Chorus.Tests.UI.Clone
 				model.LocalFolderName = "";
 				var ctrl = new TargetFolderControl(model);
 				ctrl._localFolderName.Text = "  Bob";
-				Assert.IsFalse(model.TargetHasProblem);
+				Assert.That(model.TargetHasProblem, Is.False);
 				Assert.AreEqual(Path.Combine(testFolder.Path, "Bob"), model.TargetDestination);
 			}
 		}
@@ -58,7 +58,7 @@ namespace Chorus.Tests.UI.Clone
 				model.LocalFolderName = "";
 				var ctrl = new TargetFolderControl(model);
 				ctrl._localFolderName.Text = "Billy ";
-				Assert.IsTrue(model.TargetHasProblem);
+				Assert.That(model.TargetHasProblem, Is.True);
 				Assert.AreEqual(Path.Combine(testFolder.Path, "Billy"), model.TargetDestination);
 			}
 		}

--- a/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
@@ -123,8 +123,8 @@ namespace Chorus.Tests.UI.Sync
 			// NOTE: we can't use AutoResetEvent with Sync() - for some reason this doesn't work
 			WaitForSyncToFinish(ref results);
 
-			Assert.IsFalse(results.Succeeded);
-			Assert.IsNotNull(results.ErrorEncountered);
+			Assert.That(results.Succeeded, Is.False);
+			Assert.That(results.ErrorEncountered, Is.Not.Null);
 		}
 
 		[Test]
@@ -143,9 +143,9 @@ namespace Chorus.Tests.UI.Sync
 			// NOTE: we can't use AutoResetEvent with Sync() - for some reason this doesn't work
 			WaitForSyncToFinish(ref results);
 
-			Assert.IsFalse(results.Succeeded);
-			Assert.IsTrue(results.Cancelled);
-			Assert.IsNull(results.ErrorEncountered);
+			Assert.That(results.Succeeded, Is.False);
+			Assert.That(results.Cancelled, Is.True);
+			Assert.That(results.ErrorEncountered, Is.Null);
 		}
 
 		[Test]
@@ -155,7 +155,7 @@ namespace Chorus.Tests.UI.Sync
 			var waitHandle = new AutoResetEvent(false);
 			_model.AsyncLocalCheckIn("testing", r => { result=r; waitHandle.Set();});
 			WaitForTasksToFinish(1, waitHandle);
-			Assert.IsTrue(result.Succeeded);
+			Assert.That(result.Succeeded, Is.True);
 		}
 
 		/// <summary>
@@ -175,9 +175,9 @@ namespace Chorus.Tests.UI.Sync
 			_model.AsyncLocalCheckIn("testing", r => { result3=r; waitHandle3.Set(); });
 			WaitForTasksToFinish(3, waitHandle1, waitHandle2, waitHandle3);
 
-			Assert.IsFalse(_model.StatusProgress.WarningEncountered, "There was a warning encountered during the sync: {0}", _model.StatusProgress.LastWarning);
-			Assert.IsFalse(_model.StatusProgress.ErrorEncountered, "There was an error encountered during the sync: {0}", _model.StatusProgress.LastError);
-			Assert.IsTrue(result1.Succeeded && result2.Succeeded && result3.Succeeded, "One of the CheckIn attempts did not succeed.");
+			Assert.That(_model.StatusProgress.WarningEncountered, Is.False, $"There was a warning encountered during the sync: {_model.StatusProgress.LastWarning}");
+			Assert.That(_model.StatusProgress.ErrorEncountered, Is.False, $"There was an error encountered during the sync: {_model.StatusProgress.LastError}");
+			Assert.That(result1.Succeeded && result2.Succeeded && result3.Succeeded, Is.True, "One of the CheckIn attempts did not succeed.");
 		}
 
 		[Test]

--- a/src/Chorus.Tests/UI/Sync/SyncDialogTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncDialogTests.cs
@@ -206,7 +206,7 @@ namespace Chorus.Tests.UI.Sync
 				{
 					dlg.SyncOptions.RepositorySourcesToTry.Add(RepositoryAddress.Create("bogus", @"z:/"));
 					dlg.ShowDialog();
-					Assert.IsTrue(dlg.FinalStatus.WarningEncountered);
+					Assert.That(dlg.FinalStatus.WarningEncountered, Is.True);
 				}
 			}
 		}
@@ -220,7 +220,7 @@ namespace Chorus.Tests.UI.Sync
 			var syncStartModel = new SyncStartModel(null);
 			var result = syncStartModel.GetUsbStatusLink(usbLocator, out message);
 
-			Assert.IsFalse(result, "Should fail!");
+			Assert.That(result, Is.False, "Should fail!");
 			Assert.AreEqual("First insert a USB flash drive.", message);
 		}
 
@@ -233,7 +233,7 @@ namespace Chorus.Tests.UI.Sync
 			var syncStartModel = new SyncStartModel(null);
 			var result = syncStartModel.GetUsbStatusLink(usbLocator, out message);
 
-			Assert.IsFalse(result, "Should fail!");
+			Assert.That(result, Is.False, "Should fail!");
 			Assert.AreEqual("More than one USB drive detected. Please remove one.", message);
 		}
 
@@ -246,8 +246,8 @@ namespace Chorus.Tests.UI.Sync
 			var syncStartModel = new SyncStartModel(null);
 			var result = syncStartModel.GetUsbStatusLink(usbLocator, out message);
 
-			Assert.IsTrue(result, "Should pass!");
-			Assert.IsTrue(message.StartsWith("C:"));
+			Assert.That(result, Is.True, "Should pass!");
+			Assert.That(message.StartsWith("C:"), Is.True);
 		}
 	}
 }

--- a/src/Chorus.Tests/UI/notes/AnnotationModelTests.cs
+++ b/src/Chorus.Tests/UI/notes/AnnotationModelTests.cs
@@ -26,15 +26,15 @@ namespace Chorus.Tests.notes
 			var messageSelected = new MessageSelectedEvent();
 			AnnotationEditorModel annotationModel = CreateAnnotationModel(messageSelected);
 			messageSelected.Raise(annotation, annotation.Messages.First());
-			Assert.IsFalse(annotationModel.IsResolved);
-			Assert.IsFalse(annotation.IsClosed);
+			Assert.That(annotationModel.IsResolved, Is.False);
+			Assert.That(annotation.IsClosed, Is.False);
 			Assert.AreEqual(1, annotation.Messages.Count());
 			annotationModel.AddMessage("hello");
-			Assert.IsFalse(annotationModel.IsResolved,"should not have changed status");
+			Assert.That(annotationModel.IsResolved, Is.False,"should not have changed status");
 			Assert.AreEqual(2, annotation.Messages.Count());
 			Assert.AreEqual("bob", annotation.Messages.Last().GetAuthor(""));
 			Assert.AreEqual("hello", annotation.Messages.Last().Text);
-			Assert.IsTrue(DateTime.Now.Subtract(annotation.Messages.Last().Date).Seconds < 2);
+			Assert.That(DateTime.Now.Subtract(annotation.Messages.Last().Date).Seconds, Is.LessThan(2));
 		}
 
 		[Test]
@@ -44,11 +44,11 @@ namespace Chorus.Tests.notes
 			var messageSelected = new MessageSelectedEvent();
 			AnnotationEditorModel annotationModel = CreateAnnotationModel(messageSelected);
 			messageSelected.Raise(annotation, annotation.Messages.First());
-			Assert.IsFalse(annotationModel.IsResolved);
-			Assert.IsFalse(annotation.IsClosed);
+			Assert.That(annotationModel.IsResolved, Is.False);
+			Assert.That(annotation.IsClosed, Is.False);
 			annotationModel.IsResolved = true;
-			Assert.IsTrue(annotationModel.IsResolved);
-			Assert.IsTrue(annotation.IsClosed);
+			Assert.That(annotationModel.IsResolved, Is.True);
+			Assert.That(annotation.IsClosed, Is.True);
 		}
 
 		[Test]
@@ -58,15 +58,15 @@ namespace Chorus.Tests.notes
 			var messageSelected = new MessageSelectedEvent();
 			AnnotationEditorModel annotationModel = CreateAnnotationModel(messageSelected);
 			messageSelected.Raise(annotation, annotation.Messages.First());
-			Assert.IsFalse(annotationModel.IsResolved);
-			Assert.IsFalse(annotation.IsClosed);
+			Assert.That(annotationModel.IsResolved, Is.False);
+			Assert.That(annotation.IsClosed, Is.False);
 			Assert.AreEqual(1, annotation.Messages.Count());
 			annotationModel.UnResolveAndAddMessage("hello");
-			Assert.IsTrue(annotationModel.IsResolved, "should have changed status");
+			Assert.That(annotationModel.IsResolved, Is.True, "should have changed status");
 			Assert.AreEqual(2, annotation.Messages.Count());
 			Assert.AreEqual("bob", annotation.Messages.Last().GetAuthor(""));
 			Assert.AreEqual("hello", annotation.Messages.Last().Text);
-			Assert.IsTrue(DateTime.Now.Subtract(annotation.Messages.Last().Date).Seconds < 2);
+			Assert.That(DateTime.Now.Subtract(annotation.Messages.Last().Date).Seconds, Is.LessThan(2));
 		}
 
 		private AnnotationEditorModel CreateAnnotationModel(MessageSelectedEvent messageSelected)

--- a/src/Chorus.Tests/UI/notes/MessageTests.cs
+++ b/src/Chorus.Tests/UI/notes/MessageTests.cs
@@ -21,7 +21,7 @@ namespace Chorus.Tests.notes
 
 			var m = new Message(element);
 			string text = m.GetHtmlText(new EmbeddedMessageContentHandlerRepository());
-			Assert.IsTrue(text.Contains("<a"));
+			Assert.That(text, Does.Contain("<a"));
 		}
 
 		[Test]
@@ -33,7 +33,7 @@ namespace Chorus.Tests.notes
 </message>");
 
 			var m = new Message(element);
-			Assert.IsFalse(m.GetHtmlText(new EmbeddedMessageContentHandlerRepository()).Contains("<a"));
+			Assert.That(m.GetHtmlText(new EmbeddedMessageContentHandlerRepository()), Does.Not.Contain("<a"));
 		}
 	}
 }

--- a/src/Chorus.Tests/UI/notes/NotesBarModelTests.cs
+++ b/src/Chorus.Tests/UI/notes/NotesBarModelTests.cs
@@ -27,7 +27,7 @@ namespace Chorus.Tests.notes
 			model.SetTargetObject("foo3");
 			model.AddAnnotation(model.CreateAnnotation());
 			Assert.AreEqual(1, repo.GetAllAnnotations().Count());
-			Assert.IsTrue(repo.GetAllAnnotations().First().RefStillEscaped.Contains("id="+"foo3"));
+			Assert.That(repo.GetAllAnnotations().First().RefStillEscaped, Does.Contain("id="+"foo3"));
 		}
 
 		[Test]
@@ -56,7 +56,7 @@ namespace Chorus.Tests.notes
 			 var model = new NotesBarModel(repo, mapping);
 			model.SetTargetObject("two'<three&four");
 			model.AddAnnotation(model.CreateAnnotation());
-			Assert.IsTrue(repo.GetAllAnnotations().First().RefUnEscaped.Contains("two'<three&four"));
+			Assert.That(repo.GetAllAnnotations().First().RefUnEscaped, Does.Contain("two'<three&four"));
 		}
 
 		[Test]

--- a/src/Chorus.Tests/clone/ClonerTests.cs
+++ b/src/Chorus.Tests/clone/ClonerTests.cs
@@ -26,7 +26,7 @@ namespace Chorus.Tests.clone
 				var progress = new ConsoleProgress();
 				progress.ShowVerbose = true;
 				model.MakeClone(repo.ProjectFolder.Path, f.Path, progress);
-				Assert.IsTrue(Directory.Exists(f.Combine(RepositorySetup.ProjectNameForTest, ".hg")));
+				Assert.That(f.Combine(RepositorySetup.ProjectNameForTest, ".hg"), Does.Exist);
 			}
 		}
 
@@ -47,8 +47,8 @@ namespace Chorus.Tests.clone
 				Directory.CreateDirectory(extantSubfolderPath);
 
 				var cloneFolder = model.MakeClone(repo.ProjectFolder.Path, f.Path, progress);
-				Assert.AreEqual(extantFolder + "1", cloneFolder);
-				Assert.IsTrue(Directory.Exists(extantFolder + "1"));
+				Assert.That(cloneFolder, Is.EqualTo(extantFolder + "1"));
+				Assert.That(extantFolder + "1", Does.Exist);
 			}
 		}
 
@@ -66,9 +66,9 @@ namespace Chorus.Tests.clone
 				Directory.CreateDirectory(extantFolder);
 
 				var cloneFolder = model.MakeClone(repo.ProjectFolder.Path, f.Path, progress);
-				Assert.AreEqual(extantFolder, cloneFolder);
-				Assert.IsTrue(Directory.Exists(extantFolder));
-				Assert.IsFalse(Directory.Exists(extantFolder + "1"));
+				Assert.That(cloneFolder, Is.EqualTo(extantFolder));
+				Assert.That(extantFolder, Does.Exist);
+				Assert.That(extantFolder + "1", Does.Not.Exist);
 			}
 		}
 

--- a/src/ChorusHubTests/ChorusHubTests.cs
+++ b/src/ChorusHubTests/ChorusHubTests.cs
@@ -37,7 +37,7 @@ namespace ChorusHubTests
 		[Test, Ignore("Run by hand.")]
 		public void FindServer_NoServerFound_Null()
 		{
-			Assert.IsNull(ChorusHubServerInfo.FindServerInformation());
+			Assert.That(ChorusHubServerInfo.FindServerInformation(), Is.Null);
 		}
 
 		[Test]
@@ -75,7 +75,7 @@ namespace ChorusHubTests
 				ChorusHubOptions.RootDirectory = chorusHubSourceFolder.Path;
 				using (var service = new ChorusHubServer())
 				{
-					Assert.IsTrue(service.Start(true));
+					Assert.That(service.Start(true), Is.True);
 
 					var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();
 					Assert.NotNull(chorusHubServerInfo);
@@ -83,7 +83,7 @@ namespace ChorusHubTests
 					var client1 = new ChorusHubClient(chorusHubServerInfo);
 					var allRepoInfo = client1.GetRepositoryInformation(string.Empty);
 					Assert.AreEqual(2, allRepoInfo.Count());
-					Assert.IsTrue(allRepoInfo.Select(ri => ri.RepoName.Contains("repo2")).Any());
+					Assert.That(allRepoInfo.Select(ri => ri.RepoName.Contains("repo2")).Any(), Is.True);
 
 					// Make sure filter works
 					// In order to have a hope of getting a different result to GetRepositoryInformation
@@ -94,7 +94,7 @@ namespace ChorusHubTests
 					var repoInfo = client2.GetRepositoryInformation(queryString);
 					Assert.AreEqual(1, repoInfo.Count());
 					var info = repoInfo.First();
-					Assert.IsTrue(info.RepoName == "repo1");
+					Assert.That(info.RepoName, Is.EqualTo("repo1"));
 				}
 			}
 		}
@@ -123,7 +123,7 @@ namespace ChorusHubTests
 				using (var service = new ChorusHubServer())
 				{
 					// hg server side is now involved in deciding what repos are available
-					Assert.IsTrue(service.Start(true));
+					Assert.That(service.Start(true), Is.True);
 					var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();
 					Assert.NotNull(chorusHubServerInfo);
 					var client = new ChorusHubClient(chorusHubServerInfo);
@@ -131,8 +131,8 @@ namespace ChorusHubTests
 					Assert.AreEqual(2, repoInfo.Count());
 					var info1 = repoInfo.First();
 					var info2 = repoInfo.Last();
-					Assert.IsTrue(info1.RepoName == "repo1");
-					Assert.IsTrue(info2.RepoName == "repo2");
+					Assert.That(info1.RepoName, Is.EqualTo("repo1"));
+					Assert.That(info2.RepoName, Is.EqualTo("repo2"));
 				}
 			}
 		}
@@ -172,7 +172,7 @@ namespace ChorusHubTests
 				ChorusHubOptions.RootDirectory = chorusHubSourceFolder.Path;
 				using (var service = new ChorusHubServer())
 				{
-					Assert.IsTrue(service.Start(true));
+					Assert.That(service.Start(true), Is.True);
 
 					// Make sure filter works
 					var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();
@@ -182,8 +182,8 @@ namespace ChorusHubTests
 					Assert.AreEqual(2, repoInfo.Count());
 					var info1 = repoInfo.First();
 					var info2 = repoInfo.Last();
-					Assert.IsTrue(info1.RepoName == "repo1");
-					Assert.IsTrue(info2.RepoName == "repo3");
+					Assert.That(info1.RepoName, Is.EqualTo("repo1"));
+					Assert.That(info2.RepoName, Is.EqualTo("repo3"));
 				}
 			}
 		}
@@ -216,7 +216,7 @@ namespace ChorusHubTests
 				ChorusHubOptions.RootDirectory = chorusHubSourceFolder.Path;
 				using (var service = new ChorusHubServer())
 				{
-					Assert.IsTrue(service.Start(true));
+					Assert.That(service.Start(true), Is.True);
 
 					// Make sure filter works
 					var chorusHubServerInfo = ChorusHubServerInfo.FindServerInformation();

--- a/src/ChorusMerge.Tests/ChorusMergeTests.cs
+++ b/src/ChorusMerge.Tests/ChorusMergeTests.cs
@@ -30,10 +30,10 @@ namespace ChorusMerge.Tests
 		{
 			using (var group = new GroupOfConflictingLiftFiles())
 			{
-				Assert.AreEqual(0, DoMerge(group));
-				Assert.IsTrue(File.Exists(group.BobTextConflictsPath));
+				Assert.That(DoMerge(group), Is.EqualTo(0));
+				Assert.That(group.BobTextConflictsPath, Does.Exist);
 				var text = File.ReadAllText(group.BobTextConflictsPath);
-				Assert.AreNotEqual(string.Empty, text);
+				Assert.That(text, Is.Not.Empty);
 			}
 		}
 

--- a/src/LibChorus.TestUtilities/RepositorySetup.cs
+++ b/src/LibChorus.TestUtilities/RepositorySetup.cs
@@ -98,7 +98,7 @@ namespace LibChorus.TestUtilities
 		{
 			if (Repository != null)
 			{
-				Assert.IsFalse(Repository.GetHasLocks(), "A lock was left over, after the test.");
+				Assert.That(Repository.GetHasLocks(), Is.False, "A lock was left over, after the test.");
 			}
 			if (ProjectFolder != null)
 			{
@@ -199,17 +199,17 @@ namespace LibChorus.TestUtilities
 
 		public void AssertFileExistsRelativeToRoot(string relativePath)
 		{
-			Assert.IsTrue(File.Exists(RootFolder.Combine(relativePath)));
+			Assert.That(RootFolder.Combine(relativePath), Does.Exist);
 		}
 
 		public void AssertFileExistsInRepository(string pathRelativeToRepositoryRoot)
 		{
-			Assert.IsTrue(Repository.GetFileExistsInRepo(pathRelativeToRepositoryRoot));
+			Assert.That(Repository.GetFileExistsInRepo(pathRelativeToRepositoryRoot), Is.True);
 		}
 
 		public void AssertFileDoesNotExistInRepository(string pathRelativeToRepositoryRoot)
 		{
-			Assert.IsFalse(Repository.GetFileExistsInRepo(pathRelativeToRepositoryRoot));
+			Assert.That(Repository.GetFileExistsInRepo(pathRelativeToRepositoryRoot), Is.False);
 		}
 
 		public static void MakeRepositoryForTest(string newRepositoryPath, string userId, IProgress progress)
@@ -262,7 +262,7 @@ namespace LibChorus.TestUtilities
 
 		public void AssertFileExists(string relativePath)
 		{
-			Assert.IsTrue(File.Exists(ProjectFolder.Combine(relativePath)));
+			Assert.That(ProjectFolder.Combine(relativePath), Does.Exist);
 		}
 
 		public void AssertFileContents(string relativePath, string expectedContents)

--- a/src/LibChorus.TestUtilities/RepositoryWithFilesSetup.cs
+++ b/src/LibChorus.TestUtilities/RepositoryWithFilesSetup.cs
@@ -111,7 +111,7 @@ namespace LibChorus.TestUtilities
 		{
 			if (Repository != null)
 			{
-				Assert.IsFalse(Repository.GetHasLocks(), "A lock was left over, after the test.");
+				Assert.That(Repository.GetHasLocks(), Is.False, "A lock was left over, after the test.");
 			}
 
 			if (DoNotDispose)
@@ -214,8 +214,8 @@ namespace LibChorus.TestUtilities
 		public void AssertSingleConflictType<TConflict>()
 		{
 			string cmlFile = ChorusNotesMergeEventListener.GetChorusNotesFilePath(UserFile.Path);
-			Assert.IsTrue(File.Exists(cmlFile), "ChorusNotes file should have been in working set");
-			Assert.IsTrue(Synchronizer.Repository.GetFileIsInRepositoryFromFullPath(cmlFile), "ChorusNotes file should have been in repository");
+			Assert.That(cmlFile, Does.Exist, "ChorusNotes file should have been in working set");
+			Assert.That(Synchronizer.Repository.GetFileIsInRepositoryFromFullPath(cmlFile), Is.True, "ChorusNotes file should have been in repository");
 
 			XmlDocument doc = new XmlDocument();
 			doc.Load(cmlFile);
@@ -230,12 +230,12 @@ namespace LibChorus.TestUtilities
 
 		public void AssertNoErrorsReported()
 		{
-			Assert.IsFalse(ProgressString.ToLower().Contains("error"));
+			Assert.That(ProgressString, Does.Not.Contain("error").IgnoreCase);
 		}
 
 		public void AssertFileExists(string relativePath)
 		{
-			Assert.IsTrue(File.Exists(ProjectFolder.Combine(relativePath)));
+			Assert.That(ProjectFolder.Combine(relativePath), Does.Exist);
 		}
 
 		public void AssertFileContents(string relativePath, string expectedContents)

--- a/src/LibChorus.TestUtilities/XmlTestHelper.cs
+++ b/src/LibChorus.TestUtilities/XmlTestHelper.cs
@@ -69,7 +69,7 @@ namespace LibChorus.TestUtilities
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
-			Assert.IsNotNull(node);
+			Assert.That(node, Is.Not.Null);
 		}
 
 		public static void AssertXPathIsNull(string xml, string xpath)
@@ -88,7 +88,7 @@ namespace LibChorus.TestUtilities
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
-			Assert.IsNull(node);
+			Assert.That(node, Is.Null);
 		}
 
 		public static void AssertXPathMatchesExactlyOne(string xml, string xpath, Dictionary<string, string> namespaces)
@@ -137,7 +137,7 @@ namespace LibChorus.TestUtilities
 				doc.WriteContentTo(writer);
 				writer.Flush();
 			}
-			Assert.IsNull(node, "Unexpectedly found a match for: " + xpath);
+			Assert.That(node, Is.Null, "Unexpectedly found a match for: " + xpath);
 		}
 
 		public static string DoMerge(

--- a/src/LibChorusTests/FileHandlers/ChorusNotesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusNotesFileHandlerTests.cs
@@ -46,7 +46,7 @@ namespace LibChorus.Tests.FileHandlers
 		[Test]
 		public void CanValidate_IsFalse()
 		{
-			Assert.IsFalse(_chorusNotesFileHandler.CanValidateFile(null));
+			Assert.That(_chorusNotesFileHandler.CanValidateFile(null), Is.False);
 		}
 
 		[Test]
@@ -61,7 +61,7 @@ namespace LibChorus.Tests.FileHandlers
 			using (var tempFile = TempFile.WithExtension("." + AnnotationRepository.FileExtension))
 			{
 				File.WriteAllText(tempFile.Path, "<?xml version='1.0' encoding='utf-8'?>" + Environment.NewLine + "<notes />");
-				Assert.IsTrue(_chorusNotesFileHandler.CanMergeFile(tempFile.Path));
+				Assert.That(_chorusNotesFileHandler.CanMergeFile(tempFile.Path), Is.True);
 			}
 		}
 
@@ -262,9 +262,9 @@ namespace LibChorus.Tests.FileHandlers
 
 		private static void CheckResults(bool expectedToMatch, string source, string target)
 		{
-			Assert.IsTrue(target.Contains("524786f4-8e27-4ebf-b7ea-02846723c2d8"));
-			Assert.IsTrue(target.Contains("a0481907-3fff-45a2-bb1c-961c3198c86a"));
-			Assert.IsTrue(target.Contains("<![CDATA[<conflict"));
+			Assert.That(target, Does.Contain("524786f4-8e27-4ebf-b7ea-02846723c2d8"));
+			Assert.That(target, Does.Contain("a0481907-3fff-45a2-bb1c-961c3198c86a"));
+			Assert.That(target, Does.Contain("<![CDATA[<conflict"));
 			CompareResults(expectedToMatch, source, target);
 		}
 

--- a/src/LibChorusTests/FileHandlers/LargeFileIntegrationTestService.cs
+++ b/src/LibChorusTests/FileHandlers/LargeFileIntegrationTestService.cs
@@ -70,15 +70,15 @@ namespace LibChorus.Tests.FileHandlers
 					};
 
 				var syncResults = synchronizer.SyncNow(syncOptions);
-				Assert.IsTrue(syncResults.Succeeded);
+				Assert.That(syncResults.Succeeded, Is.True);
 
 				projectFolderConfiguration.ExcludePatterns.Remove(ProjectFolderConfiguration.BareFolderReadmeFileName);
-				Assert.AreEqual(2, projectFolderConfiguration.ExcludePatterns.Count);
-				Assert.IsTrue(projectFolderConfiguration.ExcludePatterns[0].Contains(whopperFileName));
+				Assert.That(projectFolderConfiguration.ExcludePatterns.Count, Is.EqualTo(2));
+				Assert.That(projectFolderConfiguration.ExcludePatterns[0], Does.Contain(whopperFileName));
 
 				var repo = new HgRepository(pathToTestRoot, progress);
-				Assert.IsTrue(repo.GetFileExistsInRepo(goodFileName), goodFileName);
-				Assert.IsFalse(repo.GetFileExistsInRepo(whopperFileName), whopperFileName);
+				Assert.That(repo.GetFileExistsInRepo(goodFileName), Is.True, goodFileName);
+				Assert.That(repo.GetFileExistsInRepo(whopperFileName), Is.False, whopperFileName);
 			}
 			finally
 			{

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileHandlerTests.cs
@@ -37,8 +37,8 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		public void HandlerOnlySupportsProjectLexiconSettingsExtension()
 		{
 			var extensions = _projectLexiconSettingsFileHandler.GetExtensionsOfKnownTextFileTypes();
-			Assert.IsTrue(extensions.Count() == 1);
-			Assert.AreEqual("plsx", extensions.First());
+			Assert.That(extensions.Count(), Is.EqualTo(1));
+			Assert.That(extensions.First(), Is.EqualTo("plsx"));
 		}
 
 		[Test]

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileMergeTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileMergeTests.cs
@@ -96,7 +96,7 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		[Test]
 		public void CannotMergeNonexistantFile()
 		{
-			Assert.IsFalse(_projectLexiconSettingsFileHandler.CanMergeFile("bogusPathname"));
+			Assert.That(_projectLexiconSettingsFileHandler.CanMergeFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
@@ -105,20 +105,20 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 			using (var tempFile = TempFile.WithExtension(".plsx"))
 			{
 				File.WriteAllText(tempFile.Path, "<?xml version='1.0' encoding='utf-8'?>" + Environment.NewLine + "<ProjectLexiconSettings />");
-				Assert.IsTrue(_projectLexiconSettingsFileHandler.CanMergeFile(tempFile.Path));
+				Assert.That(_projectLexiconSettingsFileHandler.CanMergeFile(tempFile.Path), Is.True);
 			}
 		}
 
 		[Test]
 		public void CannotMergeEmptyStringFile()
 		{
-			Assert.IsFalse(_projectLexiconSettingsFileHandler.CanMergeFile(String.Empty));
+			Assert.That(_projectLexiconSettingsFileHandler.CanMergeFile(String.Empty), Is.False);
 		}
 
 		[Test]
 		public void CannotMergeNullFile()
 		{
-			Assert.IsFalse(_projectLexiconSettingsFileHandler.CanMergeFile(null));
+			Assert.That(_projectLexiconSettingsFileHandler.CanMergeFile(null), Is.False);
 		}
 
 		[Test]
@@ -145,9 +145,9 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 			XmlMergeService.RemoveAmbiguousChildren(merger.EventListener, merger.MergeStrategies, badRootNode);
 			XmlMergeService.RemoveAmbiguousChildNodes = oldValue;
 			var childNodes = badRootNode.SelectNodes("WritingSystems");
-			Assert.IsNotNull(childNodes);
-			Assert.IsTrue(childNodes.Count == 1);
-			Assert.IsNull(childNodes[0].Attributes["goner"]);
+			Assert.That(childNodes, Is.Not.Null);
+			Assert.That(childNodes.Count, Is.EqualTo(1));
+			Assert.That(childNodes[0].Attributes["goner"], Is.Null);
 		}
 
 		[Test]

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileValidationTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/ProjectLexiconSettingsFileValidationTests.cs
@@ -64,61 +64,61 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		[Test]
 		public void Cannot_Validate_Nonexistant_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile("bogusPathname"));
+			Assert.That(_handler.CanValidateFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Null_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(null));
+			Assert.That(_handler.CanValidateFile(null), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Empty_String_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(String.Empty));
+			Assert.That(_handler.CanValidateFile(string.Empty), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Nonxml_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(_nonXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_nonXmlTempFile.Path), Is.False);
 		}
 
 		[Test]
 		public void Can_Validate_Fw_Xml_File()
 		{
-			Assert.IsTrue(_handler.CanValidateFile(_goodXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_goodXmlTempFile.Path), Is.True);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Empty_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile("", null));
+			Assert.That(_handler.ValidateFile("", null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Null_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(null, null));
+			Assert.That(_handler.ValidateFile(null, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Null_For_Good_File()
 		{
-			Assert.IsNull(_handler.ValidateFile(_goodXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlTempFile.Path, null), Is.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Crummy_ProjectLexiconSettings_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_illformedXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_illformedXmlTempFile.Path, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Good_But_Not_ProjectLexiconSettings_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_goodXmlButNotProjectLexiconSettingsTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlButNotProjectLexiconSettingsTempFile.Path, null), Is.Not.Null);
 		}
 	}
 }

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileHandlerTests.cs
@@ -37,7 +37,7 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		public void HandlerOnlySupportsUserLexiconSettingsExtension()
 		{
 			var extensions = _userLexiconSettingsFileHandler.GetExtensionsOfKnownTextFileTypes();
-			Assert.IsTrue(extensions.Count() == 1);
+			Assert.That(extensions.Count(), Is.EqualTo(1));
 			Assert.AreEqual("ulsx", extensions.First());
 		}
 

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileMergeTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileMergeTests.cs
@@ -96,7 +96,7 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		[Test]
 		public void CannotMergeNonexistantFile()
 		{
-			Assert.IsFalse(_userLexiconSettingsFileHandler.CanMergeFile("bogusPathname"));
+			Assert.That(_userLexiconSettingsFileHandler.CanMergeFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
@@ -105,20 +105,20 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 			using (var tempFile = TempFile.WithExtension(".ulsx"))
 			{
 				File.WriteAllText(tempFile.Path, "<?xml version='1.0' encoding='utf-8'?>" + Environment.NewLine + "<UserLexiconSettings />");
-				Assert.IsTrue(_userLexiconSettingsFileHandler.CanMergeFile(tempFile.Path));
+				Assert.That(_userLexiconSettingsFileHandler.CanMergeFile(tempFile.Path), Is.True);
 			}
 		}
 
 		[Test]
 		public void CannotMergeEmptyStringFile()
 		{
-			Assert.IsFalse(_userLexiconSettingsFileHandler.CanMergeFile(String.Empty));
+			Assert.That(_userLexiconSettingsFileHandler.CanMergeFile(String.Empty), Is.False);
 		}
 
 		[Test]
 		public void CannotMergeNullFile()
 		{
-			Assert.IsFalse(_userLexiconSettingsFileHandler.CanMergeFile(null));
+			Assert.That(_userLexiconSettingsFileHandler.CanMergeFile(null), Is.False);
 		}
 
 		[Test]
@@ -145,9 +145,9 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 			XmlMergeService.RemoveAmbiguousChildren(merger.EventListener, merger.MergeStrategies, badRootNode);
 			XmlMergeService.RemoveAmbiguousChildNodes = oldValue;
 			var childNodes = badRootNode.SelectNodes("WritingSystems");
-			Assert.IsNotNull(childNodes);
-			Assert.IsTrue(childNodes.Count == 1);
-			Assert.IsNull(childNodes[0].Attributes["goner"]);
+			Assert.That(childNodes, Is.Not.Null);
+			Assert.That(childNodes.Count, Is.EqualTo(1));
+			Assert.That(childNodes[0].Attributes["goner"], Is.Null);
 		}
 
 		[Test]

--- a/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileValidationTests.cs
+++ b/src/LibChorusTests/FileHandlers/LexiconSettings/UserLexiconSettingsFileValidationTests.cs
@@ -64,61 +64,61 @@ namespace LibChorus.Tests.FileHandlers.LexiconSettings
 		[Test]
 		public void Cannot_Validate_Nonexistant_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile("bogusPathname"));
+			Assert.That(_handler.CanValidateFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Null_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(null));
+			Assert.That(_handler.CanValidateFile(null), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Empty_String_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(String.Empty));
+			Assert.That(_handler.CanValidateFile(String.Empty), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Nonxml_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(_nonXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_nonXmlTempFile.Path), Is.False);
 		}
 
 		[Test]
 		public void Can_Validate_Fw_Xml_File()
 		{
-			Assert.IsTrue(_handler.CanValidateFile(_goodXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_goodXmlTempFile.Path), Is.True);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Empty_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile("", null));
+			Assert.That(_handler.ValidateFile("", null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Null_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(null, null));
+			Assert.That(_handler.ValidateFile(null, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Null_For_Good_File()
 		{
-			Assert.IsNull(_handler.ValidateFile(_goodXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlTempFile.Path, null), Is.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Crummy_ProjectLexiconSettings_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_illformedXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_illformedXmlTempFile.Path, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Good_But_Not_ProjectLexiconSettings_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_goodXmlButNotUserLexiconSettingsTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlButNotUserLexiconSettingsTempFile.Path, null), Is.Not.Null);
 		}
 	}
 }

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -54,13 +54,13 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		[Test]
 		public void CannotDiffAFile()
 		{
-			Assert.IsFalse(_liftRangesFileHandler.CanDiffFile(null));
+			Assert.That(_liftRangesFileHandler.CanDiffFile(null), Is.False);
 		}
 
 		[Test]
 		public void CannotValidateAFile()
 		{
-			Assert.IsFalse(_liftRangesFileHandler.CanValidateFile(null));
+			Assert.That(_liftRangesFileHandler.CanValidateFile(null), Is.False);
 		}
 
 		[Test]
@@ -69,20 +69,20 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			using (var tempFile = TempFile.WithExtension(".lift-ranges"))
 			{
 				File.WriteAllText(tempFile.Path, "<?xml version='1.0' encoding='utf-8'?>" + Environment.NewLine + "<lift-ranges />");
-				Assert.IsTrue(_liftRangesFileHandler.CanMergeFile(tempFile.Path));
+				Assert.That(_liftRangesFileHandler.CanMergeFile(tempFile.Path), Is.True);
 			}
 		}
 
 		[Test]
 		public void CannotPresentANullFile()
 		{
-			Assert.IsFalse(_liftRangesFileHandler.CanPresentFile(null));
+			Assert.That(_liftRangesFileHandler.CanPresentFile(null), Is.False);
 		}
 
 		[Test]
 		public void CannotPresentAnEmptyFileName()
 		{
-			Assert.IsFalse(_liftRangesFileHandler.CanPresentFile(""));
+			Assert.That(_liftRangesFileHandler.CanPresentFile(""), Is.False);
 		}
 
 		[Test]
@@ -90,7 +90,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		{
 			using (var tempFile = TempFile.WithExtension(".ClassData"))
 			{
-				Assert.IsFalse(_liftRangesFileHandler.CanPresentFile(tempFile.Path));
+				Assert.That(_liftRangesFileHandler.CanPresentFile(tempFile.Path), Is.False);
 			}
 		}
 
@@ -99,7 +99,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		{
 			using (var tempFile = TempFile.WithExtension(".ClassData"))
 			{
-				Assert.IsFalse(_liftRangesFileHandler.CanPresentFile(tempFile.Path));
+				Assert.That(_liftRangesFileHandler.CanPresentFile(tempFile.Path), Is.False);
 			}
 		}
 
@@ -119,7 +119,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 </lift-ranges>";
 			using (var tempFile = new TempFile(data))
 			{
-				Assert.IsNull(_liftRangesFileHandler.ValidateFile(tempFile.Path, new NullProgress()));
+				Assert.That(_liftRangesFileHandler.ValidateFile(tempFile.Path, new NullProgress()), Is.Null);
 			}
 		}
 

--- a/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
@@ -37,7 +37,7 @@ namespace LibChorus.Tests.FileHandlers.audio
 		public void HandlerSupportsCorrectExtensions()
 		{
 			var extensions = _audioFileHandler.GetExtensionsOfKnownTextFileTypes().ToList();
-			Assert.IsTrue(extensions.Count() == 8);
+			Assert.That(extensions.Count(), Is.EqualTo(8));
 			var expectedExtensions = new HashSet<string> {"wav", "snd", "au", "aif", "aifc", "aiff", "wma", "mp3"};
 			foreach (var expectedExtension in expectedExtensions)
 				Assert.Contains(expectedExtension, extensions);

--- a/src/LibChorusTests/FileHandlers/default/DefaultFileTypeHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/default/DefaultFileTypeHandlerTests.cs
@@ -35,7 +35,7 @@ namespace LibChorus.Tests.FileHandlers.Default
 		public void HandlerSupportsCorrectExtensions()
 		{
 			var extensions = _defaultFileHandler.GetExtensionsOfKnownTextFileTypes().ToList();
-			Assert.IsTrue(extensions.Count == 0);
+			Assert.That(extensions.Count, Is.EqualTo(0));
 		}
 
 		[Test]

--- a/src/LibChorusTests/FileHandlers/ldml/LdmlFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/ldml/LdmlFileHandlerTests.cs
@@ -37,7 +37,7 @@ namespace LibChorus.Tests.FileHandlers.ldml
 		public void HandlerOnlySupportsldmlExtension()
 		{
 			var extensions = _ldmlFileHandler.GetExtensionsOfKnownTextFileTypes();
-			Assert.IsTrue(extensions.Count() == 1);
+			Assert.That(extensions.Count(), Is.EqualTo(1));
 			Assert.AreEqual("ldml", extensions.First());
 		}
 

--- a/src/LibChorusTests/FileHandlers/ldml/LdmlFileMergeTests.cs
+++ b/src/LibChorusTests/FileHandlers/ldml/LdmlFileMergeTests.cs
@@ -42,13 +42,13 @@ namespace LibChorus.Tests.FileHandlers.ldml
 		[Test]
 		public void CannotMergeNonexistantFile()
 		{
-			Assert.IsFalse(_ldmlFileHandler.CanMergeFile("bogusPathname"));
+			Assert.That(_ldmlFileHandler.CanMergeFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
 		public void CannotMergeEmptyStringFile()
 		{
-			Assert.IsFalse(_ldmlFileHandler.CanMergeFile(String.Empty));
+			Assert.That(_ldmlFileHandler.CanMergeFile(String.Empty), Is.False);
 		}
 
 		[Test]
@@ -57,14 +57,14 @@ namespace LibChorus.Tests.FileHandlers.ldml
 			using (var tempFile = TempFile.WithExtension(".ldml"))
 			{
 				File.WriteAllText(tempFile.Path, "<?xml version='1.0' encoding='utf-8'?>" + Environment.NewLine + "<ldml />");
-				Assert.IsTrue(_ldmlFileHandler.CanMergeFile(tempFile.Path));
+				Assert.That(_ldmlFileHandler.CanMergeFile(tempFile.Path), Is.True);
 			}
 		}
 
 		[Test]
 		public void CannotMergeNullFile()
 		{
-			Assert.IsFalse(_ldmlFileHandler.CanMergeFile(null));
+			Assert.That(_ldmlFileHandler.CanMergeFile(null), Is.False);
 		}
 
 		[Test]
@@ -97,26 +97,26 @@ namespace LibChorus.Tests.FileHandlers.ldml
 			XmlMergeService.RemoveAmbiguousChildren(merger.EventListener, merger.MergeStrategies, badRootNode);
 			XmlMergeService.RemoveAmbiguousChildNodes = oldValue;
 			var childNodes = badRootNode.SelectNodes("special");
-			Assert.IsTrue(childNodes.Count == 4);
+			Assert.That(childNodes.Count, Is.EqualTo(4));
 			for (var idx = 0; idx < 4; ++idx)
 			{
 				XmlNode currentNode = childNodes[idx];
 				switch (idx)
 				{
 					case 0:
-						Assert.IsNotNull(currentNode.Attributes["xmlns:palaso"]);
+						Assert.That(currentNode.Attributes["xmlns:palaso"], Is.Not.Null);
 						break;
 					case 1:
-						Assert.IsNotNull(currentNode.Attributes["xmlns:palaso2"]);
+						Assert.That(currentNode.Attributes["xmlns:palaso2"], Is.Not.Null);
 						break;
 					case 2:
-						Assert.IsNotNull(currentNode.Attributes["xmlns:fw"]);
+						Assert.That(currentNode.Attributes["xmlns:fw"], Is.Not.Null);
 						break;
 					case 3:
-						Assert.IsNotNull(currentNode.Attributes["xmlns:sil"]);
+						Assert.That(currentNode.Attributes["xmlns:sil"], Is.Not.Null);
 						break;
 				}
-				Assert.IsNull(currentNode.Attributes["goner"]);
+				Assert.That(currentNode.Attributes["goner"], Is.Null);
 			}
 		}
 

--- a/src/LibChorusTests/FileHandlers/ldml/LdmlFileValidationTests.cs
+++ b/src/LibChorusTests/FileHandlers/ldml/LdmlFileValidationTests.cs
@@ -64,61 +64,61 @@ namespace LibChorus.Tests.FileHandlers.ldml
 		[Test]
 		public void Cannot_Validate_Nonexistant_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile("bogusPathname"));
+			Assert.That(_handler.CanValidateFile("bogusPathname"), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Null_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(null));
+			Assert.That(_handler.CanValidateFile(null), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Empty_String_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(String.Empty));
+			Assert.That(_handler.CanValidateFile(String.Empty), Is.False);
 		}
 
 		[Test]
 		public void Cannot_Validate_Nonxml_File()
 		{
-			Assert.IsFalse(_handler.CanValidateFile(_nonXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_nonXmlTempFile.Path), Is.False);
 		}
 
 		[Test]
 		public void Can_Validate_Fw_Xml_File()
 		{
-			Assert.IsTrue(_handler.CanValidateFile(_goodXmlTempFile.Path));
+			Assert.That(_handler.CanValidateFile(_goodXmlTempFile.Path), Is.True);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Empty_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile("", null));
+			Assert.That(_handler.ValidateFile("", null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Null_Pathname()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(null, null));
+			Assert.That(_handler.ValidateFile(null, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Null_For_Good_File()
 		{
-			Assert.IsNull(_handler.ValidateFile(_goodXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlTempFile.Path, null), Is.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Crummy_Ldml_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_illformedXmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_illformedXmlTempFile.Path, null), Is.Not.Null);
 		}
 
 		[Test]
 		public void ValidateFile_Returns_Message_For_Good_But_Not_Ldml_File()
 		{
-			Assert.IsNotNull(_handler.ValidateFile(_goodXmlButNotLdmlTempFile.Path, null));
+			Assert.That(_handler.ValidateFile(_goodXmlButNotLdmlTempFile.Path, null), Is.Not.Null);
 		}
 	}
 }

--- a/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
@@ -16,7 +16,7 @@ namespace LibChorus.Tests.Model
 				var model = new InternetCloneSettingsModel(testFolder.Path);
 				model.InitFromUri("http://john:myPassword@hg-languagedepot.org/tpi?localFolder=tokPisin");
 				Assert.AreEqual("tokPisin", model.LocalFolderName);
-				Assert.IsTrue(model.ReadyToDownload);
+				Assert.That(model.ReadyToDownload, Is.True);
 				Assert.AreEqual("http://john:myPassword@hg-languagedepot.org/tpi",model.URL);
 			}
 		}

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -81,7 +81,7 @@ namespace LibChorus.Tests.Model
 		{
 			var m = new ServerSettingsModel();
 			m.InitFromUri("http://joe:pass@hg-public.languagedepot.org/tpi");
-			Assert.IsFalse(m.CustomUrlSelected);
+			Assert.That(m.CustomUrlSelected, Is.False);
 		}
 
 		[Test]
@@ -97,7 +97,7 @@ namespace LibChorus.Tests.Model
 		{
 			var m = new ServerSettingsModel();
 			m.InitFromUri("http://somewhereelse.net/xyz");
-			Assert.IsTrue(m.CustomUrlSelected);
+			Assert.That(m.CustomUrlSelected, Is.True);
 		}
 
 		[Test]
@@ -105,7 +105,7 @@ namespace LibChorus.Tests.Model
 		{
 			var m = new ServerSettingsModel();
 			m.InitFromUri("\\mybox\tpi");
-			Assert.IsTrue(m.CustomUrlSelected);
+			Assert.That(m.CustomUrlSelected, Is.True);
 		}
 
 		[Test]
@@ -113,7 +113,7 @@ namespace LibChorus.Tests.Model
 		{
 			var m = new ServerSettingsModel();
 			m.InitFromUri("\\mybox\tpi");
-			Assert.IsTrue(m.SelectedServerLabel.ToLower().Contains("custom"));
+			Assert.That(m.SelectedServerLabel, Does.Contain("custom").IgnoreCase);
 		}
 
 		[Test]
@@ -126,8 +126,8 @@ namespace LibChorus.Tests.Model
 				m.InitFromProjectPath(folder.Path);
 				m.SetUrlToUseIfSettingsAreEmpty(url);
 				m.SaveSettings();
-				Assert.IsTrue(Directory.Exists(folder.Combine(".hg")));
-				Assert.IsTrue(File.Exists(folder.Combine(".hg","hgrc")));
+				Assert.That(folder.Combine(".hg"), Does.Exist);
+				Assert.That(folder.Combine(".hg","hgrc"), Does.Exist);
 				var repo = HgRepository.CreateOrUseExisting(folder.Path, new NullProgress());
 				var address = repo.GetDefaultNetworkAddress<HttpRepositoryPath>();
 				Assert.AreEqual("languageDepot.org[safemode]".ToLower(), address.Name.ToLower());
@@ -148,8 +148,8 @@ namespace LibChorus.Tests.Model
 				m.InitFromProjectPath(folder.Path);
 				m.Password = "newPassword";
 				m.SaveSettings();
-				Assert.IsTrue(Directory.Exists(folder.Combine(".hg")));
-				Assert.IsTrue(File.Exists(folder.Combine(".hg", "hgrc")));
+				Assert.That(folder.Combine(".hg"), Does.Exist);
+				Assert.That(folder.Combine(".hg", "hgrc"), Does.Exist);
 				var repo = HgRepository.CreateOrUseExisting(folder.Path, new NullProgress());
 				var address = repo.GetDefaultNetworkAddress<HttpRepositoryPath>();
 				Assert.AreEqual("http://joe:newPassword@hg-public.languagedepot.org/tpi", address.URI);

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgSettingsTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgSettingsTests.cs
@@ -104,7 +104,7 @@ two = http://foo.com");
 		{
 			using (new MercurialIniForTests())
 			{
-				Assert.IsFalse(GetIsReady(@""));
+				Assert.That(GetIsReady(@""), Is.False);
 			}
 		}
 
@@ -113,7 +113,7 @@ two = http://foo.com");
 		{
 			using (new MercurialIniForTests())
 			{
-				Assert.IsFalse(GetIsReady(@"LanguageDepot = http://hg-public.languagedepot.org/xyz"));
+				Assert.That(GetIsReady(@"LanguageDepot = http://hg-public.languagedepot.org/xyz"), Is.False);
 			}
 		}
 
@@ -122,7 +122,7 @@ two = http://foo.com");
 		{
 			using (new MercurialIniForTests())
 			{
-				Assert.IsTrue(GetIsReady(@"LanguageDepot = http://joe_user:xyz@hg-public.languagedepot.org/xyz"));
+				Assert.That(GetIsReady(@"LanguageDepot = http://joe_user:xyz@hg-public.languagedepot.org/xyz"), Is.True);
 			}
 		}
 
@@ -312,7 +312,7 @@ username = Joe Schmoe
 
 		private void AssertHgrcNowContainsUri(HgRepository repository, string uri)
 		{
-			Assert.IsNotNull(repository.GetRepositoryPathsInHgrc().FirstOrDefault(a=>a.URI == uri));
+			Assert.That(repository.GetRepositoryPathsInHgrc().FirstOrDefault(a=>a.URI == uri), Is.Not.Null);
 		}
 
 		[Test]

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgVersionBranchingTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgVersionBranchingTests.cs
@@ -93,7 +93,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				bool result = branchingHelper.IsLatestBranchDifferent(myVersion, out revNum);
 
 				// Verification
-				Assert.IsTrue(result, "The only branch should be default.");
+				Assert.That(result, Is.True, "The only branch should be default.");
 				var revision = repoWithFiles.Repository.GetRevision(revNum);
 				Assert.AreEqual(newBranchName, revision.Branch, "Wrong branch name in new branch.");
 				var revisions = repoWithFiles.Repository.GetAllRevisions();
@@ -123,7 +123,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				bool result = branchingHelper.IsLatestBranchDifferent(myVersion, out revNum);
 
 				// Verification
-				Assert.IsFalse(result, "The only branch should be default.");
+				Assert.That(result, Is.False, "The only branch should be default.");
 			}
 		}
 

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgWrappingTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgWrappingTests.cs
@@ -49,7 +49,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		{
 			using (var setup = new HgTestSetup())
 			{
-				Assert.IsTrue(setup.Repository.RemoveOldLocks());
+				Assert.That(setup.Repository.RemoveOldLocks(), Is.True);
 			}
 		}
 
@@ -59,8 +59,8 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			using (var setup = new HgTestSetup())
 			{
 				var file = TempFileFromFolder.CreateAt(setup.Root.Combine(".hg", "wlock"), "blah");
-				Assert.IsTrue(setup.Repository.RemoveOldLocks());
-				Assert.IsFalse(File.Exists(file.Path));
+				Assert.That(setup.Repository.RemoveOldLocks(), Is.True);
+				Assert.That(File.Exists(file.Path), Is.False);
 			}
 		}
 
@@ -71,9 +71,9 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			{
 				var file1 = TempFileFromFolder.CreateAt(setup.Root.Combine(".hg", "wlock"), "blah");
 				var file2 = TempFileFromFolder.CreateAt(setup.Root.Combine(".hg", "store", "lock"), "blah");
-				Assert.IsTrue(setup.Repository.RemoveOldLocks());
-				Assert.IsFalse(File.Exists(file1.Path));
-				Assert.IsFalse(File.Exists(file2.Path));
+				Assert.That(setup.Repository.RemoveOldLocks(), Is.True);
+				Assert.That(File.Exists(file1.Path), Is.False);
+				Assert.That(File.Exists(file2.Path), Is.False);
 			}
 		}
 
@@ -87,7 +87,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 
 				using(var file = TempFileFromFolder.CreateAt(setup.Root.Combine(".hg", "wlock"), "blah"))
 				{
-					Assert.IsFalse(setup.Repository.RemoveOldLocks(ourName, true));
+					Assert.That(setup.Repository.RemoveOldLocks(ourName, true), Is.False);
 				}
 			}
 		}
@@ -102,7 +102,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 
 				using(var file = TempFileFromFolder.CreateAt(setup.Root.Combine(".hg", "store", "lock"), "blah"))
 				{
-					Assert.IsFalse(setup.Repository.RemoveOldLocks(ourName, true));
+					Assert.That(setup.Repository.RemoveOldLocks(ourName, true), Is.False);
 				}
 			}
 		}
@@ -141,7 +141,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				HgRepository.CreateRepositoryInExistingDir(testRoot.Path, _progress);
 				var repo = new HgRepository(testRoot.Path, new NullProgress());
 				var rev = repo.GetRevisionWorkingSetIsBasedOn();
-				Assert.IsNull(rev);
+				Assert.That(rev, Is.Null);
 			}
 		}
 
@@ -228,7 +228,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		{
 			using (var setup = new RepositorySetup("Dan"))
 			{
-				Assert.IsNull(setup.Repository.GetRevision("1"));
+				Assert.That(setup.Repository.GetRevision("1"), Is.Null);
 			}
 		}
 
@@ -238,7 +238,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			using (var setup = new RepositorySetup("Dan"))
 			{
 				var id = setup.Repository.Identifier;
-				Assert.IsTrue(String.IsNullOrEmpty(id));
+				Assert.That(id, Is.Null.Or.Empty);
 
 				var path = setup.ProjectFolder.Combine("test.1w1");
 				File.WriteAllText(path, "hello");
@@ -248,7 +248,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				setup.AddAndCheckIn(); // Need to have one commit.
 
 				id = setup.Repository.Identifier;
-				Assert.IsFalse(String.IsNullOrEmpty(id));
+				Assert.That(id, Is.Not.Null.And.Not.Empty);
 
 				var results = HgRunner.Run("log -r0 --template " + "\"{node}\"", setup.Repository.PathToRepo, 10, setup.Progress);
 				// This will probably fail, if some other version of Hg is used,
@@ -264,7 +264,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			using (var setup = new RepositorySetup("Dan"))
 			{
 				setup.AddAndCheckinFile("test.txt", "hello");
-				Assert.IsNotNull(setup.Repository.GetRevision("0"));
+				Assert.That(setup.Repository.GetRevision("0"), Is.Not.Null);
 			}
 		}
 
@@ -457,7 +457,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 //            var progress = new StringBuilderProgress();
 //            var hg = new HgRepository(Path.GetTempPath(), progress);
 //            hg.GetTip();
-//            Assert.IsTrue(progress.Text.Contains("Error"));
+//            Assert.That(progress.Text, Does.Contain("Error"));
 //        }
 
 

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HistoryTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HistoryTests.cs
@@ -80,7 +80,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		{
 			using (var setup = new RepositorySetup("Dan"))
 			{
-				Assert.IsNull(setup.Repository.GetTip());
+				Assert.That(setup.Repository.GetTip(), Is.Null);
 			}
 		}
 

--- a/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
@@ -156,7 +156,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				HgHighLevel.MakeCloneFromLocalToUsb(repo.ProjectFolder.Path, f.Path, new NullProgress());
 				var cloneRepo = new HgRepository(f.Path, new NullProgress());
 				var hgFolderPath = Path.Combine(f.Path, ".hg");
-				Assert.IsTrue(Directory.Exists(hgFolderPath));
+				Assert.That(hgFolderPath, Does.Exist);
 				var hgrcLines = File.ReadAllLines(Path.Combine(hgFolderPath, "hgrc"));
 				//SUT
 				CollectionAssert.DoesNotContain(hgrcLines, "[extensions]", "extensions section created in bare clone");

--- a/src/LibChorusTests/VcsDrivers/Mercurial/Utf8Tests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/Utf8Tests.cs
@@ -91,7 +91,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				//setup.ProjectFolderConfig.IncludePatterns.Add("*.wav");
 				//setup.AddAndCheckIn();
 				//setup.AssertFileDoesNotExistInRepository(utf8FilePath);
-				//Assert.IsTrue(setup.GetProgressString().Contains("Failed to set up extensions"));
+				//Assert.That(setup.GetProgressString(), Does.Contain("Failed to set up extensions"));
 			}
 		}
 
@@ -140,8 +140,6 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 					other.AssertFileExists(utf8FilePath);
 					string[] fileNames = Directory.GetFiles(other.ProjectFolder.Path, "*.wav");
 					Assert.AreEqual(1, fileNames.Length);
-
-					//Assert.IsTrue(setup.GetProgressString().Contains());
 				}
 
 			}
@@ -169,8 +167,6 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 					other.AssertFileExists(utf8FilePath);
 					string[] fileNames = Directory.GetFiles(other.ProjectFolder.Path, "*.wav");
 					Assert.AreEqual(1, fileNames.Length);
-
-					//Assert.IsTrue(setup.GetProgressString().Contains());
 				}
 
 			}

--- a/src/LibChorusTests/VcsDrivers/RepositoryAddressTests.cs
+++ b/src/LibChorusTests/VcsDrivers/RepositoryAddressTests.cs
@@ -51,16 +51,16 @@ namespace LibChorus.Tests.VcsDrivers
 					null, null, new object[] { repoInfo, projectName });
 		}
 
-		[Test]
-		public void TestIsMatchingName()
+		[TestCase("1", ExpectedResult = true)]
+		[TestCase("2", ExpectedResult = true)]
+		[TestCase("3", ExpectedResult = true)]
+		[TestCase("54", ExpectedResult = true)]
+		[TestCase("NaN", ExpectedResult = false)]
+		public bool TestIsMatchingName(string num)
 		{
-			string name = "RepoName";
-			string id = "RepoID";
-			foreach (string num in new List<string> {"1", "2", "3", "54"})
-			{
-				Assert.IsTrue(InvokeIsMatchingName(new RepositoryInformation(name + num, id), name));
-			}
-			Assert.IsFalse(InvokeIsMatchingName(new RepositoryInformation(name + "NaN", id), name));
+			const string name = "RepoName";
+			const string id = "RepoID";
+			return InvokeIsMatchingName(new RepositoryInformation(name + num, id), name);
 		}
 
 		// Allows us to access and test the private method
@@ -83,32 +83,27 @@ namespace LibChorus.Tests.VcsDrivers
 			string matchName, warningMessage;
 
 			// Case 1: Repo name and ID both match
-			Assert.IsTrue(InvokeTryGetBestRepoMatch(
-				_normalRepo.RepoID, _normalRepo.RepoName, out matchName, out warningMessage));
+			Assert.That(InvokeTryGetBestRepoMatch(_normalRepo.RepoID, _normalRepo.RepoName, out matchName, out warningMessage), Is.True);
 			Assert.AreEqual(_normalRepo.RepoName, matchName);
-			Assert.IsNull(warningMessage);
+			Assert.That(warningMessage, Is.Null);
 
 			// Case 2: Repo ID matches, but name does not
-			Assert.IsTrue(InvokeTryGetBestRepoMatch(
-				_normalRepo.RepoID, "DifferentProjectName", out matchName, out warningMessage));
+			Assert.That(InvokeTryGetBestRepoMatch(_normalRepo.RepoID, "DifferentProjectName", out matchName, out warningMessage), Is.True);
 			Assert.AreEqual(_normalRepo.RepoName, matchName);
-			Assert.IsNull(warningMessage);
+			Assert.That(warningMessage, Is.Null);
 
 			// Case 3: There is a new repo with the correct name
-			Assert.IsTrue(InvokeTryGetBestRepoMatch(
-				"AnyIDWillDo", _newRepo.RepoName, out matchName, out warningMessage));
+			Assert.That(InvokeTryGetBestRepoMatch("AnyIDWillDo", _newRepo.RepoName, out matchName, out warningMessage), Is.True);
 			Assert.AreEqual(_newRepo.RepoName, matchName);
-			Assert.IsNull(warningMessage);
+			Assert.That(warningMessage, Is.Null);
 
 			// Case 4: There is a new repo with a properly-derived name
-			Assert.IsTrue(InvokeTryGetBestRepoMatch(
-				"AnyIDWillDo", _duplicateRepo.RepoName, out matchName, out warningMessage));
+			Assert.That(InvokeTryGetBestRepoMatch("AnyIDWillDo", _duplicateRepo.RepoName, out matchName, out warningMessage), Is.True);
 			Assert.AreEqual(_newRepo.RepoName, matchName);
 			Assert.That(warningMessage, Is.Not.Null.Or.Empty);
 
 			// Case 5: There is no matching repo
-			Assert.IsFalse(InvokeTryGetBestRepoMatch(
-				"DoesNotExist", "DoesNotExist", out matchName, out warningMessage));
+			Assert.That(InvokeTryGetBestRepoMatch("DoesNotExist", "DoesNotExist", out matchName, out warningMessage), Is.False);
 			Assert.That(warningMessage, Is.Not.Null.Or.Empty);
 		}
 

--- a/src/LibChorusTests/merge/XmlLogMergeEventListenerTests.cs
+++ b/src/LibChorusTests/merge/XmlLogMergeEventListenerTests.cs
@@ -94,7 +94,7 @@ namespace LibChorus.Tests.merge
 			using (ChorusNotesMergeEventListener log = new ChorusNotesMergeEventListener(tempFile))
 			{
 			}
-			Assert.IsFalse(File.Exists(tempFile));
+			Assert.That(tempFile, Does.Not.Exist);
 		}
 
 	}

--- a/src/LibChorusTests/merge/xml/FindByKeyAttributeTests.cs
+++ b/src/LibChorusTests/merge/xml/FindByKeyAttributeTests.cs
@@ -59,7 +59,7 @@ namespace LibChorus.Tests.merge.xml
 
 			var finder = new FindByKeyAttribute("id");
 			var node = doc1.SelectSingleNode("//b");
-			Assert.IsNull(finder.GetNodeToMerge(node, doc1.DocumentElement, SetFromChildren.Get(doc1.DocumentElement)));
+			Assert.That(finder.GetNodeToMerge(node, doc1.DocumentElement, SetFromChildren.Get(doc1.DocumentElement)), Is.Null);
 		}
 
 		[Test]

--- a/src/LibChorusTests/merge/xml/generic/ConflictIOTest.cs
+++ b/src/LibChorusTests/merge/xml/generic/ConflictIOTest.cs
@@ -140,7 +140,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			var conflict2 = Conflict.CreateFromConflictElement(node2);
 
 			//verify
-			Assert.IsFalse(ReferenceEquals(conflict1, conflict2), "Two different conflicts of the same type but different istances.");
+			Assert.That(ReferenceEquals(conflict1, conflict2), Is.False, "Two different conflicts of the same type but different istances.");
 			Assert.AreNotEqual(conflict1.Guid, conflict2.Guid);
 		}
 	}

--- a/src/LibChorusTests/merge/xml/generic/ConflictTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/ConflictTests.cs
@@ -10,12 +10,12 @@ namespace LibChorus.Tests.merge.xml.generic
 		public void EnsureConflictClassHasContext()
 		{
 			var randomConflict = new MergeWarning(string.Empty);
-			Assert.IsNotNull(randomConflict.Context);
+			Assert.That(randomConflict.Context, Is.Not.Null);
 			Assert.IsInstanceOf<NullContextDescriptor>(randomConflict.Context);
 
 			// Try to set it to null.
 			randomConflict.Context = null;
-			Assert.IsNotNull(randomConflict.Context);
+			Assert.That(randomConflict.Context, Is.Not.Null);
 			Assert.IsInstanceOf<NullContextDescriptor>(randomConflict.Context);
 		}
 	}

--- a/src/LibChorusTests/merge/xml/generic/ElementStrategyTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/ElementStrategyTests.cs
@@ -15,13 +15,13 @@ namespace LibChorus.Tests.merge.xml.generic
 		[Test]
 		public void DefaultIsImmutable_Is_False()
 		{
-			Assert.IsFalse(new ElementStrategy(false).IsImmutable);
+			Assert.That(new ElementStrategy(false).IsImmutable, Is.False);
 		}
 
 		[Test]
 		public void DefaultIsAtomic_Is_False()
 		{
-			Assert.IsFalse(new ElementStrategy(false).IsAtomic);
+			Assert.That(new ElementStrategy(false).IsAtomic, Is.False);
 		}
 
 		[Test]

--- a/src/LibChorusTests/merge/xml/generic/ImmutableElementMergeServiceTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/ImmutableElementMergeServiceTests.cs
@@ -18,7 +18,7 @@ namespace LibChorus.Tests.merge.xml.generic
 		{
 			XmlNode ours;
 			XmlNode theirs;
-			Assert.IsNull(DoMerge(null, null, null, new NullMergeSituation(), new ListenerForUnitTests(), out ours, out theirs));
+			Assert.That(DoMerge(null, null, null, new NullMergeSituation(), new ListenerForUnitTests(), out ours, out theirs), Is.Null);
 		}
 
 		[Test]
@@ -28,7 +28,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge(null, null, "<NewImmutableElemment />", new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<NewImmutableElemment />", resultNode.OuterXml);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlAdditionChangeReport>();
@@ -45,7 +45,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge(null, "<NewImmutableElemment />", null, new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<NewImmutableElemment />", resultNode.OuterXml);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlAdditionChangeReport>();
@@ -61,7 +61,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge(null, "<NewImmutableElemment />", "<NewImmutableElemment />", new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<NewImmutableElemment />", resultNode.OuterXml);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlBothAddedSameChangeReport>();
@@ -77,7 +77,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge(null, "<MyNewImmutableElemment />", "<TheirNewImmutableElemment />", new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<MyNewImmutableElemment />", resultNode.OuterXml);
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -93,7 +93,7 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge(null, "<MyNewImmutableElemment />", "<TheirNewImmutableElemment />", new NullMergeSituationTheyWin(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<TheirNewImmutableElemment />", resultNode.OuterXml);
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -110,9 +110,9 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge("<OriginalImmutableElemment />", null, null, new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNull(resultNode);
-			Assert.IsNull(ours);
-			Assert.IsNull(theirs);
+			Assert.That(resultNode, Is.Null);
+			Assert.That(ours, Is.Null);
+			Assert.That(theirs, Is.Null);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlBothDeletionChangeReport>();
 			listener.AssertExpectedConflictCount(0);
@@ -125,9 +125,9 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge("<OriginalImmutableElemment />", null, "<TheirImmutableElemment />", new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNull(resultNode);
-			Assert.IsNull(ours);
-			Assert.IsNotNull(theirs);
+			Assert.That(resultNode, Is.Null);
+			Assert.That(ours, Is.Null);
+			Assert.That(theirs, Is.Not.Null);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlDeletionChangeReport>();
 			listener.AssertExpectedConflictCount(0);
@@ -140,9 +140,9 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge("<OriginalImmutableElemment />", "<OurImmutableElemment />", null, new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNull(resultNode);
-			Assert.IsNull(ours);
-			Assert.IsNull(theirs);
+			Assert.That(resultNode, Is.Null);
+			Assert.That(ours, Is.Null);
+			Assert.That(theirs, Is.Null);
 			listener.AssertExpectedChangesCount(1);
 			listener.AssertFirstChangeType<XmlDeletionChangeReport>();
 			listener.AssertExpectedConflictCount(0);
@@ -155,10 +155,10 @@ namespace LibChorus.Tests.merge.xml.generic
 			XmlNode ours;
 			XmlNode theirs;
 			var resultNode = DoMerge("<OriginalImmutableElemment />", "<OurImmutableElemment />", "<TheirImmutableElemment />", new NullMergeSituation(), listener, out ours, out theirs);
-			Assert.IsNotNull(resultNode);
+			Assert.That(resultNode, Is.Not.Null);
 			Assert.AreEqual("<OriginalImmutableElemment />", resultNode.OuterXml);
-			Assert.IsNotNull(ours);
-			Assert.IsNotNull(theirs);
+			Assert.That(ours, Is.Not.Null);
+			Assert.That(theirs, Is.Not.Null);
 			Assert.AreSame(resultNode, ours);
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(0);

--- a/src/LibChorusTests/merge/xml/generic/MergeAtomicElementServiceTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/MergeAtomicElementServiceTests.cs
@@ -151,7 +151,7 @@ namespace LibChorus.Tests.merge.xml.generic
 		public void DefaultIsFalse()
 		{
 			var elementStrategy = new ElementStrategy(false);
-			Assert.IsFalse(elementStrategy.IsAtomic);
+			Assert.That(elementStrategy.IsAtomic, Is.False);
 		}
 
 		[Test]
@@ -161,7 +161,7 @@ namespace LibChorus.Tests.merge.xml.generic
 				{
 					IsAtomic = true
 				};
-			Assert.IsTrue(elementStrategy.IsAtomic);
+			Assert.That(elementStrategy.IsAtomic, Is.True);
 		}
 
 		[Test]

--- a/src/LibChorusTests/merge/xml/generic/XmlMergerTests.cs
+++ b/src/LibChorusTests/merge/xml/generic/XmlMergerTests.cs
@@ -591,7 +591,7 @@ namespace LibChorus.Tests.merge.xml.generic
 								</b>
 							</a>";
 
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(red, blue));
+			Assert.That(XmlUtilities.AreXmlElementsEqual(red, blue), Is.False);
 
 			CheckBothWaysNoConflicts(red, blue, ancestor,
 									 "a/b[@key='one']/c[text()='first']");
@@ -1369,7 +1369,7 @@ namespace LibChorus.Tests.merge.xml.generic
 						EventListener = listener
 					};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlBothAddedSameChangeReport>();
 				listener.AssertExpectedConflictCount(0);
@@ -1395,7 +1395,7 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlAdditionChangeReport>();
 				listener.AssertExpectedConflictCount(0);
@@ -1421,7 +1421,7 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlAdditionChangeReport>();
 				listener.AssertExpectedConflictCount(0);
@@ -1447,11 +1447,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(0);
 				listener.AssertExpectedConflictCount(1);
 				listener.AssertFirstConflictType<BothAddedMainElementButWithDifferentContentConflict>();
-				Assert.IsTrue(result.MergedNode.OuterXml.Contains("our addition"));
+				Assert.That(result.MergedNode.OuterXml, Does.Contain("our addition"));
 			}
 		}
 
@@ -1474,11 +1474,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(0);
 				listener.AssertExpectedConflictCount(1);
 				listener.AssertFirstConflictType<BothAddedMainElementButWithDifferentContentConflict>();
-				Assert.IsTrue(result.MergedNode.OuterXml.Contains("their addition"));
+				Assert.That(result.MergedNode.OuterXml, Does.Contain("their addition"));
 			}
 		}
 
@@ -1501,11 +1501,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlBothDeletionChangeReport>();
 				listener.AssertExpectedConflictCount(0);
-				Assert.IsNull(result.MergedNode);
+				Assert.That(result.MergedNode, Is.Null);
 			}
 		}
 
@@ -1528,11 +1528,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlDeletionChangeReport>();
 				listener.AssertExpectedConflictCount(0);
-				Assert.IsNull(result.MergedNode);
+				Assert.That(result.MergedNode, Is.Null);
 			}
 		}
 
@@ -1555,11 +1555,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(0);
 				listener.AssertExpectedConflictCount(1);
 				listener.AssertFirstConflictType<RemovedVsEditedElementConflict>();
-				Assert.IsTrue(result.MergedNode.OuterXml.Contains("their change"));
+				Assert.That(result.MergedNode.OuterXml, Does.Contain("their change"));
 			}
 		}
 
@@ -1582,11 +1582,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(1);
 				listener.AssertFirstChangeType<XmlDeletionChangeReport>();
 				listener.AssertExpectedConflictCount(0);
-				Assert.IsNull(result.MergedNode);
+				Assert.That(result.MergedNode, Is.Null);
 			}
 		}
 
@@ -1609,11 +1609,11 @@ namespace LibChorus.Tests.merge.xml.generic
 					EventListener = listener
 				};
 				var result = merger.MergeFiles(ours.Path, theirs.Path, ancestor.Path);
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 				listener.AssertExpectedChangesCount(0);
 				listener.AssertExpectedConflictCount(1);
 				listener.AssertFirstConflictType<EditedVsRemovedElementConflict>();
-				Assert.IsTrue(result.MergedNode.OuterXml.Contains("our change"));
+				Assert.That(result.MergedNode.OuterXml, Does.Contain("our change"));
 			}
 		}
 	}

--- a/src/LibChorusTests/merge/xml/lift/FileLevelMergeTests.cs
+++ b/src/LibChorusTests/merge/xml/lift/FileLevelMergeTests.cs
@@ -95,7 +95,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 		}
 
@@ -499,7 +499,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -570,7 +570,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -640,7 +640,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -709,7 +709,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedChangesCount(0);
 			listener.AssertExpectedConflictCount(1);
@@ -772,7 +772,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedConflictCount(0);
 			listener.AssertExpectedChangesCount(0);
@@ -834,7 +834,7 @@ namespace LibChorus.Tests.merge.xml.lift
 					"header",
 					"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.ToLower().Contains("utf-8"));
+				Assert.That(result, Does.Contain("utf-8").IgnoreCase);
 			}
 			listener.AssertExpectedConflictCount(0);
 			listener.AssertExpectedChangesCount(0);
@@ -894,9 +894,9 @@ namespace LibChorus.Tests.merge.xml.lift
 					"entry",
 					"guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.Contains("<header>"));
-				Assert.IsTrue(result.Contains("<description>"));
-				Assert.IsTrue(result.Contains("<ranges>"));
+				Assert.That(result, Does.Contain("<header>"));
+				Assert.That(result, Does.Contain("<description>"));
+				Assert.That(result, Does.Contain("<ranges>"));
 				listener.AssertExpectedChangesCount(2);
 			}
 		}
@@ -929,7 +929,7 @@ namespace LibChorus.Tests.merge.xml.lift
 											"header",
 											"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.Contains("form alpha"));
+				Assert.That(result, Does.Contain("form alpha"));
 				listener.AssertExpectedChangesCount(0);
 			}
 		}
@@ -962,7 +962,7 @@ namespace LibChorus.Tests.merge.xml.lift
 											"header",
 											"entry", "guid");
 				var result = File.ReadAllText(mergeOrder.pathToOurs);
-				Assert.IsTrue(result.Contains("form beta"));
+				Assert.That(result, Does.Contain("form beta"));
 				listener.AssertExpectedChangesCount(0);
 			}
 		}

--- a/src/LibChorusTests/merge/xml/lift/MultiTextMergingTests.cs
+++ b/src/LibChorusTests/merge/xml/lift/MultiTextMergingTests.cs
@@ -32,8 +32,8 @@ namespace LiftIO.Tests.Merging
 			XmlMergeService.RemoveAmbiguousChildNodes = true;
 			var result = XmlMergeService.RemoveAmbiguousChildren(new ListenerForUnitTests(), new MergeStrategies(), data, "some.lift");
 			XmlMergeService.RemoveAmbiguousChildNodes = originalValue;
-			Assert.IsFalse(result.Contains("<element name=\"text\">first</element>"), "Still has bogus <element> element.");
-			Assert.IsTrue(result.Contains("<text>myStuff</text>"), "Converted <text> element is not present.");
+			Assert.That(result, Does.Not.Contain("<element name=\"text\">first</element>"), "Still has bogus <element> element.");
+			Assert.That(result, Does.Contain("<text>myStuff</text>"), "Converted <text> element is not present.");
 		}
 
 		[Test]
@@ -55,8 +55,8 @@ namespace LiftIO.Tests.Merging
 			doc.LoadXml(data);
 			var results = XmlMergeService.RemoveAmbiguousChildren(new ListenerForUnitTests(), new MergeStrategies(), data, "some.lift-ranges");
 			XmlMergeService.RemoveAmbiguousChildNodes = originalValue;
-			Assert.IsFalse(results.Contains("<element name=\"text\">first</element>"), "Still has bogus <element> element.");
-			Assert.IsTrue(results.Contains("<text>myStuff</text>"), "Converted <text> element is not present.");
+			Assert.That(results, Does.Not.Contain("<element name=\"text\">first</element>"), "Still has bogus <element> element.");
+			Assert.That(results, Does.Contain("<text>myStuff</text>"), "Converted <text> element is not present.");
 		}
 
 		[Test]
@@ -81,8 +81,8 @@ namespace LiftIO.Tests.Merging
 			doc.LoadXml(data);
 			XmlMergeService.RemoveAmbiguousChildren(new ListenerForUnitTests(), new MergeStrategies(), doc.DocumentElement);
 			XmlMergeService.RemoveAmbiguousChildNodes = originalValue;
-			Assert.IsFalse(doc.DocumentElement.OuterXml.Contains("<text>myStuff</text>"), "Converted <element> element to <text>, but should not have.");
-			Assert.IsTrue(doc.DocumentElement.OuterXml.Contains("<element name=\"text\">myStuff</element>"), "Element <element> went away, but should have been present.");
+			Assert.That(doc.DocumentElement.OuterXml, Does.Not.Contain("<text>myStuff</text>"), "Converted <element> element to <text>, but should not have.");
+			Assert.That(doc.DocumentElement.OuterXml, Does.Contain("<element name=\"text\">myStuff</element>"), "Element <element> went away, but should have been present.");
 		}
 /*
 		[Test]
@@ -188,7 +188,7 @@ namespace LiftIO.Tests.Merging
 								</form>
 							</lexical-unit>";
 
-			Assert.IsFalse(Utilities.AreXmlElementsEqual(red, blue));
+			Assert.That(Utilities.AreXmlElementsEqual(red, blue), Is.False);
 
 			CheckBothWays(red, blue, ancestor,
 				"lexical-unit/form[@lang='one']/text[text()='first']");

--- a/src/LibChorusTests/merge/xml/lift/ValidationTests.cs
+++ b/src/LibChorusTests/merge/xml/lift/ValidationTests.cs
@@ -12,11 +12,11 @@ namespace LibChorus.Tests.merge.xml.lift
 		public void CanValidateFile_AcceptsCorrectSet()
 		{
 			var handler = new LiftFileHandler();
-			Assert.IsTrue(handler.CanValidateFile("foo.lift"));
-			Assert.IsTrue(handler.CanValidateFile("foo.LiFt"));
-			Assert.IsFalse(handler.CanValidateFile("foo.WeSayConfig"));
-			Assert.IsFalse(handler.CanValidateFile("foo.xml"));
-			Assert.IsFalse(handler.CanValidateFile("foo.abc"));
+			Assert.That(handler.CanValidateFile("foo.lift"), Is.True);
+			Assert.That(handler.CanValidateFile("foo.LiFt"), Is.True);
+			Assert.That(handler.CanValidateFile("foo.WeSayConfig"), Is.False);
+			Assert.That(handler.CanValidateFile("foo.xml"), Is.False);
+			Assert.That(handler.CanValidateFile("foo.abc"), Is.False);
 		}
 
 		[Test]
@@ -26,7 +26,7 @@ namespace LibChorus.Tests.merge.xml.lift
 			using(var file = new TempFile("<lift/>"))
 			{
 				var result = handler.ValidateFile(file.Path, new ConsoleProgress());
-				Assert.IsNull(result);
+				Assert.That(result, Is.Null);
 			}
 		}
 
@@ -37,7 +37,7 @@ namespace LibChorus.Tests.merge.xml.lift
 			using (var file = new TempFile("<lift>"))
 			{
 				var result = handler.ValidateFile(file.Path, new ConsoleProgress());
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 			}
 		}
 
@@ -48,7 +48,7 @@ namespace LibChorus.Tests.merge.xml.lift
 			using (var file = new TempFile("<lift><foo/></lift>"))
 			{
 				var result = handler.ValidateFile(file.Path, new ConsoleProgress());
-				Assert.IsNotNull(result);
+				Assert.That(result, Is.Not.Null);
 			}
 		}
 	}

--- a/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
+++ b/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
@@ -35,7 +35,7 @@ namespace LibChorus.Tests.notes
 				File.Delete(f.Path);
 				var repo = AnnotationRepository.FromFile("id", f.Path, new ConsoleProgress());
 				repo.Save(new ConsoleProgress());
-				Assert.IsTrue(File.Exists(f.Path));
+				Assert.That(f.Path, Does.Exist);
 			}
 		}
 
@@ -347,9 +347,9 @@ namespace LibChorus.Tests.notes
 			{
 				Console.WriteLine("Building File...");
 				var r = AnnotationRepository.FromFile("id", f.Path, new NullProgress());
-				for (int i = 0; i < 10000; i++)
+				for (var i = 0; i < 10000; i++)
 				{
-					var annotation = new Annotation("question", string.Format("nowhere://blah?id={0}", Guid.NewGuid().ToString()), f.Path);
+					var annotation = new Annotation("question", $"nowhere://blah?id={Guid.NewGuid().ToString()}", f.Path);
 					r.AddAnnotation(annotation);
 					annotation.AddMessage("test", "open", "blah blah");
 				}
@@ -358,16 +358,16 @@ namespace LibChorus.Tests.notes
 				w.Start();
 				r.Save(new NullProgress());
 				w.Stop();
-				Console.WriteLine("Elapsed Time:"+w.ElapsedMilliseconds.ToString()+" milliseconds");
-				Assert.IsTrue(w.ElapsedMilliseconds < 250); //it's around 70 on my laptop, and around 225 on mono desktop
+				Console.WriteLine($"Elapsed Time:{w.ElapsedMilliseconds} milliseconds");
+				Assert.That(w.ElapsedMilliseconds, Is.LessThan(250)); //it's around 70 on my laptop, and around 225 on mono desktop
 
 				w.Reset();
 				Console.WriteLine("Reading Large File...");
 				w.Start();
 				var rToRead = AnnotationRepository.FromFile("id", f.Path, new NullProgress());
 				w.Stop();
-				Console.WriteLine("Elapsed Time:"+w.ElapsedMilliseconds.ToString()+" milliseconds");
-				Assert.IsTrue(w.ElapsedMilliseconds < 1000); //it's around 240 on my laptop, and around 800 on mono desktop
+				Console.WriteLine($"Elapsed Time:{w.ElapsedMilliseconds} milliseconds");
+				Assert.That(w.ElapsedMilliseconds, Is.LessThan(1000)); //it's around 240 on my laptop, and around 800 on mono desktop
 			}
 		}
 

--- a/src/LibChorusTests/sync/ChorusMLFileSyncTests.cs
+++ b/src/LibChorusTests/sync/ChorusMLFileSyncTests.cs
@@ -29,8 +29,8 @@ namespace LibChorus.Tests.sync
 
 					string notesFile = ChorusNotesMergeEventListener.GetChorusNotesFilePath(sally.UserFile.Path);
 					Console.WriteLine("notesFile '{0}'", notesFile);
-					Assert.IsTrue(File.Exists(notesFile), "Conflict file should have been in working set");
-					Assert.IsTrue(sally.Synchronizer.Repository.GetFileIsInRepositoryFromFullPath(notesFile),"Notes file should have been added to repository");
+					Assert.That(notesFile, Does.Exist, "Conflict file should have been in working set");
+					Assert.That(sally.Synchronizer.Repository.GetFileIsInRepositoryFromFullPath (notesFile), Is.True, "Notes file should have been added to repository");
 
 				}
 			}

--- a/src/LibChorusTests/sync/CommitCopTests.cs
+++ b/src/LibChorusTests/sync/CommitCopTests.cs
@@ -49,7 +49,7 @@ namespace LibChorus.Tests.sync
 				bob.ChangeFile("test.chorusTest",ChorusTestFileHandler.GetInvalidContents());
 				using (var cop = new CommitCop(bob.Repository, ChorusFileTypeHandlerCollection.CreateWithTestHandlerOnly(), bob.Progress))
 				{
-					Assert.IsFalse(string.IsNullOrEmpty(cop.ValidationResult));
+					Assert.That(cop.ValidationResult, Is.Not.Null.And.Not.Empty);
 					bob.Repository.Commit(false, "bad data");
 				}
 				Debug.WriteLine(bob.Repository.GetLog(-1));

--- a/src/LibChorusTests/sync/LargeFileFilterTests.cs
+++ b/src/LibChorusTests/sync/LargeFileFilterTests.cs
@@ -52,10 +52,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					_handlersColl);
-				Assert.IsFalse(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Not.Null.And.Not.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns.Contains(shortpath), Is.True);
+				Assert.That(config.IncludePatterns.Contains(shortpath), Is.False);
 			}
 		}
 
@@ -79,10 +79,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					_handlersColl);
-				Assert.IsFalse(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Not.Null.And.Not.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns.Contains(shortpath), Is.True);
+				Assert.That(config.IncludePatterns.Contains(shortpath), Is.False);
 			}
 		}
 
@@ -115,10 +115,10 @@ namespace LibChorus.Tests.sync
 				bob.AssertLocalRevisionNumber(1); // 'forget' marks it as deleted in the repo.
 				bob.AssertFileContents(fullPathname, _longData);
 
-				Assert.IsFalse(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Not.Null.And.Not.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -141,10 +141,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					_handlersColl);
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -166,10 +166,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					_handlersColl);
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -201,10 +201,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					_handlersColl);
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -231,10 +231,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsFalse(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Not.Null.And.Not.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 				bob.Repository.AddAndCheckinFiles(config.IncludePatterns, config.ExcludePatterns, "Some commit");
 				bob.AssertFileDoesNotExistInRepository("big.wav");
 			}
@@ -265,11 +265,11 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 
 				var shortpath = largeFwdataPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -301,11 +301,11 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 
 				var shortpath = largeVideoPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -339,11 +339,11 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 
 				var shortpath = largeVideoPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -393,12 +393,12 @@ namespace LibChorus.Tests.sync
 				Assert.True(string.IsNullOrEmpty(result), @"Cache folder at root was improperly filtered by foo\**\Cache");
 
 				var shortpath = largeNestedVideoPathname.Replace(pathToRepo, null);
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 
 				shortpath = smallNestedVideoPathname.Replace(pathToRepo, null);
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -441,15 +441,14 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsFalse(string.IsNullOrEmpty(result), @"Cache folder at root wasn't properly filtered by large file filer in [repo]\Cache\biggie.mov");
-
+				Assert.That(result, Is.Not.Null.And.Not.Empty, @"Cache folder at root wasn't properly filtered by large file filer in [repo]\Cache\biggie.mov");
 				var shortpath = largeNestedVideoPathname.Replace(pathToRepo, null);
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 
 				shortpath = biggieNestedNonExcludedVideoPathname.Replace(pathToRepo, null);
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -484,11 +483,11 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 
 				var shortpath = largeVideoPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -519,11 +518,11 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 
 				var shortpath = largeVideoPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -556,10 +555,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullDictionaryPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -587,14 +586,14 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullDictionaryPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 
 				shortpath = fullRandomPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -636,18 +635,18 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsTrue(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Null.Or.Empty);
 				var shortpath = fullDictionaryPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 
 				shortpath = fullOldDictionaryPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 
 				shortpath = fullLargeVideoPathname.Replace(pathToRepo, "");
-				Assert.IsFalse(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Not.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -673,10 +672,10 @@ namespace LibChorus.Tests.sync
 					bob.Repository,
 					config,
 					ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers());
-				Assert.IsFalse(string.IsNullOrEmpty(result));
+				Assert.That(result, Is.Not.Null.And.Not.Empty);
 				var shortpath = fullPathname.Replace(pathToRepo, "");
-				Assert.IsTrue(config.ExcludePatterns.Contains(shortpath));
-				Assert.IsFalse(config.IncludePatterns.Contains(shortpath));
+				Assert.That(config.ExcludePatterns, Does.Contain(shortpath));
+				Assert.That(config.IncludePatterns, Does.Not.Contain(shortpath));
 			}
 		}
 
@@ -715,15 +714,15 @@ namespace LibChorus.Tests.sync
 
 				var results = LargeFileFilter.GetStatusOfFilesOfInterest(repo.Repository, repo.ProjectFolderConfig);
 				Assert.AreEqual(3, results.Keys.Count);
-				Assert.IsTrue(results.ContainsKey("M")); // tracked and modifed
-				Assert.IsTrue(results.ContainsKey("A")); // Added with hg add
-				Assert.IsTrue(results.ContainsKey("?")); // untracked
+				Assert.That(results, Does.ContainKey("M")); // tracked and modified
+				Assert.That(results, Does.ContainKey("A")); // Added with hg add
+				Assert.That(results, Does.ContainKey("?")); // untracked
 
 				foreach (var resultKvp in results)
 				{
 					var resultValue = resultKvp.Value;
 					Assert.AreEqual(1, resultValue.Keys.Count);
-					Assert.IsTrue(resultValue.ContainsKey("txt"));
+					Assert.That(resultValue, Does.ContainKey("txt"));
 					Assert.AreEqual(1, resultValue.Values.Count);
 					switch (resultKvp.Key)
 					{

--- a/src/LibChorusTests/sync/ProxyTests.cs
+++ b/src/LibChorusTests/sync/ProxyTests.cs
@@ -32,7 +32,7 @@ namespace LibChorus.Tests.sync
 			using (var f = new TemporaryFolder("clonetest"))
 			{
 				HgRepository.Clone(new HttpRepositoryPath("cloneableTestProjectUrl", _cloneableTestProjectUrl, false), f.Path, _progress);
-				Assert.IsTrue(Directory.Exists(f.Combine(f.Path, ".hg")));
+				Assert.That(f.Combine(f.Path, ".hg"), Does.Exist);
 			}
 		}
 
@@ -46,7 +46,7 @@ namespace LibChorus.Tests.sync
 				var repo = HgRepository.CreateOrUseExisting(f.Path, _progress);
 				var address = new HttpRepositoryPath("default", _cloneableTestProjectUrl, false);
 				repo.Pull(address, _cloneableTestProjectUrl);
-				Assert.IsTrue(Directory.Exists(f.Combine(f.Path, ".hg")));
+				Assert.That(f.Combine(f.Path, ".hg"), Does.Exist);
 			}
 		}
 
@@ -59,7 +59,7 @@ namespace LibChorus.Tests.sync
 				var repo = HgRepository.CreateOrUseExisting(f.Path, _progress);
 				var address = new HttpRepositoryPath("default", _cloneableTestProjectUrl, false);
 				repo.Pull(address, _cloneableTestProjectUrl);
-				Assert.IsTrue(Directory.Exists(f.Combine(f.Path, ".hg")));
+				Assert.That(f.Combine(f.Path, ".hg"), Does.Exist);
 
 				//nb: this is safe to do over an over, because it will just say "no changes found", never actually add a changeset
 

--- a/src/LibChorusTests/sync/SychronizerAdjunctTests.cs
+++ b/src/LibChorusTests/sync/SychronizerAdjunctTests.cs
@@ -44,11 +44,11 @@ namespace LibChorus.Tests.sync
 			using (var bob = new RepositorySetup("bob", true))
 			{
 				var synchronizer = bob.CreateSynchronizer();
-				Assert.IsNotNull(synchronizer.SynchronizerAdjunct);
+				Assert.That(synchronizer.SynchronizerAdjunct, Is.Not.Null);
 				Assert.IsInstanceOf<DefaultSychronizerAdjunct>(synchronizer.SynchronizerAdjunct);
 
 				synchronizer.SynchronizerAdjunct = null;
-				Assert.IsNotNull(synchronizer.SynchronizerAdjunct);
+				Assert.That(synchronizer.SynchronizerAdjunct, Is.Not.Null);
 				Assert.IsInstanceOf<DefaultSychronizerAdjunct>(synchronizer.SynchronizerAdjunct);
 			}
 		}
@@ -101,7 +101,7 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = bob.SyncWithOptions(options, synchronizer);
-				Assert.IsFalse(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.False);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, false, false, false, true, false);
 			}
 		}
@@ -127,7 +127,7 @@ namespace LibChorus.Tests.sync
 				var synchronizer = bob.Synchronizer;
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 				var syncResults = bob.SyncWithOptions(options, synchronizer);
-				Assert.IsFalse(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.False);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, false, false, false, true, true);
 			}
 		}
@@ -164,7 +164,7 @@ namespace LibChorus.Tests.sync
 				alistair.SyncWithOptions(options);
 				susanna.ReplaceSomethingElse("no problems.");
 				var syncResults = susanna.SyncWithOptions(bobOptions, synchronizer);
-				Assert.IsTrue(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, true, false, true, true, true);
 			}
 		}
@@ -198,7 +198,7 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = sally.SyncWithOptions(options, synchronizer);
-				Assert.IsTrue(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, true, false, true, true, true);
 			}
 		}
@@ -231,7 +231,7 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = sally.SyncWithOptions(options, synchronizer);
-				Assert.IsTrue(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, true, false, true, true, true);
 			}
 		}
@@ -262,7 +262,7 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = sally.SyncWithOptions(options, synchronizer);
-				Assert.IsTrue(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, true, false, false, true, true);
 			}
 		}
@@ -296,9 +296,9 @@ namespace LibChorus.Tests.sync
 				using (new FailureSimulator("SychronizerAdjunct"))
 				{
 					var syncResults = sally.SyncWithOptions(options, synchronizer);
-					Assert.IsTrue(syncResults.DidGetChangesFromOthers);
-					Assert.IsFalse(syncResults.Cancelled);
-					Assert.IsFalse(syncResults.Succeeded);
+					Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
+					Assert.That(syncResults.Cancelled, Is.False);
+					Assert.That(syncResults.Succeeded, Is.False);
 					CheckExistanceOfAdjunctFiles(syncAdjunct, true, false, true, false, true, false);
 				}
 			}
@@ -328,7 +328,7 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = sally.SyncWithOptions(options, synchronizer);
-				Assert.IsTrue(syncResults.DidGetChangesFromOthers);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.True);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, true, false, false, true, true);
 				var lines = File.ReadAllLines(syncAdjunct.CheckRepoBranchesPathName);
 				Assert.AreEqual(lines.Length, 2, "Wrong number of branches on CheckBranches call");
@@ -358,9 +358,9 @@ namespace LibChorus.Tests.sync
 				synchronizer.SynchronizerAdjunct = syncAdjunct;
 
 				var syncResults = bob.SyncWithOptions(options, synchronizer);
-				Assert.IsFalse(syncResults.Cancelled);
-				Assert.IsFalse(syncResults.DidGetChangesFromOthers);
-				Assert.IsFalse(syncResults.Succeeded);
+				Assert.That(syncResults.Cancelled, Is.False);
+				Assert.That(syncResults.DidGetChangesFromOthers, Is.False);
+				Assert.That(syncResults.Succeeded, Is.False);
 				CheckExistanceOfAdjunctFiles(syncAdjunct, true, false, true, false, true, false);
 			}
 		}
@@ -465,44 +465,44 @@ namespace LibChorus.Tests.sync
 														 bool branchesFileShouldExist)
 		{
 			if (commitFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.CommitPathname), "CommitFile should exist.");
+				Assert.That(syncAdjunct.CommitPathname, Does.Exist, "CommitFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.CommitPathname), "CommitFile should not exist.");
+				Assert.That(syncAdjunct.CommitPathname, Does.Not.Exist, "CommitFile should not exist.");
 
 			if (pullFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.PullPathname), "PullFile should exist.");
+				Assert.That(syncAdjunct.PullPathname, Does.Exist, "PullFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.PullPathname), "PullFile should not exist.");
+				Assert.That(syncAdjunct.PullPathname, Does.Not.Exist, "PullFile should not exist.");
 
 			if (rollbackFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.RollbackPathname), "RollbackFile should exist.");
+				Assert.That(syncAdjunct.RollbackPathname, Does.Exist, "RollbackFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.RollbackPathname), "RollbackFile shouldn't exist.");
+				Assert.That(syncAdjunct.RollbackPathname, Does.Not.Exist, "RollbackFile shouldn't exist.");
 
 			if (mergeFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.MergePathname), "MergeFile should exist.");
+				Assert.That(syncAdjunct.MergePathname, Does.Exist, "MergeFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.MergePathname), "MergeFile shouldn't exist.");
+				Assert.That(syncAdjunct.MergePathname, Does.Not.Exist, "MergeFile shouldn't exist.");
 
 			if (branchNameFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.BranchNamePathName), "BranchNameFile should exist.");
+				Assert.That(syncAdjunct.BranchNamePathName, Does.Exist, "BranchNameFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.BranchNamePathName), "BranchNameFile shouldn't exist.");
+				Assert.That(syncAdjunct.BranchNamePathName, Does.Not.Exist, "BranchNameFile shouldn't exist.");
 
 			if (branchesFileShouldExist)
-				Assert.IsTrue(File.Exists(syncAdjunct.CheckRepoBranchesPathName), "CheckRepoBranchesFile should exist.");
+				Assert.That(syncAdjunct.CheckRepoBranchesPathName, Does.Exist, "CheckRepoBranchesFile should exist.");
 			else
-				Assert.IsFalse(File.Exists(syncAdjunct.CheckRepoBranchesPathName), "CheckRepoBranchesFile shouldn't exist.");
+				Assert.That(syncAdjunct.CheckRepoBranchesPathName, Does.Not.Exist, "CheckRepoBranchesFile shouldn't exist.");
 		}
 
 		private static void CheckNoFilesExist(FileWriterSychronizerAdjunct syncAdjunct)
 		{
-			Assert.IsFalse(File.Exists(syncAdjunct.CommitPathname));
-			Assert.IsFalse(File.Exists(syncAdjunct.PullPathname));
-			Assert.IsFalse(File.Exists(syncAdjunct.RollbackPathname));
-			Assert.IsFalse(File.Exists(syncAdjunct.MergePathname));
-			Assert.IsFalse(File.Exists(syncAdjunct.BranchNamePathName));
-			Assert.IsFalse(File.Exists(syncAdjunct.CheckRepoBranchesPathName));
+			Assert.That(syncAdjunct.CommitPathname, Does.Not.Exist);
+			Assert.That(syncAdjunct.PullPathname, Does.Not.Exist);
+			Assert.That(syncAdjunct.RollbackPathname, Does.Not.Exist);
+			Assert.That(syncAdjunct.MergePathname, Does.Not.Exist);
+			Assert.That(syncAdjunct.BranchNamePathName, Does.Not.Exist);
+			Assert.That(syncAdjunct.CheckRepoBranchesPathName, Does.Not.Exist);
 		}
 
 		private class FileWriterSychronizerAdjunct : ISychronizerAdjunct

--- a/src/LibChorusTests/sync/SyncScenarioTests.cs
+++ b/src/LibChorusTests/sync/SyncScenarioTests.cs
@@ -198,7 +198,7 @@ namespace LibChorus.Tests.sync
 			options.DoSendToOthers = false;
 			options.RepositorySourcesToTry.Add(otherDirPath);
 			bob.SyncNow(options);
-			Assert.IsTrue(File.Exists(Path.Combine(bobSetup._languageProjectPath, "incoming.abc")));
+			Assert.That(Path.Combine(bobSetup._languageProjectPath, "incoming.abc"), Does.Exist);
 		}
 
 		[Test]
@@ -248,21 +248,21 @@ namespace LibChorus.Tests.sync
 
 			// Verification
 			var bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsFalse(bobContents.Contains("cat"), "'cat' should only be on Sally's branch.");
-			Assert.IsTrue(bobContents.Contains("dog"));
+			Assert.That(bobContents, Does.Not.Contain("cat"), "'cat' should only be on Sally's branch.");
+			Assert.That(bobContents, Does.Contain("dog"));
 			var sallyContents = File.ReadAllText(sallyPathToLift);
 			//Debug.WriteLine("sally's: " + sallyContents);
-			Assert.IsTrue(sallyContents.Contains("cat"));
-			Assert.IsFalse(sallyContents.Contains("dog"), "'dog' should only be in Bob's repo.");
+			Assert.That(sallyContents, Does.Contain("cat"));
+			Assert.That(sallyContents, Does.Not.Contain("dog"), "'dog' should only be in Bob's repo.");
 
 			// Verify Bob is still on the default branch (empty string)
 			string dummy;
 			var result = bobSyncer.Repository.BranchingHelper.IsLatestBranchDifferent("", out dummy);
-			Assert.IsFalse(result, "Bob should be on default branch.");
+			Assert.That(result, Is.False, "Bob should be on default branch.");
 
 			// Verify Sally is on the right branch
 			result = synchronizer.Repository.BranchingHelper.IsLatestBranchDifferent(sallyNewVersion, out dummy);
-			Assert.IsFalse(result, "Sally should be on LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Sally should be on LIFT0.13 branch.");
 		}
 
 		[Test]
@@ -319,12 +319,12 @@ namespace LibChorus.Tests.sync
 
 			// Verification stage 1
 			var bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsFalse(bobContents.Contains("cat"), "'cat' should only be on Sally's branch.");
-			Assert.IsTrue(bobContents.Contains("dog"));
+			Assert.That(bobContents, Does.Not.Contain("cat"), "'cat' should only be on Sally's branch.");
+			Assert.That(bobContents, Does.Contain("dog"));
 			var sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("cat"));
-			Assert.IsTrue(sallyContents.Contains("dog"), "Sally should have merged in older branch to hers.");
-			Assert.IsFalse(sallyContents.Contains("herring"), "The red herring is only in Bob's repo; 2nd branch.");
+			Assert.That(sallyContents, Does.Contain("cat"));
+			Assert.That(sallyContents, Does.Contain("dog"), "Sally should have merged in older branch to hers.");
+			Assert.That(sallyContents, Does.Not.Contain("herring"), "The red herring is only in Bob's repo; 2nd branch.");
 
 			// Now Sally upgrades her LIFT-capable program to Bob's version!
 			File.WriteAllText(sallyPathToLift, LiftFileStrings.lift13PigDogCat);
@@ -344,24 +344,24 @@ namespace LibChorus.Tests.sync
 			// Verification stage 2
 			bobContents = File.ReadAllText(bobSetup._pathToLift);
 			//Debug.Print("Bob's: " + bobContents);
-			Assert.IsTrue(bobContents.Contains("cat"), "'cat' survived the upgrade to Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("dog"));
-			Assert.IsTrue(bobContents.Contains("pig"), "'pig' survived the upgrade to Bob's repo.");
+			Assert.That(bobContents, Does.Contain("cat"), "'cat' survived the upgrade to Bob's repo.");
+			Assert.That(bobContents, Does.Contain("dog"));
+			Assert.That(bobContents, Does.Contain("pig"), "'pig' survived the upgrade to Bob's repo.");
 			sallyContents = File.ReadAllText(sallyPathToLift);
 			//Debug.Print("Sally's: " + sallyContents);
-			Assert.IsTrue(sallyContents.Contains("cat"));
-			Assert.IsTrue(sallyContents.Contains("dog"), "'dog' should be from Bob's older repo.");
-			Assert.IsTrue(sallyContents.Contains("herring"), "Now we should have everything from Bob's repo.");
-			Assert.IsTrue(sallyContents.Contains("pig"), "'pig' should have survived the upgrade.");
+			Assert.That(sallyContents, Does.Contain("cat"));
+			Assert.That(sallyContents, Does.Contain("dog"), "'dog' should be from Bob's older repo.");
+			Assert.That(sallyContents, Does.Contain("herring"), "Now we should have everything from Bob's repo.");
+			Assert.That(sallyContents, Does.Contain("pig"), "'pig' should have survived the upgrade.");
 
 			// Verify Bob is on the latest branch
 			string dummy;
 			var result = bobsyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Bob should be on the latest LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Bob should be on the latest LIFT0.13 branch.");
 
 			// Verify Sally is on the right branch
 			result = synchronizer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Sally should be on the latest LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Sally should be on the latest LIFT0.13 branch.");
 		}
 
 		[Test]
@@ -408,9 +408,9 @@ namespace LibChorus.Tests.sync
 			var sallyPathToLift = Path.Combine(sallyProject.FolderPath, "lexicon/foo.lift");
 			var fredPathToLift = Path.Combine(fredProject.FolderPath, "lexicon/foo.lift");
 			var sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("dog"), "'dog' should be in Sally repo.");
+			Assert.That(sallyContents, Does.Contain("dog"), "'dog' should be in Sally repo.");
 			var fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsTrue(fredContents.Contains("dog"), "'dog' should be in Fred repo.");
+			Assert.That(fredContents, Does.Contain("dog"), "'dog' should be in Fred repo.");
 
 			// bob makes another change and syncs to new version
 			File.WriteAllText(bobSetup._pathToLift, LiftFileStrings.lift13DogCat);
@@ -433,20 +433,20 @@ namespace LibChorus.Tests.sync
 
 			// Verification Step 2
 			fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsFalse(fredContents.Contains("cat"), "'cat' should only be on Bob's branch.");
-			Assert.IsTrue(fredContents.Contains("ant"));
+			Assert.That(fredContents, Does.Not.Contain("cat"), "'cat' should only be on Bob's branch.");
+			Assert.That(fredContents, Does.Contain("ant"));
 			sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("ant"), "'ant' was propogated to Sally's branch.");
-			Assert.IsFalse(sallyContents.Contains("cat"), "'cat' should only be on Bob's branch.");
+			Assert.That(sallyContents, Does.Contain("ant"), "'ant' was propogated to Sally's branch.");
+			Assert.That(sallyContents, Does.Not.Contain("cat"), "'cat' should only be on Bob's branch.");
 			var bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsFalse(bobContents.Contains("ant"), "'ant' is only on 'default' branch.");
+			Assert.That(bobContents, Does.Not.Contain("ant"), "'ant' is only on 'default' branch.");
 			// Verify Bob is on the latest branch
 			string dummy;
 			var result = bobSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Bob should be on the new LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Bob should be on the new LIFT0.13 branch.");
 			// And Fred isn't
 			result = fredSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsTrue(result, "Fred should still be on the 'default' branch.");
+			Assert.That(result, Is.True, "Fred should still be on the 'default' branch.");
 
 			// Now Sally modifies the file, not having seen Bob's changes yet, but having seen Fred's changes.
 			// She adds 'herring' and has upgraded to Bob's version of LIFT
@@ -464,20 +464,20 @@ namespace LibChorus.Tests.sync
 
 			// Verification Step 3
 			bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsTrue(bobContents.Contains("herring"), "'herring' should be pulled in from Sally's branch.");
-			Assert.IsTrue(bobContents.Contains("ant"), "'ant' should be pulled in from Sally's branch.");
+			Assert.That(bobContents, Does.Contain("herring"), "'herring' should be pulled in from Sally's branch.");
+			Assert.That(bobContents, Does.Contain("ant"), "'ant' should be pulled in from Sally's branch.");
 			sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("cat"), "'cat' should be pulled in from Bob's branch.");
-			Assert.IsTrue(sallyContents.Contains("dog"), "Everybody should have 'dog' from before.");
+			Assert.That(sallyContents, Does.Contain("cat"), "'cat' should be pulled in from Bob's branch.");
+			Assert.That(sallyContents, Does.Contain("dog"), "Everybody should have 'dog' from before.");
 			fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsFalse(fredContents.Contains("herring"), "The red herring is only in the new version for now.");
-			Assert.IsFalse(fredContents.Contains("cat"), "'cat' is only in the new version for now.");
+			Assert.That(fredContents, Does.Not.Contain("herring"), "The red herring is only in the new version for now.");
+			Assert.That(fredContents, Does.Not.Contain("cat"), "'cat' is only in the new version for now.");
 			// Verify Sally is now on the latest branch
 			result = sallySyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Sally should be on the new LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Sally should be on the new LIFT0.13 branch.");
 			// And Fred still shouldn't be
 			result = fredSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsTrue(result, "Fred should still be on the 'default' branch.");
+			Assert.That(result, Is.True, "Fred should still be on the 'default' branch.");
 
 			// Now Fred checks in 'pig' to the 'default' branch
 			File.WriteAllText(fredPathToLift, LiftFileStrings.lift12DogAntPig);
@@ -488,14 +488,14 @@ namespace LibChorus.Tests.sync
 
 			// Verification Step 4
 			bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsFalse(bobContents.Contains("pig"), "'pig' should only be on 'default' branch.");
+			Assert.That(bobContents, Does.Not.Contain("pig"), "'pig' should only be on 'default' branch.");
 			sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsFalse(sallyContents.Contains("pig"), "'pig' should only be on 'default' branch.");
+			Assert.That(sallyContents, Does.Not.Contain("pig"), "'pig' should only be on 'default' branch.");
 			fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsFalse(fredContents.Contains("herring"), "'herring' should still only be in the new version.");
+			Assert.That(fredContents, Does.Not.Contain("herring"), "'herring' should still only be in the new version.");
 			// Just check Fred hasn't changed branches
 			result = fredSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsTrue(result, "Fred should still be on the 'default' branch.");
+			Assert.That(result, Is.True, "Fred should still be on the 'default' branch.");
 
 			// Now Bob checks in 'deer' in the new version
 			File.WriteAllText(bobSetup._pathToLift, LiftFileStrings.lift13DogCatHerringAntDeer);
@@ -505,14 +505,14 @@ namespace LibChorus.Tests.sync
 			// Verification Step 5
 			// Check that Fred hasn't changed
 			fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsFalse(fredContents.Contains("deer"), "'deer' should only be on new version.");
+			Assert.That(fredContents, Does.Not.Contain("deer"), "'deer' should only be on new version.");
 			result = fredSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsTrue(result, "Fred should still be on the 'default' branch.");
+			Assert.That(result, Is.True, "Fred should still be on the 'default' branch.");
 			// Check that Sally got her 'deer'
 			sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("deer"), "'deer' should have propagated to Sally.");
+			Assert.That(sallyContents, Does.Contain("deer"), "'deer' should have propagated to Sally.");
 			// Make sure that 'pig' hasn't migrated to the new version
-			Assert.IsFalse(sallyContents.Contains("pig"), "'pig' should still only be on 'default' branch.");
+			Assert.That(sallyContents, Does.Not.Contain("pig"), "'pig' should still only be on 'default' branch.");
 
 			// Now Fred has finally upgraded and will check in 'fox' -- LAST CHECK-IN FOR THIS TEST!
 			File.WriteAllText(fredPathToLift, LiftFileStrings.lift13DogAntPigFox);
@@ -522,41 +522,41 @@ namespace LibChorus.Tests.sync
 
 			// Verification Step 6 (Last)
 			bobContents = File.ReadAllText(bobSetup._pathToLift);
-			Assert.IsTrue(bobContents.Contains("cat"), "'cat' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("dog"), "'dog' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("pig"), "'pig' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("herring"), "'herring' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("deer"), "'deer' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("ant"), "'ant' should survive the big hairy test in Bob's repo.");
-			Assert.IsTrue(bobContents.Contains("fox"), "'fox' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("cat"), "'cat' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("dog"), "'dog' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("pig"), "'pig' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("herring"), "'herring' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("deer"), "'deer' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("ant"), "'ant' should survive the big hairy test in Bob's repo.");
+			Assert.That(bobContents, Does.Contain("fox"), "'fox' should survive the big hairy test in Bob's repo.");
 			sallyContents = File.ReadAllText(sallyPathToLift);
-			Assert.IsTrue(sallyContents.Contains("cat"), "'cat' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("dog"), "'dog' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("herring"), "'herring' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("pig"), "'pig' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("deer"), "'deer' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("ant"), "'ant' should survive the big hairy test in Sally's repo.");
-			Assert.IsTrue(sallyContents.Contains("fox"), "'fox' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("cat"), "'cat' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("dog"), "'dog' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("herring"), "'herring' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("pig"), "'pig' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("deer"), "'deer' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("ant"), "'ant' should survive the big hairy test in Sally's repo.");
+			Assert.That(sallyContents, Does.Contain("fox"), "'fox' should survive the big hairy test in Sally's repo.");
 			fredContents = File.ReadAllText(fredPathToLift);
-			Assert.IsTrue(fredContents.Contains("cat"), "'cat' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("dog"), "'dog' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("herring"), "'herring' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("pig"), "'pig' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("deer"), "'deer' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("ant"), "'ant' should survive the big hairy test in Fred's repo.");
-			Assert.IsTrue(fredContents.Contains("fox"), "'fox' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("cat"), "'cat' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("dog"), "'dog' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("herring"), "'herring' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("pig"), "'pig' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("deer"), "'deer' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("ant"), "'ant' should survive the big hairy test in Fred's repo.");
+			Assert.That(fredContents, Does.Contain("fox"), "'fox' should survive the big hairy test in Fred's repo.");
 
 			// Verify Bob is on the latest branch
 			result = bobSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Bob should be on the new LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Bob should be on the new LIFT0.13 branch.");
 
 			// Verify Sally is on the right branch
 			result = sallySyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Sally should be on the new LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Sally should be on the new LIFT0.13 branch.");
 
 			// Verify Fred is finally on the new branch
 			result = fredSyncer.Repository.BranchingHelper.IsLatestBranchDifferent(lift13version, out dummy);
-			Assert.IsFalse(result, "Fred should finally be on the new LIFT0.13 branch.");
+			Assert.That(result, Is.False, "Fred should finally be on the new LIFT0.13 branch.");
 		}
 
 #if forscreenshot
@@ -717,8 +717,8 @@ namespace LibChorus.Tests.sync
 			//Debug.WriteLine("bob's: " + File.ReadAllText(bobSetup._pathToLift));
 			var contents = File.ReadAllText(sallyPathToLift);
 			//Debug.WriteLine("sally's: " + contents);
-			Assert.IsTrue(contents.Contains("cat"));
-			Assert.IsTrue(contents.Contains("dog"));
+			Assert.That(contents, Does.Contain("cat"));
+			Assert.That(contents, Does.Contain("dog"));
 		}
 
 		/// <summary>
@@ -785,8 +785,8 @@ namespace LibChorus.Tests.sync
 			//Debug.WriteLine("bob's: " + File.ReadAllText(bobSetup._pathToLift));
 			var contents = File.ReadAllText(sallyPathToLift);
 			//Debug.WriteLine("sally's: " + contents);
-			Assert.IsTrue(contents.Contains("ant"));
-			Assert.IsTrue(contents.Contains("dog"));
+			Assert.That(contents, Does.Contain("ant"));
+			Assert.That(contents, Does.Contain("dog"));
 		}
 
 		public void AssertLineOfFile(string filePath, int lineNumber1Based, string shouldEqual)

--- a/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
+++ b/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
@@ -50,7 +50,7 @@ namespace LibChorus.Tests.sync
 				using (new StreamWriter(stream))
 				{
 					var results = setup.CheckinAndPullAndMerge();
-					Assert.IsFalse(results.Succeeded);
+					Assert.That(results.Succeeded, Is.False);
 				}
 			}
 		}
@@ -69,7 +69,7 @@ namespace LibChorus.Tests.sync
 					{
 						sally.CheckinAndPullAndMerge(bob);
 					}
-					Assert.IsTrue(sally.ProgressString.Contains("InduceChorusFailure"));
+					Assert.That(sally.ProgressString, Does.Contain("InduceChorusFailure"));
 
 				   sally.AssertHeadCount(2);
 					//ok, Bob's the tip, but...
@@ -77,13 +77,13 @@ namespace LibChorus.Tests.sync
 					//make sure we didn't move up to that tip, because we weren't able to merge with it
 					var currentRevision = sally.GetRepository().GetRevisionWorkingSetIsBasedOn();
 					Assert.AreEqual("sally",  sally.GetRepository().GetRevision(currentRevision.Number.Hash).UserId);
-					Assert.IsTrue(File.ReadAllText(sally.UserFile.Path).Contains("sallyWasHere"));
+					Assert.That(File.ReadAllText(sally.UserFile.Path), Does.Contain("sallyWasHere"));
 
 					//and over at Bob's house, it's as if Sally had never connected
 
 					bob.AssertHeadCount(1);
 					Assert.AreEqual("bob", bob.Repository.GetTip().UserId);
-					Assert.IsTrue(File.ReadAllText(bob.UserFile.Path).Contains("bobWasHere"));
+					Assert.That(File.ReadAllText(bob.UserFile.Path), Does.Contain("bobWasHere"));
 				}
 			}
 			File.Delete(Path.Combine(Path.GetTempPath(), "LiftMerger.FindEntryById"));
@@ -146,7 +146,7 @@ namespace LibChorus.Tests.sync
 						sally.AddAndCheckinFile("aaa.txt", "sally-apple");
 						sally.AddAndCheckinFile("bbb.txt", "sally-bread");
 						sally.AddAndCheckinFile("zzz.txt", "sally-zipper");
-						Assert.IsFalse(sally.CheckinAndPullAndMerge(bob).Succeeded);
+						Assert.That(sally.CheckinAndPullAndMerge(bob).Succeeded, Is.False);
 
 					   //make sure we ended up on Sally's revision, even though Bob's are newer
 						var currentRevision = sally.Repository.GetRevisionWorkingSetIsBasedOn();
@@ -159,7 +159,7 @@ namespace LibChorus.Tests.sync
 
 //                        sally.ShowInTortoise();
 					   sally.AssertHeadCount(2);
-						Assert.IsFalse(sally.GetProgressString().Contains("creates new remote heads"));
+						Assert.That(sally.GetProgressString(), Does.Not.Contain("creates new remote heads"));
 					}
 				}
 			}
@@ -173,7 +173,7 @@ namespace LibChorus.Tests.sync
 			using (var bob = new RepositorySetup("bob"))
 			{
 				var result = bob.CheckinAndPullAndMerge();
-				Assert.IsTrue(result.Succeeded, result.ErrorEncountered==null?"":result.ErrorEncountered.Message);
+				Assert.That(result.Succeeded, Is.True, result.ErrorEncountered?.Message);
 			}
 		}
 
@@ -192,7 +192,7 @@ namespace LibChorus.Tests.sync
 				bob.AddAndCheckIn();
 				sally.WriteNewContentsToTestFile("sallyWasHere");
 				var result = sally.CheckinAndPullAndMerge(bob);
-				Assert.IsFalse(result.Succeeded);
+				Assert.That(result.Succeeded, Is.False);
 
 				//make sure we ended up on Sally's revision, even though Bob's are newer
 				var currentRevision = sally.Repository.GetRevisionWorkingSetIsBasedOn();
@@ -205,7 +205,7 @@ namespace LibChorus.Tests.sync
 				Assert.AreEqual("bob", sally.Repository.GetTip().UserId,"if bob's not the tip, we're not testing the right situation");
 
 				result = sally.CheckinAndPullAndMerge(bob);
-				Assert.IsFalse(result.Succeeded);
+				Assert.That(result.Succeeded, Is.False);
 				result = sally.CheckinAndPullAndMerge(bob);
 
 				Assert.AreEqual("sally",sally.Repository.GetRevisionWorkingSetIsBasedOn().UserId);
@@ -235,14 +235,14 @@ namespace LibChorus.Tests.sync
 					using (sally.GetFileLockForWriting("one.txt"))
 					{
 						// Note: Mono succeeds here
-						Assert.IsFalse(sally.CheckinAndPullAndMerge(bob).Succeeded, "CheckinAndPullAndMerge should have failed");
+						Assert.That(sally.CheckinAndPullAndMerge(bob).Succeeded, Is.False, "CheckinAndPullAndMerge should have failed");
 						sally.AssertFileContents("one.txt", "hello");
 					}
 					sally.AssertSingleHead();
 
 					//ok, now whatever was holding that file is done with it, and we try again
 
-					Assert.IsTrue(sally.CheckinAndPullAndMerge(bob).Succeeded, "ChecinAndPullAndMerge(bob) should have succeeded");
+					Assert.That(sally.CheckinAndPullAndMerge(bob).Succeeded, Is.True, "ChecinAndPullAndMerge(bob) should have succeeded");
 					sally.AssertFileContents("one.txt", "hello-bob");
 				}
 			}
@@ -291,7 +291,7 @@ namespace LibChorus.Tests.sync
 
 					// nb: this is sally because the conflict handling mode is (at the time of this test
 					// writing) set to WeWin.
-					Assert.IsTrue(File.ReadAllText(sally.UserFile.Path).Contains("sallyWasHere"));
+					Assert.That(File.ReadAllText(sally.UserFile.Path), Does.Contain("sallyWasHere"));
 				}
 
 			}
@@ -494,13 +494,13 @@ namespace LibChorus.Tests.sync
 //            {
 //                memoryStream.Write(new byte[]{60},0,1 );
 //                string xmlString = Encoding.UTF8.GetString(memoryStream.ToArray());
-//                Assert.IsFalse(xmlString.Contains("\0"));
+//                Assert.That(xmlString, Does.Not.Contain("\0"));
 //
 //                xmlString = Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Position);
-//                Assert.IsFalse(xmlString.Contains("\0"));
+//                Assert.That(xmlString, Does.Not.Contain("\0"));
 //
 //                xmlString = Encoding.UTF8.GetString(memoryStream.GetBuffer());
-//                Assert.IsFalse(xmlString.Contains("\0"));
+//                Assert.That(xmlString, Does.Not.Contain("\0"));
 //            }
 //        }
 

--- a/src/LibChorusTests/sync/Synchronizer.FileBasedTests.cs
+++ b/src/LibChorusTests/sync/Synchronizer.FileBasedTests.cs
@@ -89,12 +89,12 @@ namespace LibChorus.Tests.sync
 			_synchronizer.SyncNow(options);
 
 			string path = Path.Combine(_pathToProjectRoot, "foo.txt");
-			Assert.IsTrue(File.Exists(path));
+			Assert.That(path, Does.Exist);
 			_synchronizer.SyncNow(options);
 			File.Delete(path);
 			_synchronizer.SyncNow(options);
 
-			Assert.IsFalse(File.Exists(path));
+			Assert.That(path, Does.Not.Exist);
 		}
 
 		/// <summary>
@@ -108,9 +108,9 @@ namespace LibChorus.Tests.sync
 
 		   // WriteTestFile("version two");
 
-			Assert.IsTrue(_synchronizer.SyncNow(options).Succeeded);
+			Assert.That(_synchronizer.SyncNow(options).Succeeded, Is.True);
 			string dir = Path.Combine(_pathToBackupFolder, "foo project.2");
-			Assert.IsTrue(Directory.Exists(dir));
+			Assert.That(dir, Does.Exist);
 		}
 
 		[Test]

--- a/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
+++ b/src/LibChorusTests/sync/UsbRepositorySourceTests.cs
@@ -69,7 +69,7 @@ namespace LibChorus.Tests.sync
 
 			synchronizer.SyncNow(options);
 			string dir = Path.Combine(UsbKeyRepositorySource.RootDirForUsbSourceDuringUnitTest, "foo project");
-			Assert.IsTrue(Directory.Exists(dir));
+			Assert.That(dir, Does.Exist);
 
 		}
 
@@ -86,12 +86,12 @@ namespace LibChorus.Tests.sync
 
 			synchronizer.SyncNow(options);
 			var projectDir = Path.Combine(UsbKeyRepositorySource.RootDirForUsbSourceDuringUnitTest, "foo project");
-			Assert.IsTrue(Directory.Exists(projectDir));
+			Assert.That(projectDir, Does.Exist);
 			// SUT backward compatible clone has no dotencode in the requires file
 			var requiresLines = File.ReadAllLines(Path.Combine(projectDir, ".hg", "requires"));
 			CollectionAssert.DoesNotContain(requiresLines, "dotencode");
 			// SUT bare clone should get this text file
-			Assert.IsTrue(File.Exists(projectDir.CombineForPath(projectDir, "~~Folder has an invisible repository.txt")));
+			Assert.That(projectDir.CombineForPath(projectDir, "~~Folder has an invisible repository.txt"), Does.Exist);
 		}
 
 		[Test]

--- a/src/LibChorusTests/utilities/ChorusDiff3Tests.cs
+++ b/src/LibChorusTests/utilities/ChorusDiff3Tests.cs
@@ -17,7 +17,7 @@ namespace LibChorus.Tests.utilities
 		[Test]
 		public void Diff3IsAccessible()
 		{
-			Assert.IsTrue(TextMerger.GetVersion().Contains("Copyright"));
+			Assert.That(TextMerger.GetVersion(), Does.Contain("Copyright"));
 		}
 
 		[Test]
@@ -30,21 +30,21 @@ namespace LibChorus.Tests.utilities
 			m.Go();
 			AssertLeftNoMergeArtifacts(m);
 			Assert.AreEqual(string.Empty, m.LeastCommonDenominator.Trim());
-			Assert.IsTrue(m.OurPartial.Contains("bob"));
-			Assert.IsTrue(m.TheirPartial.Contains("sally"));
+			Assert.That(m.OurPartial, Does.Contain("bob"));
+			Assert.That(m.TheirPartial, Does.Contain("sally"));
 		}
 
 		private void AssertLeftNoMergeArtifacts(Merge m)
 		{
-			Assert.IsFalse(m.LeastCommonDenominator.Contains("<<<<"));
-			Assert.IsFalse(m.LeastCommonDenominator.Contains(">>>>"));
-			Assert.IsFalse(m.LeastCommonDenominator.Contains("===="));
-			Assert.IsFalse(m.OurPartial.Contains("<<<<"));
-			Assert.IsFalse(m.OurPartial.Contains("===="));
-			Assert.IsFalse(m.OurPartial.Contains(">>>>"));
-			Assert.IsFalse(m.TheirPartial.Contains("<<<<"));
-			Assert.IsFalse(m.TheirPartial.Contains("===="));
-			Assert.IsFalse(m.TheirPartial.Contains(">>>>"));
+			Assert.That(m.LeastCommonDenominator, Does.Not.Contain("<<<<"));
+			Assert.That(m.LeastCommonDenominator, Does.Not.Contain(">>>>"));
+			Assert.That(m.LeastCommonDenominator, Does.Not.Contain("===="));
+			Assert.That(m.OurPartial, Does.Not.Contain("<<<<"));
+			Assert.That(m.OurPartial, Does.Not.Contain("===="));
+			Assert.That(m.OurPartial, Does.Not.Contain(">>>>"));
+			Assert.That(m.TheirPartial, Does.Not.Contain("<<<<"));
+			Assert.That(m.TheirPartial, Does.Not.Contain("===="));
+			Assert.That(m.TheirPartial, Does.Not.Contain(">>>>"));
 		}
 
 		[Test]
@@ -57,18 +57,18 @@ namespace LibChorus.Tests.utilities
 			m.Go();
 			AssertLeftNoMergeArtifacts(m);
 
-			Assert.IsTrue(m.LeastCommonDenominator.Contains("two"));
-			Assert.IsTrue(m.LeastCommonDenominator.Contains("bob4"));
-			Assert.IsTrue(m.LeastCommonDenominator.Contains("sally6"));
+			Assert.That(m.LeastCommonDenominator, Does.Contain("two"));
+			Assert.That(m.LeastCommonDenominator, Does.Contain("bob4"));
+			Assert.That(m.LeastCommonDenominator, Does.Contain("sally6"));
 
 
-			Assert.IsTrue(m.OurPartial.Contains("bob2"));
-			Assert.IsTrue(m.OurPartial.Contains("bob4"));
-			Assert.IsTrue(m.OurPartial.Contains("sally6"));
+			Assert.That(m.OurPartial, Does.Contain("bob2"));
+			Assert.That(m.OurPartial, Does.Contain("bob4"));
+			Assert.That(m.OurPartial, Does.Contain("sally6"));
 
-			Assert.IsTrue(m.TheirPartial.Contains("sally2"));
-			Assert.IsTrue(m.TheirPartial.Contains("bob4"));
-			Assert.IsTrue(m.TheirPartial.Contains("sally6"));
+			Assert.That(m.TheirPartial, Does.Contain("sally2"));
+			Assert.That(m.TheirPartial, Does.Contain("bob4"));
+			Assert.That(m.TheirPartial, Does.Contain("sally6"));
 		}
 
 		class Merge

--- a/src/LibChorusTests/utilities/XmlUtilitiesTests.cs
+++ b/src/LibChorusTests/utilities/XmlUtilitiesTests.cs
@@ -30,8 +30,8 @@ namespace LibChorus.Tests.utilities
 @"<foo />";
 			const string theirs =
 @"<foo>New foo text.</foo>";
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(ours, theirs));
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(theirs, ours));
+			Assert.That(XmlUtilities.AreXmlElementsEqual(ours, theirs), Is.False);
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.False);
 		}
 
 		[Test]
@@ -52,8 +52,8 @@ namespace LibChorus.Tests.utilities
 @"<foo attr='val' />";
 			const string theirs =
 @"<foo attr='val' >New foo text.</foo>";
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(ours, theirs));
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(theirs, ours));
+			Assert.That(XmlUtilities.AreXmlElementsEqual(ours, theirs), Is.False);
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.False);
 		}
 
 		[Test]
@@ -82,8 +82,8 @@ namespace LibChorus.Tests.utilities
 @"<foo attr='val'>
 <bar attr='val'>new stuff.</bar>
 </foo>";
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(ours, theirs));
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(theirs, ours));
+			Assert.That(XmlUtilities.AreXmlElementsEqual(ours, theirs), Is.False);
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.False);
 		}
 
 		[Test]
@@ -168,8 +168,8 @@ namespace LibChorus.Tests.utilities
 <ParseIsCurrent val='False' />
 </rt>");
 
-			Assert.IsTrue(XmlUtilities.AreXmlElementsEqual(ours, theirs), "ours != theirs");
-			Assert.IsTrue(XmlUtilities.AreXmlElementsEqual(theirs, ours), "theirs != ours");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(ours, theirs), Is.True, "ours != theirs");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.True, "theirs != ours");
 		}
 
 		[Test]
@@ -178,8 +178,8 @@ namespace LibChorus.Tests.utilities
 			var ours = Encoding.UTF8.GetBytes(@"<rt class='ScrTxtPara' guid='0030a77d-63cd-4d51-b26a-27bac7d64f17' ownerguid='046d6079-2337-425f-a8bd-b0af047fb5e5' />");
 			var theirs = Encoding.UTF8.GetBytes(@"<rt class='LexEntry' guid='0030a77d-63cd-4d51-b26a-27bac7d64f18' ownerguid='046d6079-2337-425f-a8bd-b0af047fb5e5' />");
 
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(ours, theirs), "ours == theirs");
-			Assert.IsFalse(XmlUtilities.AreXmlElementsEqual(theirs, ours), "theirs == ours");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(ours, theirs), Is.False, "ours == theirs");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.False, "theirs == ours");
 		}
 
 		#region IsTextNodeContainer
@@ -245,13 +245,13 @@ namespace LibChorus.Tests.utilities
 			var ours = doc.CreateElement("myelement");
 			var theirs = doc.CreateElement("myelement");
 			var ancestor = doc.CreateElement("myelement");
-			Assert.IsFalse(XmlUtilities.IsTextLevel(ours, theirs, ancestor));
+			Assert.That(XmlUtilities.IsTextLevel(ours, theirs, ancestor), Is.False);
 		}
 
 		[Test]
 		public void AllNullsIsNotTextlevel()
 		{
-			Assert.IsFalse(XmlUtilities.IsTextLevel(null, null, null));
+			Assert.That(XmlUtilities.IsTextLevel(null, null, null), Is.False);
 		}
 
 		#endregion IsTextLevel
@@ -267,7 +267,7 @@ namespace LibChorus.Tests.utilities
 			XmlNode theirs = theirDoc.FirstChild;
 			XmlUtilities.ReplaceOursWithTheirs(ourDoc, ref ours, theirs);
 			Assert.AreSame(ourDoc.OwnerDocument, ours.OwnerDocument);
-			Assert.IsTrue(XmlUtilities.AreXmlElementsEqual(theirs, ours), "theirs != ours");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.True, "theirs != ours");
 		}
 
 		[Test]
@@ -279,7 +279,7 @@ namespace LibChorus.Tests.utilities
 			XmlNode theirs = theirDoc.FirstChild;
 			XmlUtilities.ReplaceOursWithTheirs(ourDoc, ref ours, theirs);
 			Assert.AreSame(ourDoc.OwnerDocument, ours.OwnerDocument, "Returned node not in inserted into our parent document");
-			Assert.IsTrue(XmlUtilities.AreXmlElementsEqual(theirs, ours), "theirs != ours");
+			Assert.That(XmlUtilities.AreXmlElementsEqual(theirs, ours), Is.True, "theirs != ours");
 		}
 
 		[Test]


### PR DESCRIPTION
While things still compiled they produced errors when the nuget
package of the test gets used in client unit tests.