### PR TITLE
Always display Project ID for existing projects

### DIFF
--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -105,6 +105,7 @@ namespace Chorus.Model
 				Password = HttpUtilityFromMono.UrlDecode(UrlHelper.GetPassword(url));
 			}
 			ProjectId = HttpUtilityFromMono.UrlDecode(UrlHelper.GetPathAfterHost(url));
+			HasLoggedIn = !string.IsNullOrEmpty(ProjectId);
 			Bandwidth = new BandwidthItem(RepositoryAddress.IsKnownResumableRepository(url) ? BandwidthEnum.Low : BandwidthEnum.High);
 
 			const string languageDepot = "languagedepot.org";

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -37,6 +37,16 @@ namespace LibChorus.Tests.Model
 		}
 
 		[Test]
+		public void InitFromUri_FullTypicalLangForge_ExistingProjectIdDisplayedOnLoad(
+			[Values(true, false)] bool hasProjId)
+		{
+			const string proj = "tpi";
+			var m = new ServerSettingsModel();
+			m.InitFromUri($"https://joe:pass@hg-public.languageforge.org/{(hasProjId ? proj : string.Empty)}");
+			Assert.AreEqual(hasProjId, m.HasLoggedIn);
+		}
+
+		[Test]
 		public void InitFromUri_FullTypicalLangForge_DomainAndBandwidthCorrect()
 		{
 			var m = new ServerSettingsModel();


### PR DESCRIPTION
* When initializing server settings from a URI containing a project ID, display it without requiring the user to log in

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/231)
<!-- Reviewable:end -->
