### PR TITLE
Speed up Send/Receive operations significantly

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -688,8 +688,8 @@ namespace Chorus.VcsDrivers.Mercurial
 				} else {
 					_progress.WriteVerbose("Executing and caching: " + command);
 					result = HgRunner.Run("hg " + command, _pathToRepository, secondsBeforeTimeout, _progress);
-					if (!string.IsNullOrEmpty(result.StandardOutput) && result.StandardOutput.StartsWith("000000000000")) {
-						_progress.WriteVerbose("Not caching an all-zero result");
+					if (string.IsNullOrEmpty(result.StandardOutput) || result.StandardOutput.StartsWith(EmptyRepoIdentifier)) {
+						_progress.WriteVerbose("Not caching an empty or all-zero result");
 					} else {
 						_hgLogCache[command] = result;
 					}

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -682,7 +682,9 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (command.StartsWith("log -r") && command.Trim().EndsWith("--template \"{node}\"")) {
+			// There are two exceptions to this: `hg log` commands requesting a negative revision number, which means "N revisions back from tip",
+			// and cases where the result is an all-zero identifier, which usually means the repo is empty and that will change soon.
+			if (command.StartsWith("log -r") && !command.StartsWith("log -r-") && command.Trim().EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + command);
 				} else {

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -460,7 +460,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 		internal string GetTextFromQuery(string query)
 		{
-			ExecutionResult result = ExecuteErrorsOk(query, _pathToRepository, SecondsBeforeTimeoutOnLocalOperation, _progress, _hgLogCache);
+			ExecutionResult result = ExecuteErrorsOk(query, SecondsBeforeTimeoutOnLocalOperation);
 			// Debug.Assert(string.IsNullOrEmpty(result.StandardError), result.StandardError);
 
 			if (!string.IsNullOrEmpty(result.StandardOutput))
@@ -476,7 +476,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 		private string GetTextFromQuery(string query, int secondsBeforeTimeoutOnLocalOperation, IProgress progress)
 		{
-			ExecutionResult result = ExecuteErrorsOk(query, _pathToRepository, secondsBeforeTimeoutOnLocalOperation, _progress, _hgLogCache);
+			ExecutionResult result = ExecuteErrorsOk(query, secondsBeforeTimeoutOnLocalOperation);
 			progress.WriteVerbose(result.StandardOutput);
 			if(!string.IsNullOrEmpty(result.StandardError))
 				progress.WriteError(result.StandardError);
@@ -558,7 +558,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				b.Append(s + " ");
 			}
 
-			ExecutionResult result = ExecuteErrorsOk(b.ToString(), _pathToRepository, secondsBeforeTimeout, _progress, _hgLogCache);
+			ExecutionResult result = ExecuteErrorsOk(b.ToString(), secondsBeforeTimeout);
 			if (HgProcessOutputReader.kCancelled == result.ExitCode)
 			{
 				_progress.WriteWarning("User Cancelled");
@@ -666,9 +666,9 @@ namespace Chorus.VcsDrivers.Mercurial
 		}
 
 		/// <exception cref="System.TimeoutException"/>
-		private static ExecutionResult ExecuteErrorsOk(string command, string fromDirectory, int secondsBeforeTimeout, IProgress progress, IDictionary<string, ExecutionResult> hgLogCache)
+		private ExecutionResult ExecuteErrorsOk(string command, int secondsBeforeTimeout)
 		{
-			if (progress.CancelRequested)
+			if (_progress.CancelRequested)
 			{
 				throw new UserCancelledException();
 			}
@@ -683,16 +683,16 @@ namespace Chorus.VcsDrivers.Mercurial
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
 			if (command != null && command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
-				if (hgLogCache.TryGetValue(command, out result)) {
-					progress.WriteVerbose("Using cached result: " + command);
+				if (_hgLogCache.TryGetValue(command, out result)) {
+					_progress.WriteVerbose("Using cached result: " + command);
 				} else {
-					progress.WriteVerbose("Executing and caching: " + command);
-					result = HgRunner.Run("hg " + command, fromDirectory, secondsBeforeTimeout, progress);
-					hgLogCache[command] = result;
+					_progress.WriteVerbose("Executing and caching: " + command);
+					result = HgRunner.Run("hg " + command, _pathToRepository, secondsBeforeTimeout, _progress);
+					_hgLogCache[command] = result;
 				}
 			} else {
-				progress.WriteVerbose("Executing: " + command);
-				result = HgRunner.Run("hg " + command, fromDirectory, secondsBeforeTimeout, progress);
+				_progress.WriteVerbose("Executing: " + command);
+				result = HgRunner.Run("hg " + command, _pathToRepository, secondsBeforeTimeout, _progress);
 			}
 			if (result.DidTimeOut)
 			{
@@ -704,11 +704,11 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 			if (!string.IsNullOrEmpty(result.StandardError))
 			{
-				progress.WriteVerbose("standerr: " + result.StandardError);//not necessarily and *error*, down this deep
+				_progress.WriteVerbose("standerr: " + result.StandardError);//not necessarily and *error*, down this deep
 			}
 			if (!string.IsNullOrEmpty(result.StandardOutput))
 			{
-				progress.WriteVerbose("standout: " + result.StandardOutput);//not necessarily and *error*, down this deep
+				_progress.WriteVerbose("standout: " + result.StandardOutput);//not necessarily and *error*, down this deep
 			}
 
 #if DEBUG
@@ -1219,7 +1219,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			var f = TempFile.WithExtension(Path.GetExtension(relativePath));
 
 			var cmd = string.Format("cat -o \"{0}\" -r {1} \"{2}\"", f.Path, revOrHash, relativePath);
-			ExecutionResult result = ExecuteErrorsOk(cmd, _pathToRepository, SecondsBeforeTimeoutOnLocalOperation, _progress, _hgLogCache);
+			ExecutionResult result = ExecuteErrorsOk(cmd, SecondsBeforeTimeoutOnLocalOperation);
 			if (!string.IsNullOrEmpty(result.StandardError.Trim()))
 			{
 				// At least zap the temp file, since it isn't to be returned.
@@ -1604,7 +1604,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 
 			// No longer uses "hg incoming", since that takes just as long as a pull, according to the hg mailing list
-			//    ExecutionResult result = ExecuteErrorsOk(string.Format("incoming -l 1 {0}", SurroundWithQuotes(uri)), _pathToRepository, SecondsBeforeTimeoutOnLocalOperation, _progress, _hgLogCache);
+			//    ExecutionResult result = ExecuteErrorsOk(string.Format("incoming -l 1 {0}", SurroundWithQuotes(uri)), SecondsBeforeTimeoutOnLocalOperation);
 			//so we're going to just ping
 
 			try
@@ -2213,7 +2213,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		public void FixUnicodeAudio()
 		{
 			CheckAndUpdateHgrc();
-			ExecuteErrorsOk("addremove -s 100 -I **.wav", _pathToRepository, SecondsBeforeTimeoutOnLocalOperation, _progress, _hgLogCache);
+			ExecuteErrorsOk("addremove -s 100 -I **.wav", SecondsBeforeTimeoutOnLocalOperation);
 		}
 
 		private static string GetUniqueFolderPath(IProgress progress, string proposedTargetDirectory)

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -674,7 +674,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			}
 
 #if DEBUG
-			if (GetHasLocks(fromDirectory, progress))
+			if (GetHasLocks(_pathToRepository, _progress))
 			{
 				progress.WriteWarning("Found a lock before executing: {0}.", command);
 			}
@@ -713,7 +713,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 #if DEBUG
 			//nb: store/lock is so common with recover (in hg 1.3) that we don't even want to mention it
-			if (!command.Contains("recover") && GetHasLocks(fromDirectory, progress))
+			if (!command.Contains("recover") && GetHasLocks(_pathToRepository, _progress))
 			{
 				progress.WriteWarning("{0} left a lock.", command);
 			}

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -682,7 +682,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (command != null && command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
+			if (command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + command);
 				} else {

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -688,7 +688,11 @@ namespace Chorus.VcsDrivers.Mercurial
 				} else {
 					_progress.WriteVerbose("Executing and caching: " + command);
 					result = HgRunner.Run("hg " + command, _pathToRepository, secondsBeforeTimeout, _progress);
-					_hgLogCache[command] = result;
+					if (!string.IsNullOrEmpty(result.StandardOutput) && result.StandardOutput.StartsWith("000000000000")) {
+						_progress.WriteVerbose("Not caching an all-zero result");
+					} else {
+						_hgLogCache[command] = result;
+					}
 				}
 			} else {
 				_progress.WriteVerbose("Executing: " + command);

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -676,7 +676,7 @@ namespace Chorus.VcsDrivers.Mercurial
 #if DEBUG
 			if (GetHasLocks(_pathToRepository, _progress))
 			{
-				progress.WriteWarning("Found a lock before executing: {0}.", command);
+				_progress.WriteWarning("Found a lock before executing: {0}.", command);
 			}
 #endif
 
@@ -715,7 +715,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			//nb: store/lock is so common with recover (in hg 1.3) that we don't even want to mention it
 			if (!command.Contains("recover") && GetHasLocks(_pathToRepository, _progress))
 			{
-				progress.WriteWarning("{0} left a lock.", command);
+				_progress.WriteWarning("{0} left a lock.", command);
 			}
 #endif
 			return result;

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -682,7 +682,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
+			if (command.StartsWith("log -r") && command.Trim().EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + command);
 				} else {


### PR DESCRIPTION
The Send/Receive code does a lot of `hg log -rREV --template "{node}"` calls in order to learn the long hash of a revision number. This happens very often during a Send/Receive process: the Chorus logs are full of `hg log -r0` operations. Thing is, every single call to `hg log` incurs a cost as a Python process has to be spun up every time this happens. And in any given repository, a specific revision number wil always refer to the same revision with the same long hash, so each long hash only has to be calculated *once* for any given revision number. So we'll cache the output of `log -rREV` operations and return the cached output if the same operation runs a second time. (Other operations like `hg parents` aren't safe to cache, as their result will change during a Send/Receive operation as new commits are added to the repo. Only `log -rREV` calls are 100% safe to cache).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/257)
<!-- Reviewable:end -->
