### PR TITLE
Fix ChorusHubInstaller build

### DIFF
--- a/build/Chorus.proj
+++ b/build/Chorus.proj
@@ -130,7 +130,7 @@
 
 	</Target>
 
-	<Target Name="ChorusHubInstaller" DependsOnTargets="CleanInstaller; Test" Condition="'$(OS)'=='Windows_NT'">
+	<Target Name="ChorusHubInstaller" DependsOnTargets="CleanInstaller;Build" Condition="'$(OS)'=='Windows_NT'">
 
 		<!-- set the version number in the installer configuration program.  Perhaps there's a way to just send in the variables rather than this brute-force
 		changing of the script, but I haven't figured that out. -->


### PR DESCRIPTION
Building the ChorusHubInstaller should not depend on running the
unit tests but instead on the compile (build) step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/255)
<!-- Reviewable:end -->
