### PR TITLE
Don't duplicate hg process output in GetTextFromQuery

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -468,18 +468,6 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 			var result = ExecuteErrorsOk(query, secondsBeforeTimeoutOnLocalOperation);
 
-			var standardOutputText = result.StandardOutput?.Trim();
-			if (!string.IsNullOrEmpty(standardOutputText))
-			{
-				_progress.WriteVerbose(standardOutputText);
-			}
-
-			var standardErrorText = result.StandardError?.Trim();
-			if (!string.IsNullOrEmpty(standardErrorText))
-			{
-				_progress.WriteError(standardErrorText);
-			}
-
 			if (GetHasLocks())
 			{
 				_progress.WriteWarning("Hg Command {0} left lock", query);


### PR DESCRIPTION
Fixes #345.

GetTextFromQuery calls ExecuteErrorsOk, which already logs the value of stdout and stderr to the progress dialog. So there's no point in logging the same value a second time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/347)
<!-- Reviewable:end -->
