### PR TITLE
Read Indefinite-sized Responses

### DIFF
--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -200,7 +200,7 @@ namespace Chorus.Model
 			try
 			{
 				var response = LogIn();
-				var content = Encoding.UTF8.GetString(WebResponseHelper.ReadResponseContent(response));
+				var content = Encoding.UTF8.GetString(WebResponseHelper.ReadResponseContent(response, 300));
 				HasLoggedIn = true;
 				error = null;
 				SaveUserSettings();

--- a/src/LibChorus/Utilities/WebResponseHelper.cs
+++ b/src/LibChorus/Utilities/WebResponseHelper.cs
@@ -5,24 +5,53 @@ namespace Chorus.Utilities
 {
 	internal class WebResponseHelper
 	{
-		internal static byte[] ReadResponseContent(WebResponse response)
+		internal static byte[] ReadResponseContent(WebResponse response, int expectedLength = 0)
 		{
+			// Get the stream, if any
 			var stream = response.GetResponseStream();
-
-			if (stream == null || string.IsNullOrEmpty(response.Headers["Content-Length"]))
+			if (stream == null)
 			{
 				return new byte[0];
 			}
 
-			var length =  Convert.ToInt32(response.Headers["Content-Length"]);
-			var buffer = new byte[length];
+			// Read the length from the headers, if any
+			var responseContentLength = response.Headers["Content-Length"];
+			int capacity, maxLength;
+			if (string.IsNullOrEmpty(responseContentLength))
+			{
+				capacity = expectedLength;
+				// Any capacity < maxLength can be doubled; this maxLength prevents integer overflow
+				// (not that we expect to download nearly that much data)
+				maxLength = int.MaxValue / 2;
+			}
+			else
+			{
+				capacity = maxLength = Convert.ToInt32(response.Headers["Content-Length"]);
+			}
+
+			var buffer = new byte[capacity];
+			if (capacity == 0)
+			{
+				return buffer;
+			}
+
 			var offset = 0;
 			int bytesRead;
 			do
 			{
-				bytesRead = stream.Read(buffer, offset, length - offset);
+				bytesRead = stream.Read(buffer, offset, capacity - offset);
 				offset += bytesRead;
-			} while (bytesRead > 0 && offset < length);
+				if (offset == capacity && offset < maxLength && bytesRead > 0)
+				{
+					var fullBuffer = buffer;
+					buffer = new byte[capacity * 2];
+					for (var i = 0; i < capacity; i++)
+					{
+						buffer[i] = fullBuffer[i];
+					}
+					capacity = buffer.Length;
+				}
+			} while (bytesRead > 0 && offset < capacity);
 			return buffer;
 		}
 	}


### PR DESCRIPTION
One user has access 200+ projects, and the response headers contain no content length. This tries to read the stream anyway, allowing all projects to be displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/232)
<!-- Reviewable:end -->
