### PR TITLE
Try to fix flaky test

### DIFF
--- a/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
+++ b/src/LibChorusTests/notes/AnnotationRepositoryTests.cs
@@ -227,8 +227,8 @@ namespace LibChorus.Tests.notes
 		[Platform(Exclude = "Win", Reason = "flaky (on both platforms)")]
 		public void ExternalFileModification_NotifiesIndices_ButSaveDoesNot()
 		{
-			const int SleepTime = 10; // milliseconds
-			const int MaxTries = 1000; // max try 10ms * 1000 = 10s
+			const int SleepTime = 25; // milliseconds
+			const int MaxTries = 1000; // max try 25ms * 1000 = 25s
 			using (var t = new TempFile(@"<notes version='0'><annotation guid='123'>
 <message guid='234'>&lt;p&gt;hello</message></annotation></notes>"))
 			{


### PR DESCRIPTION
The ExternalFileModification_NotifiesIndices_ButSaveDoesNot test [has failed repeatedly](https://github.com/sillsdev/chorus/actions/runs/7211719967/job/19662567825#step:7:2142) on the GHA runner. I suspect the test, that waits 10 seconds to get notified of a filesystem change, may need more time to run. If that isn't enough to fix it, we should remove the test entirely: there's already a comment about how flaky it is, but now it's becoming "reliably flaky", so to speak.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/330)
<!-- Reviewable:end -->
