### PR TITLE
Show the Receive Project dialog in the taskbar

### DIFF
--- a/src/Chorus/UI/Clone/GetSharedProjectDlg.Designer.cs
+++ b/src/Chorus/UI/Clone/GetSharedProjectDlg.Designer.cs
@@ -111,7 +111,6 @@
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.Name = "GetSharedProjectDlg";
-			this.ShowInTaskbar = false;
 			this.Text = "Receive project";
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
 			this.ResumeLayout(false);


### PR DESCRIPTION
When it is opened from the FieldWorks Welcome dialog (and perhaps other times), it is the only dialog,
so the application disappears from the taskbar entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/315)
<!-- Reviewable:end -->
