### PR TITLE
Convert LanguageDepot projects to use LanguageForge

### DIFF
--- a/Chorus.sln.DotSettings
+++ b/Chorus.sln.DotSettings
@@ -21,4 +21,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=reimplement/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resumable/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdirectory/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdirectory/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdomain/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
@@ -111,7 +111,7 @@ namespace Chorus.Tests.UI.Sync
 		[Test]
 		[Category("SkipBehindProxy")]
 		[Category("SkipOnTeamCity")]
-		public void Sync_NonExistentLangDepotProject_ExitsGracefullyWithCorrectErrorResult()
+		public void Sync_NonExistentLangForgeProject_ExitsGracefullyWithCorrectErrorResult()
 		{
 			_model = new SyncControlModel(_project, SyncUIFeatures.Minimal, null);
 			_model.SyncOptions.RepositorySourcesToTry.Add(RepositoryAddress.Create("languageforge", "https://hg-public.languageforge.org/dummy"));

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -18,6 +18,8 @@ namespace Chorus.Model
 	public class ServerSettingsModel
 	{
 		#region static and constant
+		private const string LanguageForge = "languageforge.org";
+
 		private const string EntropyValue = "LAMED videte si est dolor sicut dolor meus";
 
 		internal class Project
@@ -104,7 +106,13 @@ namespace Chorus.Model
 			}
 			ProjectId = HttpUtilityFromMono.UrlDecode(UrlHelper.GetPathAfterHost(url));
 			Bandwidth = new BandwidthItem(RepositoryAddress.IsKnownResumableRepository(url) ? BandwidthEnum.Low : BandwidthEnum.High);
-			CustomUrl = UrlHelper.GetPathOnly(url);
+
+			const string languageDepot = "languagedepot.org";
+			if (url.Contains(languageDepot))
+			{
+				url = url.Replace(languageDepot, LanguageForge).Replace("http://", "https://");
+			}
+			CustomUrl = UrlHelper.StripCredentialsAndQuery(url);
 			IsCustomUrl = !UrlHelper.GetHost(url).Equals(Host);
 		}
 
@@ -123,7 +131,7 @@ namespace Chorus.Model
 
 		protected internal string Host => IsCustomUrl
 			? UrlHelper.GetHost(CustomUrl)
-			: $"{(Bandwidth.Value == BandwidthEnum.Low ? "resumable" : "hg-public")}.languageforge.org";
+			: $"{(Bandwidth.Value == BandwidthEnum.Low ? "resumable" : "hg-public")}.{LanguageForge}";
 
 
 		public bool HaveGoodUrl
@@ -213,7 +221,7 @@ namespace Chorus.Model
 
 		private WebResponse LogIn()
 		{
-			var request = WebRequest.Create($"https://admin.languageforge.org/api/user/{Username}/projects");
+			var request = WebRequest.Create($"https://admin.{LanguageForge}/api/user/{Username}/projects");
 			request.Method = "POST";
 			var passwordBytes = Encoding.UTF8.GetBytes($"password={Password}");
 			request.ContentType = "application/x-www-form-urlencoded";

--- a/src/LibChorus/Utilities/UrlHelper.cs
+++ b/src/LibChorus/Utilities/UrlHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -94,26 +94,25 @@ namespace Chorus.Utilities
 				startOfQuery = url.Length;
 			string host = url.Substring(0, startOfQuery);
 			string rest = url.Substring(startOfQuery, url.Length - startOfQuery);
-			return host.Replace("%20", "").Replace(" ",String.Empty) + rest;
+			return host.Replace("%20", string.Empty).Replace(" ", string.Empty) + rest;
 		}
 
+		/// <summary>Removes the query portion of the URL (the question mark and following)</summary>
+		[Obsolete]
 		public static string GetPathOnly(string url)
 		{
-// DIDN"T WORK
-//			Uri uri;
-//				if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
-//				{
-//					throw new ApplicationException("Could not parse the url " + url);
-//				}
-//
-//			return uri.AbsolutePath;
+			var locationOfQuestionMark = url.IndexOf('?');
+			return locationOfQuestionMark > 0
+				? url.Substring(0, locationOfQuestionMark)
+				: url;
+		}
 
-			int locationOfQuestionMark = url.IndexOf('?');
-			if(locationOfQuestionMark > 0)
-			{
-				return url.Substring(0, locationOfQuestionMark);
-			}
-			return url;
+		public static string StripCredentialsAndQuery(string url)
+		{
+			Uri uri;
+			return Uri.TryCreate(url, UriKind.Absolute, out uri)
+				? $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath.TrimEnd('/')}"
+				: url;
 		}
 
 		public static string GetUserName(string url)

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -71,7 +71,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			// This could be a problem if there was some way for the user to create a 'default' path, but the paths we want
 			// to find here are currently always named with an adaptation of the path. I don't think that process can produce 'default'.
 			var paths = GetRepositoryPathsInHgrc();
-			var networkPaths = paths.Where(p => p is T && p.Name != "default");
+			var networkPaths = paths.Where(p => p is T && p.Name != "default").ToArray();
 
 			//none found in the hgrc
 			if (!networkPaths.Any()) //nb: because of lazy eval, the hgrc lock exception can happen here

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeRestApiServer.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeRestApiServer.cs
@@ -27,28 +27,18 @@ namespace Chorus.VcsDrivers.Mercurial
 			return Execute(method, request, new byte[0], secondsBeforeTimeout);
 		}
 
-		public string UserName
-		{
-			get { return Uri.UnescapeDataString(_url.UserInfo.Split(':')[0]); }
-		}
-
-		public string Password
-		{
-			get { return Uri.UnescapeDataString(_url.UserInfo.Split(':')[1]); }
-		}
+		// TODO (Hasso) 2021.01: remove UserName and Password from this API
+		[Obsolete] public string UserName => Properties.Settings.Default.LanguageForgeUser;
+		[Obsolete] public string Password => Properties.Settings.Default.LanguageForgePass;
 
 		public HgResumeApiResponse Execute(string method, HgResumeApiParameters parameters, byte[] contentToSend, int secondsBeforeTimeout)
 		{
 			string queryString = parameters.BuildQueryString();
-			Url = String.Format("{0}://{1}/api/v{2}/{3}?{4}", _url.Scheme, _url.Host, ApiVersion, method, queryString);
+			Url = string.Format("{0}://{1}/api/v{2}/{3}?{4}", _url.Scheme, _url.Host, ApiVersion, method, queryString);
 			var req = (HttpWebRequest) WebRequest.Create(Url);
 			req.UserAgent = $"HgResume v{ApiVersion}";
 			req.PreAuthenticate = true;
-			if (!_url.UserInfo.Contains(":"))
-			{
-				throw new HgResumeException("Username or password were not supplied in custom location");
-			}
-			req.Credentials = new NetworkCredential(UserName, Password);
+			req.Credentials = new NetworkCredential(Properties.Settings.Default.LanguageForgeUser, Properties.Settings.Default.LanguageForgePass);
 			req.Timeout = secondsBeforeTimeout * 1000; // timeout is in milliseconds
 			if (contentToSend.Length == 0)
 			{

--- a/src/LibChorus/VcsDrivers/RepositoryAddress.cs
+++ b/src/LibChorus/VcsDrivers/RepositoryAddress.cs
@@ -148,7 +148,6 @@ namespace Chorus.VcsDrivers
 		}
 	} // end class RepositoryAddress
 
-	//[Obsolete]
 	public class HttpRepositoryPath : RepositoryAddress
 	{
 		public HttpRepositoryPath(string name, string url, bool isReadOnly, bool resumable = true)

--- a/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/InternetCloneSettingsModelTests.cs
@@ -17,7 +17,9 @@ namespace LibChorus.Tests.Model
 				model.InitFromUri("https://john:myPassword@hg-languageforge.org/tpi?localFolder=tokPisin");
 				Assert.AreEqual("tokPisin", model.LocalFolderName);
 				Assert.IsTrue(model.ReadyToDownload);
-				Assert.AreEqual("https://john:myPassword@hg-languageforge.org/tpi",model.URL);
+				Assert.AreEqual("https://hg-languageforge.org/tpi", model.URL);
+				Assert.AreEqual("john", model.Username);
+				Assert.AreEqual("myPassword", model.Password);
 			}
 		}
 

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeRestApiServerTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeRestApiServerTests.cs
@@ -7,7 +7,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 	class HgResumeRestApiServerTests
 	{
 		[Test]
-		public void Constructor_languageDepotUrl_IdentityAndProjectIdSetCorrectly()
+		public void Constructor_PrivateLanguageForgeUrl_IdentityAndProjectIdSetCorrectly()
 		{
 			var api = new HgResumeRestApiServer("https://hg-private.languageforge.org/kyu-dictionary");
 			Assert.That(api.Host, Is.EqualTo("hg-private.languageforge.org"));
@@ -15,26 +15,11 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		}
 
 		[Test]
-		public void Constructor_languageForgeUrl_IdentityAndProjectIdSetCorrectly()
+		public void Constructor_LanguageForgeUrl_IdentityAndProjectIdSetCorrectly()
 		{
-			var api = new HgResumeRestApiServer("https://hg.languageforge.com/projects/kyu-dictionary");
-			Assert.That(api.Host, Is.EqualTo("hg.languageforge.com"));
+			var api = new HgResumeRestApiServer("https://hg.languageforge.org/projects/kyu-dictionary");
+			Assert.That(api.Host, Is.EqualTo("hg.languageforge.org"));
 			Assert.That(api.ProjectId, Is.EqualTo("kyu-dictionary"));
-		}
-
-		[Test]
-		//colon is probably bogus for a username, but tests escaping well enough
-		public void Username_IsEscapedInUri_IsUnescaped()
-		{
-			var api = new HgResumeRestApiServer("https://user%3aname:password@resumable.languageforge.com/projects/kyu-dictionary");
-			Assert.That(api.UserName, Is.EqualTo("user:name"));
-		}
-
-		[Test]
-		public void Password_IsEscapedInUri_IsUnescaped()
-		{
-			var api = new HgResumeRestApiServer("https://username:pass%3aword@resumable.languageforge.com/projects/kyu-dictionary");
-			Assert.That(api.Password, Is.EqualTo("pass:word"));
 		}
 	}
 }

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgSettingsTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgSettingsTests.cs
@@ -115,7 +115,7 @@ two = https://foo.com");
 			{
 				Chorus.Properties.Settings.Default.LanguageForgeUser = string.Empty;
 				Chorus.Properties.Settings.Default.LanguageForgePass = "password";
-				Assert.IsFalse(GetIsReady(@"LanguageDepot = https://hg-public.languageforge.org/xyz"));
+				Assert.IsFalse(GetIsReady(@"LanguageForge = https://hg-public.languageforge.org/xyz"));
 			}
 		}
 
@@ -126,18 +126,18 @@ two = https://foo.com");
 			{
 				Chorus.Properties.Settings.Default.LanguageForgeUser = "username";
 				Chorus.Properties.Settings.Default.LanguageForgePass = string.Empty;
-				Assert.IsFalse(GetIsReady(@"LanguageDepot = https://hg-public.languageforge.org/xyz"));
+				Assert.IsFalse(GetIsReady(@"LanguageForge = https://hg-public.languageforge.org/xyz"));
 			}
 		}
 
 		[Test]
-		public void GetIsReadyForInternetSendReceive_HasFullLangDepotUrl_ReturnsTrue()
+		public void GetIsReadyForInternetSendReceive_HasFullLangForgeUrlAndCredentials_ReturnsTrue()
 		{
 			using (new MercurialIniForTests())
 			{
 				Chorus.Properties.Settings.Default.LanguageForgeUser = "username";
 				Chorus.Properties.Settings.Default.LanguageForgePass = "password";
-				Assert.IsTrue(GetIsReady(@"LanguageDepot = https://hg-public.languageforge.org/xyz"));
+				Assert.IsTrue(GetIsReady(@"LanguageForge = https://hg-public.languageforge.org/xyz"));
 			}
 		}
 

--- a/src/LibChorusTests/utilities/UrlHelperTests.cs
+++ b/src/LibChorusTests/utilities/UrlHelperTests.cs
@@ -33,6 +33,20 @@ namespace LibChorus.Tests.utilities
 			Assert.AreEqual("lift://somefile.lift", x);
 		}
 
+		[Test]
+		public void StripCredentialsAndQuery_WorksForLift()
+		{
+			var x = UrlHelper.StripCredentialsAndQuery("lift://somefile.lift?label=it's");
+			Assert.AreEqual("lift://somefile.lift", x);
+		}
+
+		[Test]
+		public void StripCredentialsAndQuery_WorksForLanguageForge()
+		{
+			var x = UrlHelper.StripCredentialsAndQuery("https://uname:pass@hg-public.languageforge.org/tpi?localFolder=foo");
+			Assert.AreEqual("https://hg-public.languageforge.org/tpi", x);
+		}
+
 
 		[Test]
 		public void GetUserName_HasUserAndPassword_ReturnsUserName()


### PR DESCRIPTION
* Change LanguageDepot.org projects to use LanguageForge.org
* Convert former LanguageDepot.org projects to https://
* Remove credentials from all URL's; store them securely in user settings
* Completes https://jira.sil.org/browse/LT-20407 and LT-20535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/230)
<!-- Reviewable:end -->
