### PR TITLE
Update to Newtonsoft.JSON to 13.0.2

### DIFF
--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="SIL.TestUtilities" Version="11.0.0-*" />

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />


### PR DESCRIPTION
Bumps [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) to 13.0.2. <details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/JamesNK/Newtonsoft.Json/releases">Newtonsoft.Json's releases</a>.</em></p> <blockquote>
<h2>13.0.2</h2>
<ul>
<li>New feature - Add support for DateOnly and TimeOnly</li> <li>New feature - Add UnixDateTimeConverter.AllowPreEpoch property</li> <li>New feature - Add copy constructor to JsonSerializerSettings</li> <li>New feature - Add JsonCloneSettings with property to disable copying annotations</li> <li>Change - Add nullable annotation to JToken.ToObject(Type, JsonSerializer)</li> <li>Change - Reduced allocations by reusing boxed values</li> <li>Fix - Fixed MaxDepth when used with ToObject inside of a JsonConverter</li> <li>Fix - Fixed deserializing mismatched JToken types in properties</li> <li>Fix - Fixed merging enumerable content and validate content</li> <li>Fix - Fixed using $type with arrays of more than two dimensions</li> <li>Fix - Fixed rare race condition in name table when deserializing on device with ARM processors</li> <li>Fix - Fixed deserializing via constructor with ignored base type properties</li> <li>Fix - Fixed MaxDepth not being used with ISerializable deserialization</li> </ul>
<h2>13.0.1</h2>
<ul>
<li>New feature - Add JsonSelectSettings with configuration for a regex timeout</li> <li>Change - Remove portable assemblies from NuGet package</li> <li>Change - JsonReader and JsonSerializer MaxDepth defaults to 64</li> <li>Change - Change InvalidCastException to JsonSerializationException on mismatched JToken</li> <li>Fix - Fixed throwing missing member error on ignored fields</li> <li>Fix - Fixed various nullable annotations</li>
<li>Fix - Fixed annotations not being copied when tokens are cloned</li> <li>Fix - Fixed naming strategy not being used when deserializing dictionary enum keys</li> <li>Fix - Fixed serializing nullable struct dictionaries</li> <li>Fix - Fixed JsonWriter.WriteToken to allow null with string token</li> <li>Fix - Fixed missing error when deserializing JToken with a contract type mismatch</li> <li>Fix - Fixed JTokenWriter when writing comment to an object</li> </ul>
</blockquote>
</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/312)
<!-- Reviewable:end -->
