### PR TITLE
[API] Reintroduce default GetCloneFromInternetModel ctor

### DIFF
--- a/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
@@ -12,6 +12,11 @@ namespace Chorus.UI.Clone
 {
 	public class GetCloneFromInternetModel : InternetCloneSettingsModel
 	{
+		public GetCloneFromInternetModel() : base()
+		{
+			ShowCloneOnlyControls = false;
+		}
+
 		public GetCloneFromInternetModel(string parentDirectoryToPutCloneIn): base(parentDirectoryToPutCloneIn)
 		{
 			ShowCloneOnlyControls = true;


### PR DESCRIPTION
A client was using it. This undoes one of several
+semver:breaking changes from the previous commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/244)
<!-- Reviewable:end -->
