### PR TITLE
Improve ldml file merging when only the date changes

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -300,7 +300,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 			catch (Exception err)
 			{
-				_progress.WriteWarning("Could not send to " + targetUri + Environment.NewLine + err.Message);
+				_progress.WriteMessageWithColor("OrangeRed", "Could not send to " + targetUri + Environment.NewLine + err.Message);
 			}
 
 			if (GetIsLocalUri(targetUri))
@@ -311,8 +311,8 @@ namespace Chorus.VcsDrivers.Mercurial
 				}
 				catch (Exception err)
 				{
-					_progress.WriteWarning("Could not update the actual files after a pushing to " + targetUri +
-										   Environment.NewLine + err.Message);
+					_progress.WriteMessageWithColor("OrangeRed",
+						$"Could not update the actual files after a pushing to {targetUri}{Environment.NewLine}{err.Message}");
 				}
 			}
 		}

--- a/src/LibChorus/merge/xml/generic/HumanLogMergeEventListener.cs
+++ b/src/LibChorus/merge/xml/generic/HumanLogMergeEventListener.cs
@@ -27,7 +27,7 @@ namespace Chorus.merge.xml.generic
 
 		public void WarningOccurred(IConflict warning)
 		{
-			_stream.WriteLine("warning: "+warning.GetFullHumanReadableDescription());
+			_stream.WriteLine($"warning: {warning.GetFullHumanReadableDescription()}");
 		}
 
 		public void ChangeOccurred(IChangeReport change)

--- a/src/LibChorus/merge/xml/generic/XmlUtilities.cs
+++ b/src/LibChorus/merge/xml/generic/XmlUtilities.cs
@@ -40,6 +40,11 @@ namespace Chorus.merge.xml.generic
 			return (ours == theirs) || AreXmlElementsEqual(CreateNode(ours), CreateNode(theirs));
 		}
 
+		public static bool AreXmlElementsEqual(XElement ours, XElement theirs)
+		{
+			return XNode.DeepEquals(ours, theirs);
+		}
+
 		private static XmlNode CreateNode(string data)
 		{
 			using (var stringReader = new StringReader(data))


### PR DESCRIPTION
Partial fix for Flex bug LT-20473

* If only the date has changed just update the file to
  contain the most recent timestamp
* Write out ldml files only once, and only when changes
  were made
* Update tests where the previous code caused unnecessary
  date changes
* Unrelated: Improved visibility for failures to push by
  changing the color to RedOrange

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/225)
<!-- Reviewable:end -->
