### PR TITLE
Speed up Send/Receive operations significantly

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -687,7 +687,9 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (command.StartsWith("log -r") && command.Trim().EndsWith("--template \"{node}\"")) {
+			// There are two exceptions to this: `hg log` commands requesting a negative revision number, which means "N revisions back from tip",
+			// and cases where the result is an all-zero identifier, which usually means the repo is empty and that will change soon.
+			if (command.StartsWith("log -r") && !command.StartsWith("log -r-") && command.Trim().EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + commandToLog);
 				} else {

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -693,7 +693,11 @@ namespace Chorus.VcsDrivers.Mercurial
 				} else {
 					_progress.WriteVerbose("Executing and caching: " + commandToLog);
 					result = HgRunner.Run("hg " + commandToLog, _pathToRepository, secondsBeforeTimeout, _progress);
-					_hgLogCache[command] = result;
+					if (!string.IsNullOrEmpty(result.StandardOutput) && result.StandardOutput.StartsWith("000000000000")) {
+						_progress.WriteVerbose("Not caching an all-zero result");
+					} else {
+						_hgLogCache[command] = result;
+					}
 				}
 			} else {
 				_progress.WriteVerbose("Executing: " + commandToLog);

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -687,7 +687,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
+			if (command.StartsWith("log -r") && command.Trim().EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + commandToLog);
 				} else {

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -679,7 +679,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			var commandToLog = ServerSettingsModel.RemovePasswordForLog(command);
 
 #if DEBUG
-			if (GetHasLocks(fromDirectory, progress))
+			if (GetHasLocks(_pathToRepository, _progress))
 			{
 				_progress.WriteWarning("Found a lock before executing: {0}.", commandToLog);
 			}
@@ -718,7 +718,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 #if DEBUG
 			//nb: store/lock is so common with recover (in hg 1.3) that we don't even want to mention it
-			if (!commandToLog.Contains("recover") && GetHasLocks(fromDirectory, progress))
+			if (!commandToLog.Contains("recover") && GetHasLocks(_pathToRepository, _progress))
 			{
 				_progress.WriteWarning("{0} left a lock.", commandToLog);
 			}

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -693,7 +693,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				} else {
 					_progress.WriteVerbose("Executing and caching: " + commandToLog);
 					result = HgRunner.Run("hg " + commandToLog, _pathToRepository, secondsBeforeTimeout, _progress);
-					if (!string.IsNullOrEmpty(result.StandardOutput) && result.StandardOutput.StartsWith("000000000000")) {
+					if (!string.IsNullOrEmpty(result.StandardOutput) && result.StandardOutput.StartsWith(EmptyRepoIdentifier)) {
 						_progress.WriteVerbose("Not caching an all-zero result");
 					} else {
 						_hgLogCache[command] = result;

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -687,7 +687,7 @@ namespace Chorus.VcsDrivers.Mercurial
 
 			ExecutionResult result;
 			// The only commands safe to cache are `hg log -rREVNUM --template "{node}"`, as their output never changes for a given repo.
-			if (_hgLogCache != null && command != null && command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
+			if (command.StartsWith("log -r") && command.EndsWith("--template \"{node}\"")) {
 				if (_hgLogCache.TryGetValue(command, out result)) {
 					_progress.WriteVerbose("Using cached result: " + commandToLog);
 				} else {


### PR DESCRIPTION
The Send/Receive code does a lot of `hg log -rREV --template "{node}"` calls in order to learn the long hash of a revision number. This happens very often during a Send/Receive process: the Chorus logs are full of `hg log -r0` operations. Thing is, every single call to `hg log` incurs a cost as a Python process has to be spun up every time this happens. And in any given repository, a specific revision number wil always refer to the same revision with the same long hash, so each long hash only has to be calculated *once* for any given revision number. So we'll cache the output of `log -rREV` operations and return the cached output if the same operation runs a second time. (Other operations like `hg parents` aren't safe to cache, as their result will change during a Send/Receive operation as new commits are added to the repo. Only `log -rREV` calls are 100% safe to cache).

This is PR #257 applied to `master` (#257 is applied to the `lfmerge` branch) as suggested in https://github.com/sillsdev/chorus/pull/257#pullrequestreview-734803492

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/258)
<!-- Reviewable:end -->
