### PR TITLE
Add public StartClone() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - [SIL.Chorus.LibChorus] Add webm as additional audio file type
+- [SIL.Chorus] Add ability to clone project without direct user interaction
 
 ### Changed
 

--- a/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
+++ b/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using System.Windows.Forms;
 using Chorus.UI.Clone;
 using Chorus.VcsDrivers.Mercurial;
 using NUnit.Framework;
@@ -10,6 +11,25 @@ namespace Chorus.Tests.UI.Clone
 	[TestFixture]
 	public class GetSharedProjectModelTests
 	{
+		[Test]
+		public void GetResult([Values(true, false)] bool success)
+		{
+			const string cloneLocation = "D:\\uno";
+			var result = GetSharedProjectModel.GetResult(DialogResult.OK, cloneLocation, success);
+			Assert.That(result.CloneStatus, Is.EqualTo(success ? CloneStatus.Created : CloneStatus.NotCreated));
+			Assert.That(result.ActualLocation, Is.EqualTo(success ? cloneLocation : null));
+		}
+
+		[TestCase(DialogResult.OK, "C:\\somewhere", CloneStatus.Created)]
+		[TestCase(DialogResult.Cancel, "S:\\miles", CloneStatus.Cancelled)]
+		[TestCase(DialogResult.Abort, "E:\\elsewhere", CloneStatus.NotCreated)]
+		public void GetResult(DialogResult dialogResult, string cloneLocation, CloneStatus expectedStatus)
+		{
+			var result = GetSharedProjectModel.GetResult(dialogResult, cloneLocation);
+			Assert.That(result.CloneStatus, Is.EqualTo(expectedStatus));
+			Assert.That(result.ActualLocation, Is.EqualTo(expectedStatus == CloneStatus.Created ? cloneLocation : null));
+		}
+
 		[Test]
 		public void HasNoExtantRepositories()
 		{

--- a/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
+++ b/src/Chorus.Tests/UI/Clone/GetSharedProjectModelTests.cs
@@ -11,18 +11,10 @@ namespace Chorus.Tests.UI.Clone
 	[TestFixture]
 	public class GetSharedProjectModelTests
 	{
-		[Test]
-		public void GetResult([Values(true, false)] bool success)
-		{
-			const string cloneLocation = "D:\\uno";
-			var result = GetSharedProjectModel.GetResult(DialogResult.OK, cloneLocation, success);
-			Assert.That(result.CloneStatus, Is.EqualTo(success ? CloneStatus.Created : CloneStatus.NotCreated));
-			Assert.That(result.ActualLocation, Is.EqualTo(success ? cloneLocation : null));
-		}
-
 		[TestCase(DialogResult.OK, "C:\\somewhere", CloneStatus.Created)]
 		[TestCase(DialogResult.Cancel, "S:\\miles", CloneStatus.Cancelled)]
 		[TestCase(DialogResult.Abort, "E:\\elsewhere", CloneStatus.NotCreated)]
+		[TestCase(DialogResult.None, "~/no/where", CloneStatus.NotCreated)]
 		public void GetResult(DialogResult dialogResult, string cloneLocation, CloneStatus expectedStatus)
 		{
 			var result = GetSharedProjectModel.GetResult(dialogResult, cloneLocation);

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -262,10 +262,26 @@ namespace Chorus.UI.Clone
 
 		private void OnDownloadClick(object sender, EventArgs e)
 		{
+			StartClone();
+		}
+
+		public void StartClone(string username, string password, Uri targetUri)
+		{
+			_model.Username = username;
+			_model.Password = password;
+			_model.CustomUrl = targetUri.ToString();
+			_model.IsCustomUrl = true;
+			_model.LocalFolderName = GetProjectName(targetUri);
+
+			StartClone();
+		}
+
+		private void StartClone()
+		{
 			lock (this)
 			{
 				_logBox.Clear();
-				if(_backgroundWorker.IsBusy)
+				if (_backgroundWorker.IsBusy)
 					return;
 				UpdateDisplay(State.MakingClone);
 				_model.SaveUserSettings();
@@ -275,6 +291,10 @@ namespace Chorus.UI.Clone
 			}
 		}
 
+		private string GetProjectName(Uri uri)
+		{
+			return uri.Segments[1].ToString();
+		}
 
 		public string ThreadSafeUrl
 		{

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -270,18 +270,26 @@ namespace Chorus.UI.Clone
 		/// Starts a clone operation with the supplied information.
 		/// <param name="username">Username for Mercurial authentication</param>
 		/// <param name="password">Password for Mercurial authentication</param>
+		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name of the project to clone</param>
 		/// <param name="projectUri">URI where the project can be found</param>
 		/// </summary>
-		public void StartClone(string username, string password, string projectName, Uri projectUri)
+		public static GetCloneFromInternetDialog StartClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
 		{
-			_model.Username = username;
-			_model.Password = password;
-			_model.CustomUrl = projectUri.ToString();
-			_model.IsCustomUrl = true;
-			_model.LocalFolderName = projectName;
+			var model = new GetCloneFromInternetModel(projectFolder)
+			{
+				Username = username,
+				Password = password,
+				CustomUrl = projectUri.ToString(),
+				IsCustomUrl = true,
+				LocalFolderName = projectName
+			};
 
-			StartClone();
+			var dialog = new GetCloneFromInternetDialog(model);
+			dialog.Show();
+			dialog.StartClone();
+
+			return dialog;
 		}
 
 		private void StartClone()

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -265,13 +265,21 @@ namespace Chorus.UI.Clone
 			StartClone();
 		}
 
-		public void StartClone(string username, string password, Uri targetUri)
+		
+		/// <summary>
+		/// Starts a clone operation with the supplied information.
+		/// <param name="username">Username for Mercurial authentication</param>
+		/// <param name="password">Password for Mercurial authentication</param>
+		/// <param name="host">Host name (with scheme), e.g. https://www.google.com</param>
+		/// <param name="projectName">Name of the project to clone (will be combined with the host Uri)</param>
+		/// </summary>
+		public void StartClone(string username, string password, Uri host, string projectName)
 		{
 			_model.Username = username;
 			_model.Password = password;
-			_model.CustomUrl = targetUri.ToString();
+			_model.CustomUrl = new Uri(host, projectName).ToString();
 			_model.IsCustomUrl = true;
-			_model.LocalFolderName = GetProjectName(targetUri);
+			_model.LocalFolderName = projectName;
 
 			StartClone();
 		}
@@ -289,11 +297,6 @@ namespace Chorus.UI.Clone
 				//_backgroundWorker.RunWorkerAsync(new object[] { ThreadSafeUrl, PathToNewProject, _progress });
 				_backgroundWorker.RunWorkerAsync(new object[0]);
 			}
-		}
-
-		private string GetProjectName(Uri uri)
-		{
-			return uri.Segments[1].ToString();
 		}
 
 		public string ThreadSafeUrl

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -270,14 +270,14 @@ namespace Chorus.UI.Clone
 		/// Starts a clone operation with the supplied information.
 		/// <param name="username">Username for Mercurial authentication</param>
 		/// <param name="password">Password for Mercurial authentication</param>
-		/// <param name="host">Host name (with scheme), e.g. https://www.google.com</param>
-		/// <param name="projectName">Name of the project to clone (will be combined with the host Uri)</param>
+		/// <param name="projectName">Name of the project to clone</param>
+		/// <param name="projectUri">URI where the project can be found</param>
 		/// </summary>
-		public void StartClone(string username, string password, Uri host, string projectName)
+		public void StartClone(string username, string password, string projectName, Uri projectUri)
 		{
 			_model.Username = username;
 			_model.Password = password;
-			_model.CustomUrl = new Uri(host, projectName).ToString();
+			_model.CustomUrl = projectUri.ToString();
 			_model.IsCustomUrl = true;
 			_model.LocalFolderName = projectName;
 

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -130,20 +130,24 @@ namespace Chorus.UI.Clone
 		/// <param name="projectUri">URI where the project can be found</param>
 		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, string projectUri)
 		{
-			var model = new GetCloneFromInternetModel(projectFolder)
-			{
-				Username = username,
-				Password = password,
-				CustomUrl = projectUri,
-				IsCustomUrl = true,
-				LocalFolderName = projectName
-			};
+			var model = new GetCloneFromInternetModel(projectFolder);
+			var oldUser = model.Username;
+			var oldPass = model.Password;
+			model.Username = username;
+			model.Password = password;
+			model.CustomUrl = projectUri;
+			model.IsCustomUrl = true;
+			model.LocalFolderName = projectName;
 
 			using (var dialog = new GetCloneFromInternetDialog(model))
 			{
 				dialog.Show();
 				dialog.StartClone();
 				Application.Run(dialog);
+
+				model.Username = oldUser;
+				model.Password = oldPass;
+				model.SaveUserSettings();
 
 				return GetSharedProjectModel.GetResult(dialog.DialogResult, dialog.PathToNewlyClonedFolder);
 			}

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -128,7 +128,8 @@ namespace Chorus.UI.Clone
 		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name for the project on the local machine</param>
 		/// <param name="projectUri">URI where the project can be found</param>
-		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, string projectUri)
+		/// <param name="saveUserSettings">Flag to persist username and password in settings</param>
+		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, string projectUri, bool saveUserSettings = true)
 		{
 			var model = new GetCloneFromInternetModel(projectFolder);
 			var oldUser = model.Username;
@@ -141,13 +142,21 @@ namespace Chorus.UI.Clone
 
 			using (var dialog = new GetCloneFromInternetDialog(model))
 			{
-				dialog.Show();
-				dialog.StartClone();
-				Application.Run(dialog);
-
-				model.Username = oldUser;
-				model.Password = oldPass;
-				model.SaveUserSettings();
+				try
+				{
+					dialog.Show();
+					dialog.StartClone();
+					Application.Run(dialog);
+				}
+				finally
+				{
+					if (!saveUserSettings)
+					{
+						model.Username = oldUser;
+						model.Password = oldPass;
+						model.SaveUserSettings();
+					}
+				}
 
 				return GetSharedProjectModel.GetResult(dialog.DialogResult, dialog.PathToNewlyClonedFolder);
 			}

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -96,15 +96,38 @@ namespace Chorus.UI.Clone
 
 		}
 
-
 		/// <summary>
-		/// Performs a clone operation with the supplied information.
+		/// Confirms with a dialog, then performs a clone operation with the supplied information.
+		/// </summary>
 		/// <param name="username">Username for Mercurial authentication</param>
 		/// <param name="password">Password for Mercurial authentication</param>
 		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name for the project on the local machine</param>
 		/// <param name="projectUri">URI where the project can be found</param>
+		public static CloneResult ConfirmAndDoClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
+		{
+			var projectNameExtractor = new GetCloneFromInternetModel();
+			projectNameExtractor.InitFromUri(projectUri.ToString());
+			var proj = string.IsNullOrEmpty(projectNameExtractor.ProjectId) ? projectName : projectNameExtractor.ProjectId;
+			var host = new Uri(projectUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
+
+			var msg = string.Format(LocalizationManager.GetString("GetCloneFromInternet.DownloadProjectFromHost", "Download {0} from {1}?"),
+				proj, host);
+			var caption = LocalizationManager.GetString("GetCloneFromInternet.ConfirmDownload", "Confirm Download");
+
+			return MessageBox.Show(msg, caption, MessageBoxButtons.YesNo) == DialogResult.Yes
+				? DoClone(username, password, projectFolder, projectName, projectUri)
+				: null;
+		}
+
+		/// <summary>
+		/// Performs a clone operation with the supplied information.
 		/// </summary>
+		/// <param name="username">Username for Mercurial authentication</param>
+		/// <param name="password">Password for Mercurial authentication</param>
+		/// <param name="projectFolder">The parent directory to put the clone in</param>
+		/// <param name="projectName">Name for the project on the local machine</param>
+		/// <param name="projectUri">URI where the project can be found</param>
 		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
 		{
 			var model = new GetCloneFromInternetModel(projectFolder)
@@ -305,7 +328,6 @@ namespace Chorus.UI.Clone
 				UpdateDisplay(State.MakingClone);
 				_model.SaveUserSettings();
 				ThreadSafeUrl = _model.URL;
-				//_backgroundWorker.RunWorkerAsync(new object[] { ThreadSafeUrl, PathToNewProject, _progress });
 				_backgroundWorker.RunWorkerAsync(new object[0]);
 			}
 		}

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -96,6 +96,38 @@ namespace Chorus.UI.Clone
 
 		}
 
+
+		/// <summary>
+		/// Performs a clone operation with the supplied information.
+		/// <param name="username">Username for Mercurial authentication</param>
+		/// <param name="password">Password for Mercurial authentication</param>
+		/// <param name="projectFolder">The parent directory to put the clone in</param>
+		/// <param name="projectName">Name for the project on the local machine</param>
+		/// <param name="projectUri">URI where the project can be found</param>
+		/// </summary>
+		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
+		{
+			var model = new GetCloneFromInternetModel(projectFolder)
+			{
+				Username = username,
+				Password = password,
+				CustomUrl = projectUri.ToString(),
+				IsCustomUrl = true,
+				LocalFolderName = projectName
+			};
+
+			var dialog = new GetCloneFromInternetDialog(model);
+			DialogResult? res = null;
+			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
+
+			dialog.Show();
+			dialog.StartClone();
+			Application.Run(dialog);
+
+			var cloneStatus = res == DialogResult.OK ? CloneStatus.Created : CloneStatus.NotCreated;
+			return new CloneResult(dialog.PathToNewlyClonedFolder, cloneStatus);
+		}
+
 		private void _backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
 			if (_statusProgress.ErrorEncountered)
@@ -263,33 +295,6 @@ namespace Chorus.UI.Clone
 		private void OnDownloadClick(object sender, EventArgs e)
 		{
 			StartClone();
-		}
-
-		
-		/// <summary>
-		/// Starts a clone operation with the supplied information.
-		/// <param name="username">Username for Mercurial authentication</param>
-		/// <param name="password">Password for Mercurial authentication</param>
-		/// <param name="projectFolder">The parent directory to put the clone in</param>
-		/// <param name="projectName">Name of the project to clone</param>
-		/// <param name="projectUri">URI where the project can be found</param>
-		/// </summary>
-		public static GetCloneFromInternetDialog StartClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
-		{
-			var model = new GetCloneFromInternetModel(projectFolder)
-			{
-				Username = username,
-				Password = password,
-				CustomUrl = projectUri.ToString(),
-				IsCustomUrl = true,
-				LocalFolderName = projectName
-			};
-
-			var dialog = new GetCloneFromInternetDialog(model);
-			dialog.Show();
-			dialog.StartClone();
-
-			return dialog;
 		}
 
 		private void StartClone()

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -116,16 +116,14 @@ namespace Chorus.UI.Clone
 				LocalFolderName = projectName
 			};
 
-			var dialog = new GetCloneFromInternetDialog(model);
-			DialogResult? res = null;
-			dialog.FormClosing += (sender, args) => res = dialog.DialogResult;
+			using (var dialog = new GetCloneFromInternetDialog(model))
+			{
+				dialog.Show();
+				dialog.StartClone();
+				Application.Run(dialog);
 
-			dialog.Show();
-			dialog.StartClone();
-			Application.Run(dialog);
-
-			var cloneStatus = res == DialogResult.OK ? CloneStatus.Created : CloneStatus.NotCreated;
-			return new CloneResult(dialog.PathToNewlyClonedFolder, cloneStatus);
+				return GetSharedProjectModel.GetResult(dialog.DialogResult, dialog.PathToNewlyClonedFolder);
+			}
 		}
 
 		private void _backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -104,12 +104,12 @@ namespace Chorus.UI.Clone
 		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name for the project on the local machine</param>
 		/// <param name="projectUri">URI where the project can be found</param>
-		public static CloneResult ConfirmAndDoClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
+		public static CloneResult ConfirmAndDoClone(string username, string password, string projectFolder, string projectName, string projectUri)
 		{
 			var projectNameExtractor = new GetCloneFromInternetModel();
-			projectNameExtractor.InitFromUri(projectUri.ToString());
+			projectNameExtractor.InitFromUri(projectUri);
 			var proj = string.IsNullOrEmpty(projectNameExtractor.ProjectId) ? projectName : projectNameExtractor.ProjectId;
-			var host = new Uri(projectUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
+			var host = new Uri(projectUri).GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped);
 
 			var msg = string.Format(LocalizationManager.GetString("GetCloneFromInternet.DownloadProjectFromHost", "Download {0} from {1}?"),
 				proj, host);
@@ -128,13 +128,13 @@ namespace Chorus.UI.Clone
 		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name for the project on the local machine</param>
 		/// <param name="projectUri">URI where the project can be found</param>
-		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, Uri projectUri)
+		public static CloneResult DoClone(string username, string password, string projectFolder, string projectName, string projectUri)
 		{
 			var model = new GetCloneFromInternetModel(projectFolder)
 			{
 				Username = username,
 				Password = password,
-				CustomUrl = projectUri.ToString(),
+				CustomUrl = projectUri,
 				IsCustomUrl = true,
 				LocalFolderName = projectName
 			};

--- a/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
+++ b/src/Chorus/UI/Clone/GetCloneFromInternetDialog.cs
@@ -104,7 +104,8 @@ namespace Chorus.UI.Clone
 		/// <param name="projectFolder">The parent directory to put the clone in</param>
 		/// <param name="projectName">Name for the project on the local machine</param>
 		/// <param name="projectUri">URI where the project can be found</param>
-		public static CloneResult ConfirmAndDoClone(string username, string password, string projectFolder, string projectName, string projectUri)
+		/// <param name="saveUserSettings">Flag to persist username and password in settings</param>
+		public static CloneResult ConfirmAndDoClone(string username, string password, string projectFolder, string projectName, string projectUri, bool saveUserSettings = true)
 		{
 			var projectNameExtractor = new GetCloneFromInternetModel();
 			projectNameExtractor.InitFromUri(projectUri);
@@ -116,7 +117,7 @@ namespace Chorus.UI.Clone
 			var caption = LocalizationManager.GetString("GetCloneFromInternet.ConfirmDownload", "Confirm Download");
 
 			return MessageBox.Show(msg, caption, MessageBoxButtons.YesNo) == DialogResult.Yes
-				? DoClone(username, password, projectFolder, projectName, projectUri)
+				? DoClone(username, password, projectFolder, projectName, projectUri, saveUserSettings)
 				: null;
 		}
 

--- a/src/Chorus/UI/Clone/GetSharedProjectModel.cs
+++ b/src/Chorus/UI/Clone/GetSharedProjectModel.cs
@@ -113,9 +113,13 @@ namespace Chorus.UI.Clone
 
 					using (var getCloneFromChorusHubDialog = new GetCloneFromChorusHubDialog(getCloneFromChorusHubModel))
 					{
-						result = GetResult(getCloneFromChorusHubDialog.ShowDialog(parent),
-							getCloneFromChorusHubDialog.PathToNewlyClonedFolder,
-							getCloneFromChorusHubModel.CloneSucceeded);
+						var dlgResult = getCloneFromChorusHubDialog.ShowDialog(parent);
+						if (dlgResult == DialogResult.OK && !getCloneFromChorusHubModel.CloneSucceeded)
+						{
+							// User clicked OK, but clone failed. Pass anything other than OK or Cancel to get CloneStatus.NotCreated
+							dlgResult = DialogResult.Abort;
+						}
+						result = GetResult(dlgResult, getCloneFromChorusHubDialog.PathToNewlyClonedFolder);
 					}
 					break;
 
@@ -145,7 +149,7 @@ namespace Chorus.UI.Clone
 			return result;
 		}
 
-		internal static CloneResult GetResult(DialogResult dialogResult, string cloneLocation, bool success = true)
+		internal static CloneResult GetResult(DialogResult dialogResult, string cloneLocation)
 		{
 			CloneStatus cloneStatus;
 			switch (dialogResult)
@@ -157,7 +161,7 @@ namespace Chorus.UI.Clone
 					cloneStatus = CloneStatus.Cancelled;
 					break;
 				case DialogResult.OK:
-					cloneStatus = success ? CloneStatus.Created : CloneStatus.NotCreated;
+					cloneStatus = CloneStatus.Created;
 					break;
 			}
 

--- a/src/Chorus/UI/Clone/GetSharedProjectModel.cs
+++ b/src/Chorus/UI/Clone/GetSharedProjectModel.cs
@@ -76,6 +76,8 @@ namespace Chorus.UI.Clone
 			// "Seeing fit' may mean to warn the user they already have some repository, or as a filter to not show ones that already exist.
 			// What to do with the list of extant repos is left up to a view+model pair.
 
+			var result = new CloneResult(null, CloneStatus.NotCreated);
+
 			// Select basic source type.
 			using (var getSharedProjectDlg = new GetSharedProjectDlg())
 			{
@@ -83,13 +85,11 @@ namespace Chorus.UI.Clone
 				getSharedProjectDlg.ShowDialog(parent);
 				if (getSharedProjectDlg.DialogResult != DialogResult.OK)
 				{
-					return new CloneResult(null, CloneStatus.NotCreated);
+					return result;
 				}
 			}
 
 			// Make clone from some source.
-			string actualCloneLocation = null;
-			var cloneStatus = CloneStatus.NotCreated;
 			switch (RepositorySource)
 			{
 				case ExtantRepoSource.Internet:
@@ -99,19 +99,7 @@ namespace Chorus.UI.Clone
 						};
 					using (var cloneFromInternetDialog = new GetCloneFromInternetDialog(cloneFromInternetModel))
 					{
-						switch (cloneFromInternetDialog.ShowDialog(parent))
-						{
-							default:
-								cloneStatus = CloneStatus.NotCreated;
-								break;
-							case DialogResult.Cancel:
-								cloneStatus = CloneStatus.Cancelled;
-								break;
-							case DialogResult.OK:
-								actualCloneLocation = cloneFromInternetDialog.PathToNewlyClonedFolder;
-								cloneStatus = CloneStatus.Created;
-								break;
-						}
+						result = GetResult(cloneFromInternetDialog.ShowDialog(parent), cloneFromInternetDialog.PathToNewlyClonedFolder);
 					}
 					break;
 
@@ -125,26 +113,9 @@ namespace Chorus.UI.Clone
 
 					using (var getCloneFromChorusHubDialog = new GetCloneFromChorusHubDialog(getCloneFromChorusHubModel))
 					{
-						switch (getCloneFromChorusHubDialog.ShowDialog(parent))
-						{
-							default:
-								cloneStatus = CloneStatus.NotCreated;
-								break;
-							case DialogResult.Cancel:
-								cloneStatus = CloneStatus.Cancelled;
-								break;
-							case DialogResult.OK:
-								if (getCloneFromChorusHubModel.CloneSucceeded)
-								{
-									actualCloneLocation = getCloneFromChorusHubDialog.PathToNewlyClonedFolder;
-									cloneStatus = CloneStatus.Created;
-								}
-								else
-								{
-									cloneStatus = CloneStatus.NotCreated;
-								}
-								break;
-						}
+						result = GetResult(getCloneFromChorusHubDialog.ShowDialog(parent),
+							getCloneFromChorusHubDialog.PathToNewlyClonedFolder,
+							getCloneFromChorusHubModel.CloneSucceeded);
 					}
 					break;
 
@@ -154,40 +125,43 @@ namespace Chorus.UI.Clone
 						cloneFromUsbDialog.Model.ProjectFilter = projectFilter ?? DefaultProjectFilter;
 						cloneFromUsbDialog.Model.ReposInUse = existingRepositories;
 						cloneFromUsbDialog.Model.ExistingProjects = existingProjectNames;
-						switch (cloneFromUsbDialog.ShowDialog(parent))
-						{
-							default:
-								cloneStatus = CloneStatus.NotCreated;
-								break;
-							case DialogResult.Cancel:
-								cloneStatus = CloneStatus.Cancelled;
-								break;
-							case DialogResult.OK:
-								actualCloneLocation = cloneFromUsbDialog.PathToNewlyClonedFolder;
-								cloneStatus = CloneStatus.Created;
-								break;
-						}
+						// USB repositories have already been checked for to see if the same repo has already been cloned; return before this check
+						return GetResult(cloneFromUsbDialog.ShowDialog(parent), cloneFromUsbDialog.PathToNewlyClonedFolder);
 					}
-					break;
 
 			}
 			// Warn the user if they already have this by another name.
-			// Not currently needed for USB, since those have already been checked.
-			if (RepositorySource != ExtantRepoSource.Usb && cloneStatus == CloneStatus.Created)
+			if (result.CloneStatus == CloneStatus.Created)
 			{
-				var repo = new HgRepository(actualCloneLocation, new NullProgress());
-				string projectWithExistingRepo;
-				if (repo.Identifier != null && existingRepositories.TryGetValue(repo.Identifier, out projectWithExistingRepo))
+				var repo = new HgRepository(result.ActualLocation, new NullProgress());
+				if (repo.Identifier != null && existingRepositories.TryGetValue(repo.Identifier, out var projectWithExistingRepo))
 				{
 					using (var warningDlg = new DuplicateProjectWarningDialog())
 						warningDlg.Run(projectWithExistingRepo, howToSendReceiveMessageText);
-					Directory.Delete(actualCloneLocation, true);
-					actualCloneLocation = null;
-					cloneStatus = CloneStatus.Cancelled;
+					Directory.Delete(result.ActualLocation, true);
+					return new CloneResult(null, CloneStatus.NotCreated);
 				}
-
 			}
-			return new CloneResult(actualCloneLocation, cloneStatus);
+			return result;
+		}
+
+		internal static CloneResult GetResult(DialogResult dialogResult, string cloneLocation, bool success = true)
+		{
+			CloneStatus cloneStatus;
+			switch (dialogResult)
+			{
+				default:
+					cloneStatus = CloneStatus.NotCreated;
+					break;
+				case DialogResult.Cancel:
+					cloneStatus = CloneStatus.Cancelled;
+					break;
+				case DialogResult.OK:
+					cloneStatus = success ? CloneStatus.Created : CloneStatus.NotCreated;
+					break;
+			}
+
+			return new CloneResult(cloneStatus == CloneStatus.Created ? cloneLocation : null, cloneStatus);
 		}
 
 		internal static bool DefaultProjectFilter(string path)

--- a/src/LibChorus/CloneResult.cs
+++ b/src/LibChorus/CloneResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 
@@ -17,9 +17,9 @@ namespace Chorus
 		}
 
 		/// <summary>Get the actual location of a clone. (May, or may not, be the same as the desired location.)</summary>
-		public string ActualLocation { get; private set; }
+		public string ActualLocation { get; }
 		/// <summary>Get the status of the clone attempt.</summary>
-		public CloneStatus CloneStatus { get; private set; }
+		public CloneStatus CloneStatus { get; }
 	}
 
 	/// <summary>


### PR DESCRIPTION
This is necessary so that flexbridge can supply required cloning information and start a repo download without direct/manual user input. This order will come from Fieldworks when launched from CMD or protocol handler with the proper arguments.

Original issue [here](https://github.com/sillsdev/languageforge-lexbox/issues/242).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/325)
<!-- Reviewable:end -->
