### PR TITLE
Add Microsoft.NET.Test.Sdk to test projects

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,10 +25,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
 
-    env:
-      FILTER: '--filter TestCategory!=RequiresUI'
-      if: runner.os == 'Linux'
-
     steps:
     - name: Checkout
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -46,8 +42,16 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release
 
-    - name: Test
-      run: dotnet test --no-build -c Release ${{env.FILTER}} -- NUnit.TestOutputXml=TestResults
+    # Unfortunately we need two test steps because we need different filters.
+    # We could conditionally set an environment variable, but unfortunately
+    # the syntax to access that is different on Windows vs Linux.
+    - name: Test on Linux
+      run: dotnet test --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Test on Windows
+      run: dotnet test --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      if: matrix.os == 'windows-latest'
 
     - name: Upload Test Results
       if: always()

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,6 +25,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
 
+    env:
+      FILTER: '--filter TestCategory!=RequiresUI'
+      if: runner.os == 'Linux'
+
     steps:
     - name: Checkout
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -43,9 +47,7 @@ jobs:
       run: dotnet build --no-restore -c Release
 
     - name: Test
-      # it would be nice to run tests with `--no-build -c Release` but that causes test
-      # failures on Ubuntu where it suddenly can't open the display.
-      run: dotnet test -- NUnit.TestOutputXml=TestResults
+      run: dotnet test --no-build -c Release ${{env.FILTER}} -- NUnit.TestOutputXml=TestResults
 
     - name: Upload Test Results
       if: always()

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -10,10 +10,18 @@ extraction:
   csharp:
     after_prepare:
       - git branch -f PR && git checkout PR
+    index:
+      # LGTM doesn't support .NET 6.0 which we use, so we tell LGTM to analyze
+      # the code without building which is less accurate but at least doesn't fail
+      # the check
+      buildless: true
+      nuget_restore: false
 
 queries:
-  # Exclude python queries
+  # Exclude python queries. Also exclude all other queries since that would cause a
+  # failing check again.
   - exclude: py/*
+  - exclude: "*"
 
   # The following queries are irrelevant for desktop apps
   - exclude: cs/path-injection         # Uncontrolled data used in path expression

--- a/src/Chorus.Tests/Chorus.Tests.csproj
+++ b/src/Chorus.Tests/Chorus.Tests.csproj
@@ -10,8 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Chorus.Tests/ChorusApplicationTests.cs
+++ b/src/Chorus.Tests/ChorusApplicationTests.cs
@@ -25,6 +25,7 @@ namespace Chorus.Tests
 
 		[Test]
 		[Category("SkipOnBuildServer")]
+		[Category("RequiresUI")]
 		public void Launch_CloseAfterAFewSeconds_DoesntCrash()
 		{
 			using (var folder = new TemporaryFolder("ChorusApplicationTests"))

--- a/src/Chorus.Tests/ChorusSystemTests.cs
+++ b/src/Chorus.Tests/ChorusSystemTests.cs
@@ -70,6 +70,7 @@ namespace Chorus.Tests
 		/// found at compile time
 		/// </summary>
 		[Test]
+		[Category("RequiresUI")]
 		public void CanShowNotesBar()
 		{
 			using (var view =
@@ -80,6 +81,7 @@ namespace Chorus.Tests
 		}
 
 		[Test]
+		[Category("RequiresUI")]
 		public void CanMakeNotesBarWithOtherFiles()
 		{
 			using (var otherFile = new TempFileFromFolder(_folder, "two.txt", "just a pretend file"))

--- a/src/Chorus.Tests/ChorusSystemUsage.cs
+++ b/src/Chorus.Tests/ChorusSystemUsage.cs
@@ -119,6 +119,7 @@ namespace Chorus.Tests
 		/// get group annotation ability with just a few lines of code.
 		/// </summary>
 		[Test]
+		[Category("RequiresUI")]
 		public void CreateNotesBar()
 		{
 			//Tell Chorus how to map between our records and the url system we want to use in notes
@@ -162,8 +163,8 @@ namespace Chorus.Tests
 		/// tools to search and filter them.
 		/// </summary>
 		[Test]
-	[Category("KnownMonoIssue")] //running CreateNotesBrowser twice in a mono test session causes a crash
-	[Platform(Exclude="Mono")]
+		[Category("KnownMonoIssue")] //running CreateNotesBrowser twice in a mono test session causes a crash
+		[Platform(Exclude="Mono")]
 		public void CreateNotesBrowser()
 		{
 			var browser = _chorusSystem.WinForms.CreateNotesBrowser();

--- a/src/Chorus.Tests/UI/Clone/TargetFolderControlTests.cs
+++ b/src/Chorus.Tests/UI/Clone/TargetFolderControlTests.cs
@@ -6,6 +6,7 @@ using SIL.TestUtilities;
 namespace Chorus.Tests.UI.Clone
 {
 	[TestFixture]
+	[Category("RequiresUI")]
 	public class TargetFolderControlTests
 	{
 		///--------------------------------------------------------------------------------------

--- a/src/Chorus.Tests/UI/Review/HistoryPanelModelTests.cs
+++ b/src/Chorus.Tests/UI/Review/HistoryPanelModelTests.cs
@@ -11,6 +11,7 @@ using SIL.Progress;
 namespace Chorus.Tests
 {
 	[TestFixture]
+	[Category("RequiresUI")]
 	public class HistoryPanelModelTests
 	{
 		private string _pathToTestRoot;

--- a/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncControlModelTests.cs
@@ -14,6 +14,7 @@ using SIL.Progress;
 namespace Chorus.Tests.UI.Sync
 {
 	[TestFixture]
+	[Category("RequiresUI")]
 	public class SyncControlModelTests
 	{
 		private string _pathToTestRoot;

--- a/src/ChorusHubTests/ChorusHubTests.csproj
+++ b/src/ChorusHubTests/ChorusHubTests.csproj
@@ -10,8 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -10,9 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="SIL.TestUtilities" Version="10.0.0-*" />
   </ItemGroup>
 

--- a/src/LibChorus.TestUtilities/RepositorySetup.cs
+++ b/src/LibChorus.TestUtilities/RepositorySetup.cs
@@ -4,7 +4,6 @@ using Chorus.sync;
 using Chorus.VcsDrivers;
 using Chorus.VcsDrivers.Mercurial;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 using SIL.PlatformUtilities;
 using SIL.Progress;
 using SIL.TestUtilities;

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
+++ b/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
@@ -223,6 +223,7 @@ namespace LibChorus.Tests.notes
 		// the setup of the watcher or the code in Save that tries to prevent the notifications at all,
 		// which is more than half the code this test wants to exercise.
 		[Test]
+		[Category("SkipOnBuildServer")]
 		public void ExternalFileModification_NotifiesIndices_ButSaveDoesNot()
 		{
 			const int SleepTime = 10; // milliseconds

--- a/src/Tests-ChorusPlugin/Tests-ChorusPlugin.csproj
+++ b/src/Tests-ChorusPlugin/Tests-ChorusPlugin.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
According to the docs[^1] it is recommended to add Microsoft.NET.Test.Sdk to all projects so that the tests can be discovered in VS.

Also add NUnit3TestAdapter to all test projects which is now required[^2] and remove NUnit from Tests-ChorusPlugin where it's not used.

[^1]: https://docs.nunit.org/articles/vs-test-adapter/Adapter-Installation.html
[^2]: https://www.nuget.org/packages/NUnit3TestAdapter/4.2.1#readme-body-tab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/296)
<!-- Reviewable:end -->
