### PR TITLE
[API] Add public property to use private LanguageForge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.0.0] - 2021-10-28
+
+### Fixed
+
+- On Unauthorized Access of ChorusNotes, retry, then ignore; don't crash
+- Use the correct password in request URL's
+- Send/Receive settings dialog is now big enough to display its widgets without cutting them off
+
+### Changed
+
+- Speed up Send/Receive operations by caching hashes
+- Update to the latest version of Palaso libraries (9.0.0)
+- Use CrossPlatformSettingsProvider for settings (Requires migration to retain old settings; client's responsibility)
+- When there is only one available Project, populate the Project ID combobox
+
 ## [4.0.0] - 2021-04-30
 
 ### Changed

--- a/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetModel.cs
@@ -12,7 +12,8 @@ namespace Chorus.UI.Clone
 {
 	public class GetCloneFromInternetModel : InternetCloneSettingsModel
 	{
-		public GetCloneFromInternetModel() : base()
+		// ReSharper disable once UnusedMember.Global (used by clients)
+		public GetCloneFromInternetModel()
 		{
 			ShowCloneOnlyControls = false;
 		}
@@ -26,20 +27,20 @@ namespace Chorus.UI.Clone
 
 		public bool CancelRequested
 		{
-			get { return _progress.CancelRequested; }
-			set { _progress.CancelRequested = value; }
+			get => _progress.CancelRequested;
+			set => _progress.CancelRequested = value;
 		}
 
 		public IProgressIndicator ProgressIndicator
 		{
-			get { return _progress.ProgressIndicator; }
-			set { _progress.ProgressIndicator = value; }
+			get => _progress.ProgressIndicator;
+			set => _progress.ProgressIndicator = value;
 		}
 
 		public SynchronizationContext UIContext
 		{
-			get { return _progress.SyncContext; }
-			set { _progress.SyncContext = value; }
+			get => _progress.SyncContext;
+			set => _progress.SyncContext = value;
 		}
 
 		///<returns>true if successful; false if failed</returns>

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -20,10 +20,10 @@ namespace Chorus.UI.Misc
 		{
 			InitializeComponent();
 
-			_serverLabel.Visible = ServerSettingsModel.IsQaServer;
+			_serverLabel.Visible = ServerSettingsModel.IsQaServer || ServerSettingsModel.IsPrivateServer;
 			if (_serverLabel.Visible)
 			{
-				_serverLabel.Text = string.Format(_serverLabel.Text, ServerSettingsModel.LanguageForgeServer);
+				_serverLabel.Text = string.Format(_serverLabel.Text, $"{(ServerSettingsModel.IsPrivateServer ? "private" : null)}{ServerSettingsModel.LanguageForgeServer}");
 			}
 
 			_bandwidth.Items.AddRange(ServerSettingsModel.Bandwidths);

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -11,7 +11,6 @@ using Chorus.VcsDrivers.Mercurial;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.Code;
-using SIL.Network;
 using SIL.Progress;
 
 namespace Chorus.Model
@@ -20,7 +19,7 @@ namespace Chorus.Model
 	{
 		#region static and constant
 		private const string LanguageForge = "languageforge.org";
-		private const string ServerEnvVar = "LANGUAGEFORGESERVER";
+		internal const string ServerEnvVar = "LANGUAGEFORGESERVER";
 
 		public static string LanguageForgeServer
 		{
@@ -32,6 +31,8 @@ namespace Chorus.Model
 		}
 
 		public static bool IsQaServer => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(ServerEnvVar));
+
+		public static bool IsPrivateServer { get; set; }
 
 		private const string EntropyValue = "LAMED videte si est dolor sicut dolor meus";
 
@@ -146,7 +147,7 @@ namespace Chorus.Model
 
 		protected internal string Host => IsCustomUrl
 			? UrlHelper.GetHost(CustomUrl)
-			: $"{(Bandwidth.Value == BandwidthEnum.Low ? "resumable" : "hg-public")}{LanguageForgeServer}";
+			: $"{(Bandwidth.Value == BandwidthEnum.Low ? "resumable" : IsPrivateServer ? "hg-private" : "hg-public")}{LanguageForgeServer}";
 
 
 		public bool HaveGoodUrl
@@ -220,6 +221,7 @@ namespace Chorus.Model
 				HasLoggedIn = true;
 				error = null;
 				PasswordForSession = Password;
+				// ENHANCE (Hasso) 2021.12: SaveUserSettings();
 
 				// Do this last so the user is "logged in" even if JSON parsing crashes
 				PopulateAvailableProjects(content);
@@ -232,6 +234,12 @@ namespace Chorus.Model
 					case HttpStatusCode.NotFound:
 					case HttpStatusCode.Forbidden:
 						error = LocalizationManager.GetString("ServerSettings.LogIn.BadUserOrPass", "Incorrect username or password");
+						if (IsPrivateServer)
+						{
+							HasLoggedIn = true;
+							error = LocalizationManager.GetString("ServerSettings.PossibleErrorPrivateServer",
+								"Your projects on the private server could not be listed, but you may still be able to download them.");
+						}
 						break;
 					default:
 						error = e.Message;
@@ -247,7 +255,8 @@ namespace Chorus.Model
 
 		private WebResponse LogIn()
 		{
-			var request = WebRequest.Create($"https://admin{LanguageForgeServer}/api/user/{Username}/projects");
+			var privateQuery = IsPrivateServer ? "?private=true" : string.Empty;
+			var request = WebRequest.Create($"https://admin{LanguageForgeServer}/api/user/{Username}/projects{privateQuery}");
 			request.Method = "POST";
 			var passwordBytes = Encoding.UTF8.GetBytes($"password={Password}");
 			request.ContentType = "application/x-www-form-urlencoded";


### PR DESCRIPTION
[API] Add public property to use private LanguageForge 

Add static bool ServerSettingsModel.IsPrivateServer; if set to true, will use the private LanguageForge server.

- Show the server URL label next to the Log in button when using the private or QA server
- WIP: try to list private projects, but continue with a warning on errors (TODO: verify LF has implemented this API; it is not documented)

+semver: minor