### PR TITLE
Avoid NullReferenceExeption in GetTextFromQuery

### DIFF
--- a/src/LibChorus/Utilities/HgProcessOutputReader.cs
+++ b/src/LibChorus/Utilities/HgProcessOutputReader.cs
@@ -69,7 +69,7 @@ namespace Chorus.Utilities
 			}
 
 			//nb: at one point I (jh) tried adding !process.HasExited, but that made things less stable.
-			while ( _outputReader.ThreadState != ThreadState.Stopped && _errorReader.ThreadState != ThreadState.Stopped)
+			while (outputReaderArgs.Results == null || errorReaderArgs.Results == null)
 			{
 				DateTime end;
 				lock (this)

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -468,13 +468,13 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 			var result = ExecuteErrorsOk(query, secondsBeforeTimeoutOnLocalOperation);
 
-			var standardOutputText = result.StandardOutput.Trim();
+			var standardOutputText = result.StandardOutput?.Trim();
 			if (!string.IsNullOrEmpty(standardOutputText))
 			{
 				_progress.WriteVerbose(standardOutputText);
 			}
 
-			var standardErrorText = result.StandardError.Trim();
+			var standardErrorText = result.StandardError?.Trim();
 			if (!string.IsNullOrEmpty(standardErrorText))
 			{
 				_progress.WriteError(standardErrorText);
@@ -485,7 +485,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				_progress.WriteWarning("Hg Command {0} left lock", query);
 			}
 
-			return result.StandardOutput;
+			return result.StandardOutput ?? "";
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #344.

In rare cases, a thread-scheduling race condition can cause a thread's state to be ThreadState.Stopped even though it hasn't yet executed its `finally` block, which can result in result.StandardOutput or Error not being assigned a string, leaving them null. Furthermore, [the C# docs say not to depend on ThreadState](https://learn.microsoft.com/en-us/dotnet/api/system.threading.threadstate?view=net-8.0#remarks) for synchronizing thread activity. So instead we check for the thread having ended by seeing whether the `finally` block has assigned a value to its Results property; until then, Results is null.

This should guarantee the safety of the existing GetTextFromQuery code, but to be safe we also make sure it can turn null into an empty string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/346)
<!-- Reviewable:end -->
