### PR TITLE
Add webm as audio-file-type so it gets 10MB limit

### DIFF
--- a/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/audio/AudioFileTypeHandler.cs
@@ -68,7 +68,7 @@ namespace Chorus.FileTypeHandlers.audio
 		/// <returns>A collection of extensions (without leading period (.)) that can be processed.</returns>
 		public IEnumerable<string> GetExtensionsOfKnownTextFileTypes()
 		{
-			return new List<string> { "wav", "snd", "au", "aif", "aifc", "aiff", "wma", "mp3" };
+			return new List<string> { "wav", "snd", "au", "aif", "aifc", "aiff", "wma", "mp3", "webm" };
 		}
 
 		/// <summary>

--- a/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/audio/AudioFileTypeHandlerTests.cs
@@ -37,8 +37,8 @@ namespace LibChorus.Tests.FileHandlers.audio
 		public void HandlerSupportsCorrectExtensions()
 		{
 			var extensions = _audioFileHandler.GetExtensionsOfKnownTextFileTypes().ToList();
-			Assert.That(extensions.Count(), Is.EqualTo(8));
-			var expectedExtensions = new HashSet<string> {"wav", "snd", "au", "aif", "aifc", "aiff", "wma", "mp3"};
+			Assert.That(extensions.Count(), Is.EqualTo(9));
+			var expectedExtensions = new HashSet<string> {"wav", "snd", "au", "aif", "aifc", "aiff", "wma", "mp3", "webm"};
 			foreach (var expectedExtension in expectedExtensions)
 				Assert.Contains(expectedExtension, extensions);
 		}


### PR DESCRIPTION
We [recently increased](https://github.com/sillsdev/chorus/pull/301) the max file size for audio and images to 10MB.

But webm is a significant file format in the browser (i.e. Language Forge) and it's not included in the list of known audio file types, so recording audio in LF never actually benefited from this previous change 😲😢,

Webm is a file-type that FLEx supports, so there's no obvious reason to me why we shouldn't include it here, it was simply forgotten.
![image](https://github.com/sillsdev/chorus/assets/12587509/42da21f6-a450-4309-8ec5-6d9279cd5386)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/319)
<!-- Reviewable:end -->
