### PR TITLE
Update changelog and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- [SIL.Chorus.ChorusMerge] Additionally build with .net 6
+- [SIL.Chorus.LibChorus] Add netstandard 2.0
+
+## [5.0.0] - 2022-09-13
+
 ### Added
 
 - Add static bool ServerSettingsModel.IsPrivateServer to allow clients to select the private LanguageForge
-
-## [5.0.0] - 2021-10-28
 
 ### Fixed
 
@@ -31,9 +36,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Speed up Send/Receive operations by caching hashes
-- Update to the latest version of Palaso libraries (9.0.0)
+- Update to the latest version of Palaso libraries (10.0.0)
 - Use CrossPlatformSettingsProvider for settings (Requires migration to retain old settings; client's responsibility)
 - When there is only one available Project, populate the Project ID combobox
+- Update SIL.Chorus.Mercurial dependency to the latest version which looks for python2
 
 ## [4.0.0] - 2021-04-30
 
@@ -43,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.0.0] - non-nuget version
 
-[Unreleased]: https://github.com/sillsdev/libpalaso/compare/v4.0.0...master
+[Unreleased]: https://github.com/sillsdev/libpalaso/compare/v5.0.0...master
 
+[5.0.0]: https://github.com/sillsdev/libpalaso/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/sillsdev/libpalaso/compare/v3.0.0...v4.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>chorus</Product>
-    <Copyright>Copyright © 2010-2021 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2022 SIL International</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/chorus</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Overview
-========
+# Overview
+
+[![NuGet version (chorus)](https://img.shields.io/nuget/v/SIL.Chorus.LibChorus.svg?style=flat-square)](https://www.nuget.org/packages/SIL.Chorus.LibChorus)
+[![Build, Test and Pack](https://github.com/sillsdev/chorus/actions/workflows/dotnet.yml/badge.svg)](https://github.com/sillsdev/chorus/actions/workflows/dotnet.yml)
 
 Chorus is a version control system designed to enable workflows appropriate for typical language
 development teams who are geographically distributed. These teams need to edit a set of common
@@ -101,9 +103,20 @@ Chorus is written in C#. The UI widgets use Windows Forms, but you could make yo
 different platform and just use the engine.
 
 After cloning the project you should now have a solution that you can build using any edition
-of Visual Studio 2019, including the free Express version, or Visual Studio Code.
+of Visual Studio 2022, including the free Express version, JetBrains Rider or
+Visual Studio Code. This works on both Windows and Linux.
 
-On Linux you can open and build the solution in MonoDevelop, or run the `build/TestBuild.sh` script.
+From the command line you can build with:
+
+```bash
+dotnet build
+```
+
+and run the unit tests with:
+
+```bash
+dotnet test
+```
 
 ### Building client projects against locally-built artifacts
 


### PR DESCRIPTION
This change updates `CHANGELOG.md` - we never released a v5.0.0 despite the entry in the changelog, and adjust the wording to
reality since the non-existing release.

Also up-ing the minor version number because the previous commit added support for netstandard 2.0/.net 6.

+semver:minor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/290)
<!-- Reviewable:end -->
