### PR TITLE
LT-20999: Move the location of the local Chorus cache

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -908,17 +908,16 @@ namespace Chorus.VcsDrivers.Mercurial
 		}
 
 		///<summary>
-		/// returns something like %AppData%\Chorus\ChorusStorage\uniqueRepoId
+		/// returns something like:
+		/// FLEX:	C:\ProgramData\SIL\FieldWorks\Projects\<ProjectName>\OtherRepositories\<ProjectName>_LIFT\Chorus\ChorusStorage
+		/// WeSay:	%USERPROFILE%\Documents\WeSay\<ProjectName>\Chorus\ChorusStorage
 		///</summary>
 		public string PathToLocalStorage
 		{
 			get
 			{
-				string appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Chorus");
-				return Path.Combine(appDataPath,
-									Path.Combine("ChorusStorage",
-												 RepoIdentifier)
-					);
+				string chorusPath = Path.Combine(_repo.PathToRepo, "Chorus");
+				return Path.Combine(chorusPath, "ChorusStorage");
 			}
 		}
 

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -916,8 +916,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 			get
 			{
-				string chorusPath = Path.Combine(_repo.PathToRepo, "Chorus");
-				return Path.Combine(chorusPath, "ChorusStorage");
+				return Path.Combine(_repo.PathToRepo, "Chorus", "ChorusStorage");
 			}
 		}
 


### PR DESCRIPTION
Move the location of the local Chorus cache from AppData to the
specific FLEX or WeSay project.  The problem we were seeing was when
the cache in AppData was being used by two applications; in this
case FLEX and WeSay. (Note that the same problem would exist if two
local WeSay projects or two local FLEX project were using the same
Chorus Project ID.)
When the cache was more up to date than the local FLEX or WeSay
project we would see the error described in the defect. To prevent
this problem we now store the cache in the local FLEX or WeSay
project folder, along with the other project information. This
results in one cache per application/project, so the cache should
never have more up to date chorus data than the local FLEX or
WeSay project.
https://jira.sil.org/browse/LT-20999

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/280)
<!-- Reviewable:end -->
