### PR TITLE
Update the EnricoMi/publish-unit-test-result-action, fix tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,6 +42,10 @@ jobs:
 
     - name: Build
       run: dotnet build --no-restore -c Release
+      
+    - name: Install python2 for test execution
+      run: sudo apt-get install python2
+      if: matrix.os == 'ubuntu-latest'
 
     # Unfortunately we need two test steps because we need different filters.
     # We could conditionally set an environment variable, but unfortunately

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -35,7 +35,7 @@ jobs:
            done
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@2a60c5d47eb29cd5cc922f51bbea18e148f56203 # v2.0.0
+        uses: EnricoMi/publish-unit-test-result-action@713caf1dd6f1c273144546ed2d79ca24a01f4623 # v2.1.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json

--- a/Chorus.sln.DotSettings
+++ b/Chorus.sln.DotSettings
@@ -23,6 +23,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hgrc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=languageforge/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ldml/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mebibyte/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso_0027s/@EntryIndexedValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=reimplement/@EntryIndexedValue">True</s:Boolean>

--- a/Chorus.sln.DotSettings
+++ b/Chorus.sln.DotSettings
@@ -1,5 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">USE_TABS_ONLY</s:String>
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">// Copyright (c) $CREATED_YEAR$-$CURRENT_YEAR$ SIL International&#xD;
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)&#xD;
+</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JSON/@EntryIndexedValue">JSON</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=URI/@EntryIndexedValue">URI</s:String>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ invisibly for the common cases and is kept simple for even beginner computer use
 
 ## Distinctive Features
 
-These features come for free with any Distribute Version Control System:
+These features come for free with any Distributed Version Control System:
 
  * Share files between users, even if they are never connected to the internet.
 

--- a/src/Chorus/UI/Notes/Html/StyleSheet.cs
+++ b/src/Chorus/UI/Notes/Html/StyleSheet.cs
@@ -68,7 +68,7 @@ div.selected {background-color: #FFFACD}
 				bool unitTesting = Assembly.GetEntryAssembly() == null;
 				if (unitTesting)
 				{
-					path = new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath;
+					path = new Uri(Assembly.GetExecutingAssembly().Location).AbsolutePath;
 					path = Uri.UnescapeDataString(path);
 				}
 				else

--- a/src/LibChorus/Utilities/ExecutionEnvironment.cs
+++ b/src/LibChorus/Utilities/ExecutionEnvironment.cs
@@ -15,7 +15,7 @@ namespace Chorus.Utilities
 				bool unitTesting = Assembly.GetEntryAssembly() == null;
 				if (unitTesting)
 				{
-					path = new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath;
+					path = new Uri(Assembly.GetExecutingAssembly().Location).AbsolutePath;
 					path = Uri.UnescapeDataString(path);
 				}
 				else

--- a/src/LibChorus/Utilities/ExecutionEnvironment.cs
+++ b/src/LibChorus/Utilities/ExecutionEnvironment.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2015-2022 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;
 using System.Reflection;
@@ -28,11 +30,9 @@ namespace Chorus.Utilities
 
 		protected static string GetTopAppDirectory()
 		{
-			string path;
+			var path = DirectoryOfExecutingAssembly;
 
-			path = DirectoryOfExecutingAssembly;
-
-			if (path.ToLower().IndexOf("output") > -1)
+			if (path.ToLower().IndexOf("output", StringComparison.Ordinal) > -1)
 			{
 				//go up to output
 				path = Directory.GetParent(path).FullName;

--- a/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
+++ b/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
@@ -38,7 +38,7 @@ namespace Chorus.notes
 			var libChorusAssembly = Assembly.GetExecutingAssembly();
 
 			//Set the codebase variable appropriately depending on the OS
-			var codeBase = libChorusAssembly.CodeBase.Substring(Platform.IsUnix ? 7 : 8);
+			var codeBase = libChorusAssembly.Location.Substring(Platform.IsUnix ? 7 : 8);
 			var baseDir = Path.GetDirectoryName(codeBase);
 
 			// REVIEW: for some reason using *.* or *.dll didn't work - creating the catalogs in

--- a/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
+++ b/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -37,7 +38,9 @@ namespace Chorus.notes
 
 			// REVIEW: for some reason using *.* or *.dll didn't work - creating the catalogs in
 			// unit tests (on Linux) failed with FileNotFoundException - don't know why.
-			using (var aggregateCatalog = new AggregateCatalog(new DirectoryCatalog(libChorusAssembly.Location, "Chorus.exe"),
+			using (var aggregateCatalog = new AggregateCatalog(
+				// ReSharper disable once AssignNullToNotNullAttribute
+				new DirectoryCatalog(Path.GetDirectoryName(libChorusAssembly.Location), "Chorus.exe"),
 				new AssemblyCatalog(libChorusAssembly)))
 			using (var catalog = new FilteredCatalog(aggregateCatalog,
 				def => !def.Metadata.ContainsKey("IsDefault")))

--- a/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
+++ b/src/LibChorus/notes/EmbeddedMessageContentHandlerRepository.cs
@@ -1,13 +1,11 @@
-// Copyright (c) 2015 SIL International
+// Copyright (c) 2015-2022 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using SIL.PlatformUtilities;
 
 namespace Chorus.notes
 {
@@ -37,13 +35,9 @@ namespace Chorus.notes
 		{
 			var libChorusAssembly = Assembly.GetExecutingAssembly();
 
-			//Set the codebase variable appropriately depending on the OS
-			var codeBase = libChorusAssembly.Location.Substring(Platform.IsUnix ? 7 : 8);
-			var baseDir = Path.GetDirectoryName(codeBase);
-
 			// REVIEW: for some reason using *.* or *.dll didn't work - creating the catalogs in
 			// unit tests (on Linux) failed with FileNotFoundException - don't know why.
-			using (var aggregateCatalog = new AggregateCatalog(new DirectoryCatalog(baseDir, "Chorus.exe"),
+			using (var aggregateCatalog = new AggregateCatalog(new DirectoryCatalog(libChorusAssembly.Location, "Chorus.exe"),
 				new AssemblyCatalog(libChorusAssembly)))
 			using (var catalog = new FilteredCatalog(aggregateCatalog,
 				def => !def.Metadata.ContainsKey("IsDefault")))

--- a/src/LibChorus/sync/LargeFileFilter.cs
+++ b/src/LibChorus/sync/LargeFileFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -9,7 +9,7 @@ namespace Chorus.sync
 {
 	///<summary>
 	/// Class that filters out large, binary, files from being put into the repo,
-	/// or if a binary file already is in the repo, then don't commit it if it exceeds the maximum allowablew size.
+	/// or if a binary file already is in the repo, then don't commit it if it exceeds the maximum allowable size.
 	///
 	/// JohnH comments:
 	///		"we could use a “large file” filter in Chorus.
@@ -47,6 +47,12 @@ namespace Chorus.sync
 	///
 	///		I'd err on the side of precision, and our policies rather than the users discretion and what they could really try."
 	///
+	/// 2022.03 discussion, committed 2022.12:
+	///		The 1MB limit set in 2011 was revisited. Today's phones typically take 4 MB photos that not everybody knows how to compress, and computers
+	///		and networks have become more powerful. We still don't want users to upload enormous files and prevent themselves and their team from
+	///		using their repositories, so we are increasing the limit to 10 MB. This will allow the inclusion of high-quality photos and .wav files up
+	///		to 56 seconds. https://github.com/sillsdev/chorus/issues/277
+	///
 	/// How to set the limits:
 	///		1. hard-coded
 	///		2. project manager determined
@@ -56,12 +62,9 @@ namespace Chorus.sync
 	public static class LargeFileFilter
 	{
 		///<summary>
-		/// Return a standard Megabyte size.
+		/// The number of bytes in a Mebibyte
 		///</summary>
-		public static uint Megabyte
-		{
-			get { return (uint)Math.Pow(2, 20); }
-		}
+		public static uint Megabyte => 1048576;
 
 		///<summary>
 		/// Filter the files, before the commit. Files that are too large are added to the exclude section of the configuration.

--- a/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
@@ -17,7 +17,7 @@ namespace LibChorus.Tests.FileHandlers
 			get
 		{
 				var assem = Assembly.GetExecutingAssembly();
-				return Path.GetDirectoryName(assem.CodeBase.Substring(Platform.IsUnix ? 7 : 8));
+				return Path.GetDirectoryName(assem.Location.Substring(Platform.IsUnix ? 7 : 8));
 			}
 		}
 

--- a/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2015-2022 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -5,21 +7,13 @@ using NUnit.Framework;
 using Chorus.FileTypeHandlers;
 using Chorus.FileTypeHandlers.audio;
 using Chorus.FileTypeHandlers.test;
-using SIL.PlatformUtilities;
 
 namespace LibChorus.Tests.FileHandlers
 {
 	[TestFixture]
 	public class ChorusFileTypeHandlerCollectionTests
 	{
-		private static string BaseDir
-		{
-			get
-		{
-				var assem = Assembly.GetExecutingAssembly();
-				return Path.GetDirectoryName(assem.Location.Substring(Platform.IsUnix ? 7 : 8));
-			}
-		}
+		private static string BaseDir => Assembly.GetExecutingAssembly().Location;
 
 		private static string SamplePluginPath
 		{
@@ -56,7 +50,7 @@ namespace LibChorus.Tests.FileHandlers
 		}
 
 		[Test]
-		public void CreateWithInstalledHandlers_DefaulthandlerIsNotInMainCollection()
+		public void CreateWithInstalledHandlers_DefaultHandlerIsNotInMainCollection()
 		{
 			Assert.That(ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers().Handlers
 				.Select(x => x.GetType()), Has.No.Member(typeof(DefaultFileTypeHandler)));
@@ -70,7 +64,7 @@ namespace LibChorus.Tests.FileHandlers
 		}
 
 		[Test]
-		public void CreateWithTestHandlerOnly_DefaulthandlerIsNotInTestCollection()
+		public void CreateWithTestHandlerOnly_DefaultHandlerIsNotInTestCollection()
 		{
 			Assert.That(ChorusFileTypeHandlerCollection.CreateWithTestHandlerOnly().Handlers
 				.Select(x => x.GetType()), Has.No.Member(typeof(DefaultFileTypeHandler)));

--- a/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
@@ -13,18 +13,17 @@ namespace LibChorus.Tests.FileHandlers
 	[TestFixture]
 	public class ChorusFileTypeHandlerCollectionTests
 	{
-		private static string BaseDir => Assembly.GetExecutingAssembly().Location;
+		private static string BaseDir => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
 		private static string SamplePluginPath
 		{
 			get
 			{
-				var outputDir = Directory.GetParent(BaseDir).Parent.FullName;
-				var samplePluginDir = Path.Combine(outputDir, "SamplePlugin");
-				var samplePluginDllPath = Path.Combine(samplePluginDir, "Release", "net461", "Tests-ChorusPlugin.dll");
-				return File.Exists(samplePluginDllPath) ?
-					samplePluginDllPath :
-					Path.Combine(samplePluginDir, "Debug", "net461", "Tests-ChorusPlugin.dll");
+				var configOutputDir = Directory.GetParent(BaseDir);
+				var outputDir = configOutputDir.Parent.FullName;
+				var config = configOutputDir.Name;
+				var samplePluginDllPath = Path.Combine(outputDir, "SamplePlugin", config, "net461", "Tests-ChorusPlugin.dll");
+				return samplePluginDllPath;
 			}
 		}
 

--- a/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Chorus.FileTypeHandlers;
 using Chorus.sync;
@@ -28,9 +28,9 @@ namespace LibChorus.Tests.FileHandlers.audio
 		}
 
 		[Test]
-		public void HandlerShouldOnlyProcessMegabyteSizedFiles()
+		public void HandlerShouldProcessOnlyTenMegabyteSizedFiles()
 		{
-			Assert.AreEqual(LargeFileFilter.Megabyte, _audioFileHandler.MaximumFileSize);
+			Assert.AreEqual(LargeFileFilter.Megabyte * 10, _audioFileHandler.MaximumFileSize);
 		}
 
 		[Test]

--- a/src/LibChorusTests/FileHandlers/image/ImageFileTypeHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/image/ImageFileTypeHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Chorus.FileTypeHandlers;
 using Chorus.sync;
@@ -28,9 +28,9 @@ namespace LibChorus.Tests.FileHandlers.image
 		}
 
 		[Test]
-		public void HandlerShouldOnlyProcessMegabyteSizedFiles()
+		public void HandlerShouldProcessOnlyTenMegabyteSizedFiles()
 		{
-			Assert.AreEqual(LargeFileFilter.Megabyte, _imageFileHandler.MaximumFileSize);
+			Assert.AreEqual(LargeFileFilter.Megabyte * 10, _imageFileHandler.MaximumFileSize);
 		}
 
 		[Test]

--- a/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/RepositoryTests.cs
@@ -130,7 +130,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		{
 			using (var tempRepo = new TemporaryFolder("ChorusIncompleteMerge"))
 			{
-				var baseDir = PathHelper.NormalizePath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase));
+				var baseDir = PathHelper.NormalizePath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 				baseDir = PathHelper.StripFilePrefix(baseDir);
 				string zipPath = Path.Combine(baseDir, Path.Combine("VcsDrivers", Path.Combine("TestData", "incompletemergerepo.zip")));
 				FastZip zipFile = new FastZip();

--- a/src/LibChorusTests/sync/LargeFileFilterTests.cs
+++ b/src/LibChorusTests/sync/LargeFileFilterTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) 2015-2022 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
 using System.IO;
 using System.Linq;
 using Chorus.FileTypeHandlers;
@@ -213,8 +215,8 @@ namespace LibChorus.Tests.sync
 		{
 			using (var bob = new RepositorySetup("bob"))
 			{
-				var megabyteLongData = "long" + Environment.NewLine;
-				while (megabyteLongData.Length < LargeFileFilter.Megabyte)
+				var megabyteLongData = "super-duper-long" + Environment.NewLine;
+				while (megabyteLongData.Length < LargeFileFilter.Megabyte * 10)
 					megabyteLongData += megabyteLongData;
 
 				const string fileName = "big.wav";
@@ -656,8 +658,8 @@ namespace LibChorus.Tests.sync
 			using (var bob = new RepositorySetup("bob"))
 			{
 				const string fileName = "whopper.Mp3";
-				var megabyteLongData = "long" + Environment.NewLine;
-				while (megabyteLongData.Length < LargeFileFilter.Megabyte)
+				var megabyteLongData = "super-duper-long" + Environment.NewLine;
+				while (megabyteLongData.Length < LargeFileFilter.Megabyte * 10)
 					megabyteLongData += megabyteLongData;
 				bob.ChangeFile(fileName, megabyteLongData);
 				var fullPathname = Path.Combine(bob.ProjectFolderConfig.FolderPath, fileName);


### PR DESCRIPTION
* Update the EnricoMi/publish-unit-test-result-action
** Fixes warnings about save-state and set-output deprecation
* install python2 prior to test execution
* Update Deprecated API Calls: Assembly.CodeBase is now Assembly.Location
* Update appropriate file size filter tests to expect 10MB files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/308)
<!-- Reviewable:end -->
