### PR TITLE
Do not log Send/Receive passwords

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -1071,13 +1071,18 @@ namespace Chorus.VcsDrivers.Mercurial
 				// and it will appear later in the log.
 				if(address.URI.Contains(RepositoryAddress.ProjectNameVariable))
 				{
-					return address.GetPotentialRepoUri(Identifier,
+					return ServerSettingsModel.RemovePasswordForLog(address.GetPotentialRepoUri(Identifier,
 						Path.GetFileNameWithoutExtension(_pathToRepository) + Path.GetExtension(_pathToRepository),
-						_progress);
+						_progress));
 				}
 			}
 			catch { /* Don't throw trying to get extra information to log */ }
-			return address.URI;
+			try
+			{
+				return ServerSettingsModel.RemovePasswordForLog(address.URI);
+			}
+			catch { /* Really don't throw trying to get extra information to log */ }
+			return "(unknown error getting URI)";
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #337.

Most code paths use ServerSettingsModel.RemovePasswordForLog to replace the user's Send/Receive password with a string of asterisks, but there was one code path where this was missed. This PR fixes that omission. It is also extra-cautious trying to make sure that the debug logging doesn't throw exceptions: if simply calling RemovePasswordForLog ends up throwing an exception somehow, instead of returning the unmodified URI (which might still have a password in it), we simply do not log the URI. This might be over-cautious, but it's probably better to be safe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/339)
<!-- Reviewable:end -->
