### PR TITLE
No more unnecessary empty "stderr:" lines in log

### DIFF
--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -702,13 +702,13 @@ namespace Chorus.VcsDrivers.Mercurial
 			{
 				throw new UserCancelledException();
 			}
-			if (!string.IsNullOrEmpty(result.StandardError))
+			if (!string.IsNullOrWhiteSpace(result.StandardError))
 			{
-				_progress.WriteVerbose("standerr: " + result.StandardError);//not necessarily an *error* down this deep
+				_progress.WriteVerbose("standerr: " + result.StandardError.TrimEnd());//not necessarily an *error* down this deep
 			}
-			if (!string.IsNullOrEmpty(result.StandardOutput))
+			if (!string.IsNullOrWhiteSpace(result.StandardOutput))
 			{
-				_progress.WriteVerbose("standout: " + result.StandardOutput);//not necessarily an *error* down this deep
+				_progress.WriteVerbose("standout: " + result.StandardOutput.TrimEnd());//not necessarily an *error* down this deep
 			}
 
 #if DEBUG


### PR DESCRIPTION
Many times stderr's contents are just a single newline; there's no need to write that to the progress log. We also don't need to write double newlines to the log, so trim the final trailing newline before writing.

Fixes #348.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/349)
<!-- Reviewable:end -->
