### PR TITLE
remove usage of BinaryFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use UTF-8 in conflict details view
 - [SIL.Chorus.LibChorus] Add ChorusStorage (the bundle cache) as an Excluded folder
+- [SIL.Chorus.LibChorus] Changed HgResumeTransport LastKnownCommonBases to use Json serialization instead of BinaryFormatter
 
 ### Fixed
 

--- a/src/LibChorus.TestUtilities/RepositorySetup.cs
+++ b/src/LibChorus.TestUtilities/RepositorySetup.cs
@@ -297,7 +297,7 @@ namespace LibChorus.TestUtilities
 			Synchronizer.SyncNow(options);
 
 			Revision revision = Repository.GetRevisionWorkingSetIsBasedOn();
-			revision.EnsureParentRevisionInfo();
+			revision.EnsureParentRevisionInfo(Repository);
 			Assert.AreEqual(originalTip.Number.LocalRevisionNumber, revision.Parents[0].LocalRevisionNumber, "Should have moved back to original tip.");
 		}
 

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -1148,12 +1148,12 @@ namespace Chorus.VcsDrivers.Mercurial
 								infiniteLoopChecker++;
 							break;
 						case "changeset":
-							item = new Revision(this);
+							item = new Revision();
 							items.Add(item);
-							item.SetRevisionAndHashFromCombinedDescriptor(value);
+							item.SetRevisionAndHashFromCombinedDescriptor(value, this);
 							break;
 						case "parent":
-							item.AddParentFromCombinedNumberAndHash(value);
+							item.AddParentFromCombinedNumberAndHash(value, this);
 							break;
 
 						case "branch":

--- a/src/LibChorus/retrieval/RevisionInspector.cs
+++ b/src/LibChorus/retrieval/RevisionInspector.cs
@@ -31,7 +31,7 @@ namespace Chorus.retrieval
 		public IEnumerable<IChangeReport> GetChangeRecords(Revision revision)
 		{
 			var changes = new List<IChangeReport>();
-			revision.EnsureParentRevisionInfo();
+			revision.EnsureParentRevisionInfo(Repository);
 
 			if (!revision.HasAtLeastOneParent)
 			{

--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -562,7 +562,7 @@ namespace Chorus.sync
 				//  when there are more than 2 people merging and there's a failure or a no-op merge happened
 				foreach (var head in heads)
 				{
-					if (parent.Number.Hash == head.Number.Hash || (head.Branch == parent.Branch && head.IsDirectDescendantOf(parent)))
+					if (parent.Number.Hash == head.Number.Hash || (head.Branch == parent.Branch && head.IsDirectDescendantOf(parent, repository)))
 					{
 						repository.RollbackWorkingDirectoryToRevision(head.Number.LocalRevisionNumber);
 						_sychronizerAdjunct.SimpleUpdate(_progress, true);

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeTransportTests.cs
@@ -813,7 +813,86 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
             Assert.That(HgResumeTransport.CalculateEstimatedTimeRemaining(bundleSize, chunkSize, startOfWindow), Is.EqualTo("(about 5 minutes)"));
         }
 
+		[Test]
+		public void RoundTripLastKnownCommonBases_ResultsAreTheSame()
+		{
+			string storagePath = Path.Combine(Path.GetTempPath(), "HgResumeTransportTest");
+			var expectedRevisions = new List<Revision>()
+			{
+				new Revision()
+				{
+					Branch = "test1",
+					Number = new RevisionNumber()
+					{
+						Hash = "hash1",
+						LocalRevisionNumber = "abc",
+						LongHash = "long hash"
+					},
+					Summary = "summary",
+					UserId = "123",
+					Tag = "hello",
+					DateString = "a date?",
+					Parents =
+					{
+						new RevisionNumber()
+						{
+							LocalRevisionNumber = "parent1",
+							Hash = "parent hash",
+							LongHash = "parent long hash"
+						}
+					}
+				},
+				new Revision()
+				{
+					Branch = "test2",
+					Number = new RevisionNumber()
+					{
+						Hash = "hash2",
+						LocalRevisionNumber = "def",
+						LongHash = "long hash 2"
+					},
+					Summary = "summary 2",
+					UserId = "456",
+					Tag = "hello 2",
+					DateString = "a date 2?",
+					Parents =
+					{
+						new RevisionNumber()
+						{
+							LocalRevisionNumber = "parent2",
+							Hash = "parent hash 2",
+							LongHash = "parent long hash 2"
+						}
+					}
+				}
+			};
 
+			HgResumeTransport.SetLastKnownCommonBases(expectedRevisions, storagePath, "id1");
+			var actualRevisions = HgResumeTransport.GetLastKnownCommonBases(storagePath, "id1");
+			Assert.That(actualRevisions.Count, Is.EqualTo(expectedRevisions.Count));
+			for (int i = 0; i < expectedRevisions.Count; i++)
+			{
+				var actualRevision = actualRevisions[i];
+				var expectedRevision = expectedRevisions[i];
+				Assert.That(actualRevision.Branch, Is.EqualTo(expectedRevision.Branch));
+				Assert.That(actualRevision.Number.Hash, Is.EqualTo(expectedRevision.Number.Hash));
+				Assert.That(actualRevision.Number.LocalRevisionNumber, Is.EqualTo(expectedRevision.Number.LocalRevisionNumber));
+				Assert.That(actualRevision.Number.LongHash, Is.EqualTo(expectedRevision.Number.LongHash));
+				Assert.That(actualRevision.Summary, Is.EqualTo(expectedRevision.Summary));
+				Assert.That(actualRevision.UserId, Is.EqualTo(expectedRevision.UserId));
+				Assert.That(actualRevision.Tag, Is.EqualTo(expectedRevision.Tag));
+				Assert.That(actualRevision.DateString, Is.EqualTo(expectedRevision.DateString));
+				Assert.That(actualRevision.Parents.Count, Is.EqualTo(expectedRevision.Parents.Count));
+				for (int j = 0; j < expectedRevision.Parents.Count; j++)
+				{
+					var actualRevisionParent = actualRevision.Parents[j];
+					var expectedRevisionParent = expectedRevision.Parents[j];
+					Assert.That(actualRevisionParent.LocalRevisionNumber, Is.EqualTo(expectedRevisionParent.LocalRevisionNumber));
+					Assert.That(actualRevisionParent.Hash, Is.EqualTo(expectedRevisionParent.Hash));
+					Assert.That(actualRevisionParent.LongHash, Is.EqualTo(expectedRevisionParent.LongHash));
+				}
+			}
+		}
 
 		private class BranchTestAdjunct : ISychronizerAdjunct
 		{


### PR DESCRIPTION
closes #327
transition to json serialization. Refactor Revision.cs to support serialization, Revision has a public surface area so it may effect other applications using Chorus.

Previously Revision had a private field storing an HgRepository class, it's not clear to me if that was just left null when it was read back out but I've resolved that by removing it completely, now anyone calling a method that used to depend on that field will have to provide the repository itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/328)
<!-- Reviewable:end -->
