### PR TITLE
fix case where port number is lost using resumable

### DIFF
--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -21,10 +21,14 @@ jobs:
 
   build-and-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}
+      cancel-in-progress: true
 
     steps:
     - name: Checkout

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeRestApiServer.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeRestApiServer.cs
@@ -33,10 +33,15 @@ namespace Chorus.VcsDrivers.Mercurial
 		[Obsolete] public string UserName => null;
 		[Obsolete] public string Password => null;
 
-		public HgResumeApiResponse Execute(string method, HgResumeApiParameters parameters, byte[] contentToSend, int secondsBeforeTimeout)
+		public static string FormatUrl(Uri uri, string method, HgResumeApiParameters parameters)
 		{
 			string queryString = parameters.BuildQueryString();
-			Url = string.Format("{0}://{1}/api/v{2}/{3}?{4}", _url.Scheme, _url.Host, ApiVersion, method, queryString);
+			return $"{uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped)}/api/v{ApiVersion}/{method}{queryString}";
+		}
+
+		public HgResumeApiResponse Execute(string method, HgResumeApiParameters parameters, byte[] contentToSend, int secondsBeforeTimeout)
+		{
+			Url = FormatUrl(_url, method, parameters);
 			var req = (HttpWebRequest) WebRequest.Create(Url);
 			req.UserAgent = $"HgResume v{ApiVersion}";
 			req.PreAuthenticate = true;

--- a/src/LibChorus/VcsDrivers/Mercurial/IApiServer.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/IApiServer.cs
@@ -43,9 +43,13 @@ namespace Chorus.VcsDrivers.Mercurial
 		// used only by getRevisions API
 		public int Quantity { get; set; }
 
+		/// <summary>
+		/// returns a query string, prefixed with a '?' unless there are no parameters
+		/// </summary>
+		/// <returns></returns>
 		public string BuildQueryString()
 		{
-			string query = "";
+			string query = "?";
 			if (StartOfWindow >= 0)
 			{
 				query += String.Format("offset={0}&", StartOfWindow);
@@ -76,6 +80,10 @@ namespace Chorus.VcsDrivers.Mercurial
 			if (!String.IsNullOrEmpty(RepoId))
 			{
 				query += String.Format("repoId={0}&", RepoId);
+			}
+			if (query == "?")
+			{
+				return "";
 			}
 			return query.TrimEnd('&');
 		}

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeRestApiServerTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgResumeRestApiServerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Chorus.VcsDrivers.Mercurial;
 using NUnit.Framework;
 
@@ -20,6 +21,37 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 			var api = new HgResumeRestApiServer("https://hg.languageforge.org/projects/kyu-dictionary");
 			Assert.That(api.Host, Is.EqualTo("hg.languageforge.org"));
 			Assert.That(api.ProjectId, Is.EqualTo("kyu-dictionary"));
+		}
+
+		[Test]
+		public void FormatUrl_FormatsCorrectlyWithEmptyParameters()
+		{
+			Assert.That(HgResumeRestApiServer.FormatUrl(
+					new Uri("https://hg.languageforge.org:1234/projects/kyu-dictionary"),
+					"foo",
+					new HgResumeApiParameters()),
+				Is.EqualTo("https://hg.languageforge.org:1234/api/v03/foo"));
+		}
+
+		[Test]
+		public void FormatUrl_FormatsCorrectlyWithParameters()
+		{
+			//this test is overly specific as the order of the parameters is not important, however this is much simpler to write.
+			Assert.That(HgResumeRestApiServer.FormatUrl(
+					new Uri("https://hg.languageforge.org:1234/projects/kyu-dictionary"),
+					"foo",
+					new HgResumeApiParameters
+					{
+						StartOfWindow = 10,
+						ChunkSize = 20,
+						BundleSize = 30,
+						Quantity = 40,
+						TransId = "transId",
+						BaseHashes = new[] { "baseHash1", "baseHash2" },
+						RepoId = "repoId"
+					}),
+				Is.EqualTo(
+					"https://hg.languageforge.org:1234/api/v03/foo?offset=10&chunkSize=20&bundleSize=30&quantity=40&transId=transId&baseHashes[]=baseHash1&baseHashes[]=baseHash2&repoId=repoId"));
 		}
 	}
 }


### PR DESCRIPTION
previously the port number would be lost when using resumable. Meaning if the url was typed in as localhost:5158 requests would be made to localhost port 80.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/343)
<!-- Reviewable:end -->
