### PR TITLE
increase audio and picture file size limit to 10MB

### DIFF
--- a/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
@@ -79,7 +79,7 @@ namespace Chorus.FileTypeHandlers.audio
 		/// </remarks>
 		public uint MaximumFileSize
 		{
-			get { return LargeFileFilter.Megabyte; }
+			get { return LargeFileFilter.Megabyte * 10; }
 		}
 	}
 }

--- a/src/LibChorus/FileTypeHandlers/image/ImageFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/image/ImageFileTypeHandler.cs
@@ -83,7 +83,7 @@ namespace Chorus.FileTypeHandlers.image
 		/// </remarks>
 		public uint MaximumFileSize
 		{
-			get { return LargeFileFilter.Megabyte; }
+			get { return LargeFileFilter.Megabyte * 10; }
 		}
 	}
 }


### PR DESCRIPTION
Fixes #277 

This is in response to users who report a need to add audio and pictures to their project over 1MB in FLEx and Language Forge.  The 1MB is reported to be too small.

Because we don't know practically how this will impact the majority of users, I am happy to introduce this change and evaluate the impact (pluses and minuses) on Language Forge and FLEx users who use Language Depot to collaborate, as well as the increased server storage needed to accommodate the higher limits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/301)
<!-- Reviewable:end -->
