### PR TITLE
LT-20867: Cleanup Flexbridge login dialog

### DIFF
--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.Designer.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.Designer.cs
@@ -243,7 +243,10 @@ namespace Chorus.UI.Clone
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
 			this.Text = "Get Project From Internet";
 			this.Load += new System.EventHandler(this.OnLoad);
+			this.ResizeBegin += new System.EventHandler(this.GetCloneFromInternetDialog_ResizeBegin);
+			this.ResizeEnd += new System.EventHandler(this.GetCloneFromInternetDialog_ResizeEnd);
 			this.BackColorChanged += new System.EventHandler(this.GetCloneFromInternetDialog_BackColorChanged);
+			this.Paint += new System.Windows.Forms.PaintEventHandler(this.GetCloneFromInternetDialog_Paint);
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -19,6 +19,7 @@ namespace Chorus.UI.Clone
 		private TargetFolderControl _targetFolderControl;
 		private State _state;
 		private ServerSettingsControl _serverSettingsControl;
+		private bool _resizing = false;
 
 		public GetCloneFromInternetDialog(string parentDirectoryToPutCloneIn)
 			:this(new GetCloneFromInternetModel(parentDirectoryToPutCloneIn))
@@ -312,6 +313,25 @@ namespace Chorus.UI.Clone
 		private void GetCloneFromInternetDialog_BackColorChanged(object sender, EventArgs e)
 		{
 			_logBox.BackColor  =this.BackColor;
+		}
+
+		private void GetCloneFromInternetDialog_ResizeBegin(object sender, EventArgs e)
+		{
+			_resizing = true;
+		}
+
+		private void GetCloneFromInternetDialog_ResizeEnd(object sender, EventArgs e)
+		{
+			_resizing = false;
+		}
+
+		private void GetCloneFromInternetDialog_Paint(object sender, PaintEventArgs e)
+		{
+			if (_resizing)
+			{
+				_targetFolderControl._downloadButton.Top = _okButton.Top - _targetFolderControl.Top;
+				_targetFolderControl._downloadButton.Left = _okButton.Left - 15;
+			}
 		}
 	}
 }

--- a/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
@@ -50,14 +50,14 @@ namespace Chorus.UI.Misc
 			this._serverLabel = new System.Windows.Forms.Label();
 			this._tlpPassword = new System.Windows.Forms.TableLayoutPanel();
 			this._checkRememberPassword = new System.Windows.Forms.CheckBox();
-			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._tlpUsername = new System.Windows.Forms.TableLayoutPanel();
+			this.l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this.tableLayoutPanel1.SuspendLayout();
 			this._tlpCustomUrl.SuspendLayout();
 			this._tlpLogIn.SuspendLayout();
 			this._tlpPassword.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
 			this._tlpUsername.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
 			this.SuspendLayout();
 			//
 			// _projectIdLabel
@@ -67,7 +67,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._projectIdLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._projectIdLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._projectIdLabel, "ServerSettingsControl.ProjectId");
-			this._projectIdLabel.Location = new System.Drawing.Point(23, 182);
+			this._projectIdLabel.Location = new System.Drawing.Point(16, 182);
 			this._projectIdLabel.Name = "_projectIdLabel";
 			this._projectIdLabel.Size = new System.Drawing.Size(54, 13);
 			this._projectIdLabel.TabIndex = 29;
@@ -80,7 +80,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._accountLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._accountLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._accountLabel, "ServerSettingsControl.Login");
-			this._accountLabel.Location = new System.Drawing.Point(44, 10);
+			this._accountLabel.Location = new System.Drawing.Point(37, 10);
 			this._accountLabel.Name = "_accountLabel";
 			this._accountLabel.Size = new System.Drawing.Size(33, 13);
 			this._accountLabel.TabIndex = 2;
@@ -93,7 +93,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._passwordLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._passwordLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._passwordLabel, "ServerSettingsControl.Password");
-			this._passwordLabel.Location = new System.Drawing.Point(24, 44);
+			this._passwordLabel.Location = new System.Drawing.Point(17, 44);
 			this._passwordLabel.Name = "_passwordLabel";
 			this._passwordLabel.Size = new System.Drawing.Size(53, 13);
 			this._passwordLabel.TabIndex = 8;
@@ -107,7 +107,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizingId(this._username, "ServerSettingsControl.ServerSettingsControl._username");
 			this._username.Location = new System.Drawing.Point(3, 7);
 			this._username.Name = "_username";
-			this._username.Size = new System.Drawing.Size(231, 20);
+			this._username.Size = new System.Drawing.Size(236, 20);
 			this._username.TabIndex = 2;
 			this.toolTip1.SetToolTip(this._username, "This is your account on the server, which must already be set up.");
 			this._username.TextChanged += new System.EventHandler(this._username_TextChanged);
@@ -122,7 +122,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizingId(this._password, "ServerSettingsControl.ServerSettingsControl._password");
 			this._password.Location = new System.Drawing.Point(3, 7);
 			this._password.Name = "_password";
-			this._password.Size = new System.Drawing.Size(231, 20);
+			this._password.Size = new System.Drawing.Size(236, 20);
 			this._password.TabIndex = 8;
 			this.toolTip1.SetToolTip(this._password, "This is the password belonging to this account, as it was set up on the server.");
 			this._password.UseSystemPasswordChar = true;
@@ -137,7 +137,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._customUrlLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._customUrlLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._customUrlLabel, "ServerSettingsControl.URL");
-			this._customUrlLabel.Location = new System.Drawing.Point(10, 78);
+			this._customUrlLabel.Location = new System.Drawing.Point(3, 78);
 			this._customUrlLabel.Name = "_customUrlLabel";
 			this._customUrlLabel.Size = new System.Drawing.Size(67, 13);
 			this._customUrlLabel.TabIndex = 17;
@@ -146,16 +146,14 @@ namespace Chorus.UI.Misc
 			// tableLayoutPanel1
 			//
 			this.tableLayoutPanel1.ColumnCount = 2;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, Platform.IsMono ? 120F : 80F));
 			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 99F));
 			this.tableLayoutPanel1.Controls.Add(this._projectIdLabel, 0, 5);
 			this.tableLayoutPanel1.Controls.Add(this._customUrlLabel, 0, 2);
 			this.tableLayoutPanel1.Controls.Add(this._passwordLabel, 0, 1);
 			this.tableLayoutPanel1.Controls.Add(this._bandwidthLabel, 0, 4);
 			this.tableLayoutPanel1.Controls.Add(this._accountLabel, 0, 0);
-			this.tableLayoutPanel1.Controls.Add(this._username, 1, 0);
 			this.tableLayoutPanel1.Controls.Add(this._tlpCustomUrl, 1, 2);
-			this.tableLayoutPanel1.Controls.Add(this._password, 1, 1);
 			this.tableLayoutPanel1.Controls.Add(this._bandwidth, 1, 4);
 			this.tableLayoutPanel1.Controls.Add(this._projectId, 1, 5);
 			this.tableLayoutPanel1.Controls.Add(this._tlpLogIn, 1, 3);
@@ -181,7 +179,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._bandwidthLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._bandwidthLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._bandwidthLabel, "ServerSettingsControl.Server");
-			this._bandwidthLabel.Location = new System.Drawing.Point(20, 146);
+			this._bandwidthLabel.Location = new System.Drawing.Point(13, 146);
 			this._bandwidthLabel.Name = "_bandwidthLabel";
 			this._bandwidthLabel.Size = new System.Drawing.Size(57, 13);
 			this._bandwidthLabel.TabIndex = 25;
@@ -189,21 +187,18 @@ namespace Chorus.UI.Misc
 			// 
 			// _tlpCustomUrl
 			//
-			this._tlpCustomUrl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
 			this._tlpCustomUrl.ColumnCount = 2;
 			this._tlpCustomUrl.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
 			this._tlpCustomUrl.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this._tlpCustomUrl.Controls.Add(this._checkCustomUrl, 0, 0);
 			this._tlpCustomUrl.Controls.Add(this._customUrl, 1, 0);
 			this._tlpCustomUrl.Dock = System.Windows.Forms.DockStyle.Fill;
-			this._tlpCustomUrl.Location = new System.Drawing.Point(80, 68);
+			this._tlpCustomUrl.Location = new System.Drawing.Point(73, 68);
 			this._tlpCustomUrl.Margin = new System.Windows.Forms.Padding(0);
 			this._tlpCustomUrl.Name = "_tlpCustomUrl";
 			this._tlpCustomUrl.RowCount = 1;
 			this._tlpCustomUrl.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tlpCustomUrl.Size = new System.Drawing.Size(360, 34);
+			this._tlpCustomUrl.Size = new System.Drawing.Size(367, 34);
 			this._tlpCustomUrl.TabIndex = 17;
 			//
 			// _checkCustomUrl
@@ -228,65 +223,66 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizingId(this._customUrl, "ServerSettingsControl.ServerSettingsControl._customUrl");
 			this._customUrl.Location = new System.Drawing.Point(23, 7);
 			this._customUrl.Name = "_customUrl";
-			this._customUrl.Size = new System.Drawing.Size(334, 20);
+			this._customUrl.Size = new System.Drawing.Size(341, 20);
 			this._customUrl.TabIndex = 18;
 			this._customUrl.TextChanged += new System.EventHandler(this._customUrl_TextChanged);
 			//
 			// _bandwidth
 			// 
-			this._bandwidth.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+			this._bandwidth.Dock = System.Windows.Forms.DockStyle.Fill;
 			this._bandwidth.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._bandwidth.FormattingEnabled = true;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._bandwidth, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._bandwidth, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._bandwidth, "ServerSettingsControl.comboBox1");
-			this._bandwidth.Location = new System.Drawing.Point(83, 142);
+			this._bandwidth.Location = new System.Drawing.Point(76, 139);
 			this._bandwidth.Name = "_bandwidth";
-			this._bandwidth.Size = new System.Drawing.Size(354, 21);
+			this._bandwidth.Size = new System.Drawing.Size(361, 21);
 			this._bandwidth.TabIndex = 25;
 			this._bandwidth.SelectedIndexChanged += new System.EventHandler(this._bandwidth_SelectedIndexChanged);
 			//
 			// _projectId
 			//
-			this._projectId.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
 			this._projectId.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
 			this._projectId.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+			this._projectId.Dock = System.Windows.Forms.DockStyle.Fill;
 			this._projectId.FormattingEnabled = true;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._projectId, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._projectId, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._projectId, "ServerSettingsControl.comboBox2");
-			this._projectId.Location = new System.Drawing.Point(83, 178);
+			this._projectId.Location = new System.Drawing.Point(76, 173);
 			this._projectId.Name = "_projectId";
-			this._projectId.Size = new System.Drawing.Size(354, 21);
+			this._projectId.Size = new System.Drawing.Size(361, 21);
 			this._projectId.TabIndex = 29;
 			this._projectId.TextChanged += new System.EventHandler(this._projectId_TextChanged);
 			//
 			// _tlpLogIn
 			//
 			this._tlpLogIn.ColumnCount = 2;
-			this._tlpLogIn.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+			this._tlpLogIn.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this._tlpLogIn.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this._tlpLogIn.Controls.Add(this._buttonLogIn, 0, 0);
 			this._tlpLogIn.Controls.Add(this._serverLabel, 1, 0);
 			this._tlpLogIn.Dock = System.Windows.Forms.DockStyle.Fill;
-			this._tlpLogIn.Location = new System.Drawing.Point(80, 102);
+			this._tlpLogIn.Location = new System.Drawing.Point(73, 102);
 			this._tlpLogIn.Margin = new System.Windows.Forms.Padding(0);
 			this._tlpLogIn.Name = "_tlpLogIn";
 			this._tlpLogIn.RowCount = 1;
 			this._tlpLogIn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tlpLogIn.Size = new System.Drawing.Size(360, 34);
+			this._tlpLogIn.Size = new System.Drawing.Size(367, 34);
 			this._tlpLogIn.TabIndex = 22;
 			//
 			// _buttonLogIn
 			//
+			this._buttonLogIn.AutoSize = true;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._buttonLogIn, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._buttonLogIn, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._buttonLogIn, "ServerSettingsControl.button1");
 			this._buttonLogIn.Location = new System.Drawing.Point(3, 3);
 			this._buttonLogIn.Name = "_buttonLogIn";
-			this._buttonLogIn.Size = new System.Drawing.Size(75, 24);
+			this._buttonLogIn.Size = new System.Drawing.Size(102, 24);
 			this._buttonLogIn.TabIndex = 22;
-			this._buttonLogIn.Text = "&Log in";
+			this._buttonLogIn.Text = "&Log in to continue";
 			this._buttonLogIn.UseVisualStyleBackColor = true;
 			this._buttonLogIn.Click += new System.EventHandler(this._buttonLogIn_Click);
 			//
@@ -297,7 +293,7 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._serverLabel, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._serverLabel, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._serverLabel, "ServerSettingsControl.label1");
-			this._serverLabel.Location = new System.Drawing.Point(89, 10);
+			this._serverLabel.Location = new System.Drawing.Point(111, 10);
 			this._serverLabel.Name = "_serverLabel";
 			this._serverLabel.Size = new System.Drawing.Size(33, 13);
 			this._serverLabel.TabIndex = 23;
@@ -311,12 +307,12 @@ namespace Chorus.UI.Misc
 			this._tlpPassword.Controls.Add(this._password, 0, 0);
 			this._tlpPassword.Controls.Add(this._checkRememberPassword, 1, 0);
 			this._tlpPassword.Dock = System.Windows.Forms.DockStyle.Fill;
-			this._tlpPassword.Location = new System.Drawing.Point(80, 34);
+			this._tlpPassword.Location = new System.Drawing.Point(73, 34);
 			this._tlpPassword.Margin = new System.Windows.Forms.Padding(0);
 			this._tlpPassword.Name = "_tlpPassword";
 			this._tlpPassword.RowCount = 1;
 			this._tlpPassword.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tlpPassword.Size = new System.Drawing.Size(360, 34);
+			this._tlpPassword.Size = new System.Drawing.Size(367, 34);
 			this._tlpPassword.TabIndex = 8;
 			//
 			// _checkRememberPassword
@@ -326,33 +322,33 @@ namespace Chorus.UI.Misc
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._checkRememberPassword, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this._checkRememberPassword, null);
 			this.l10NSharpExtender1.SetLocalizingId(this._checkRememberPassword, "ServerSettingsControl.checkBox1");
-			this._checkRememberPassword.Location = new System.Drawing.Point(240, 8);
+			this._checkRememberPassword.Location = new System.Drawing.Point(245, 8);
 			this._checkRememberPassword.Name = "_checkRememberPassword";
-			this._checkRememberPassword.Size = new System.Drawing.Size(117, 17);
+			this._checkRememberPassword.Size = new System.Drawing.Size(119, 17);
 			this._checkRememberPassword.TabIndex = 9;
 			this._checkRememberPassword.Text = "&Remember";
 			this._checkRememberPassword.UseVisualStyleBackColor = true;
 			this._checkRememberPassword.CheckedChanged += new System.EventHandler(this._checkRememberPassword_CheckedChanged);
 			//
-			// l10NSharpExtender1
-			//
-			this.l10NSharpExtender1.LocalizationManagerId = "Chorus";
-			this.l10NSharpExtender1.PrefixForNewItems = "ServerSettingsControl";
-			//
 			// _tlpUsername
-			// 
+			//
 			this._tlpUsername.ColumnCount = 2;
 			this._tlpUsername.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 66F));
 			this._tlpUsername.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 34F));
 			this._tlpUsername.Controls.Add(this._username, 0, 0);
 			this._tlpUsername.Dock = System.Windows.Forms.DockStyle.Fill;
-			this._tlpUsername.Location = new System.Drawing.Point(80, 0);
+			this._tlpUsername.Location = new System.Drawing.Point(73, 0);
 			this._tlpUsername.Margin = new System.Windows.Forms.Padding(0);
 			this._tlpUsername.Name = "_tlpUsername";
 			this._tlpUsername.RowCount = 1;
 			this._tlpUsername.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this._tlpUsername.Size = new System.Drawing.Size(360, 34);
+			this._tlpUsername.Size = new System.Drawing.Size(367, 34);
 			this._tlpUsername.TabIndex = 2;
+			//
+			// l10NSharpExtender1
+			//
+			this.l10NSharpExtender1.LocalizationManagerId = "Chorus";
+			this.l10NSharpExtender1.PrefixForNewItems = "ServerSettingsControl";
 			// 
 			// ServerSettingsControl
 			//
@@ -373,9 +369,9 @@ namespace Chorus.UI.Misc
 			this._tlpLogIn.PerformLayout();
 			this._tlpPassword.ResumeLayout(false);
 			this._tlpPassword.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
 			this._tlpUsername.ResumeLayout(false);
 			this._tlpUsername.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
 			this.ResumeLayout(false);
 
 		}

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -81,7 +81,6 @@ namespace Chorus.UI.Misc
 		private void _username_TextChanged(object sender, EventArgs e)
 		{
 			Model.Username = _username.Text;
-			Model.UsernameOrPasswordEdited = true;
 			UpdateDisplay();
 		}
 
@@ -115,7 +114,6 @@ namespace Chorus.UI.Misc
 		private void _password_TextChanged(object sender, EventArgs e)
 		{
 			Model.Password = _password.Text.Trim();
-			Model.UsernameOrPasswordEdited = true;
 			UpdateDisplay();
 		}
 

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -81,6 +81,7 @@ namespace Chorus.UI.Misc
 		private void _username_TextChanged(object sender, EventArgs e)
 		{
 			Model.Username = _username.Text;
+			Model.UsernameOrPasswordEdited = true;
 			UpdateDisplay();
 		}
 
@@ -114,6 +115,7 @@ namespace Chorus.UI.Misc
 		private void _password_TextChanged(object sender, EventArgs e)
 		{
 			Model.Password = _password.Text.Trim();
+			Model.UsernameOrPasswordEdited = true;
 			UpdateDisplay();
 		}
 

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -164,8 +164,29 @@ namespace Chorus.Model
 		}
 
 		public bool RememberPassword { get; set; }
-		public string Password { get; set; }
-		public string Username { get; set; }
+
+		private string _password;
+		public string Password
+		{
+			get { return _password; }
+			set
+			{
+				_password = value;
+				UsernameOrPasswordEdited = true;
+			}
+		}
+
+		private string _username;
+		public string Username
+		{
+			get { return _username; }
+			set
+			{
+				_username = value;
+				UsernameOrPasswordEdited = true;
+			}
+		}
+
 		public bool IsCustomUrl { get; set; }
 		public string CustomUrl { get; set; }
 		public BandwidthItem Bandwidth { get; set; } = Bandwidths[0];
@@ -209,7 +230,7 @@ namespace Chorus.Model
 		/// True if the username or password value has been edited since the
 		/// last log in.
 		/// </summary>
-		public bool UsernameOrPasswordEdited { get; set; }
+		private bool UsernameOrPasswordEdited { get; set; }
 
 		/// <summary>
 		/// Save the settings in the folder's .hg, creating the folder and settings if necessary.

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -175,9 +175,41 @@ namespace Chorus.Model
 		/// <summary>
 		/// True if the user has logged in since this ServerSettingsModel was created, or has already connected this project to an internet server.
 		/// </summary>
-		public bool HasLoggedIn { get; set; }
+		private bool _hasLoggedIn = false;
+		public bool HasLoggedIn
+		{
+			get { return _hasLoggedIn; }
+			set
+			{
+				_hasLoggedIn = value;
 
-		public bool CanLogIn => !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password);
+				if (_hasLoggedIn)
+					UsernameOrPasswordEdited = false;
+			}
+		}
+
+		/// <summary>
+		/// User can log in if:
+		/// Username and Password are not empty
+		/// AND
+		/// User has not logged in OR they have logged in but have made addition
+		/// edits to either the username or password.
+		/// </summary>
+		public bool CanLogIn
+		{
+			get
+			{
+				return !string.IsNullOrEmpty(Username) &&
+					   !string.IsNullOrEmpty(Password) &&
+						HasLoggedIn ? UsernameOrPasswordEdited : true;
+			}
+		}
+
+		/// <summary>
+		/// True if the username or password value has been edited since the
+		/// last log in.
+		/// </summary>
+		public bool UsernameOrPasswordEdited { get; set; }
 
 		/// <summary>
 		/// Save the settings in the folder's .hg, creating the folder and settings if necessary.


### PR DESCRIPTION
1. Change the ‘Log in’ button to “Log in to continue’.
2. Disable the ‘Log in to continue’ button when logged in and no
   edits have been made to either the username or password fields.
3. Changed the Bandwidth and Project Id combo boxes so they are not
   clipped.
4. Change the Download button so it remains in the same relative
   position when the dialog is resized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/281)
<!-- Reviewable:end -->
