### PR TITLE
Allow overriding hg.exe location with env vars

### DIFF
--- a/src/LibChorus/MercurialLocation.cs
+++ b/src/LibChorus/MercurialLocation.cs
@@ -54,7 +54,7 @@ namespace Chorus// DON'T MOVE THIS! It needs to be super easy for the client to 
 			get
 			{
 				string path = Environment.GetEnvironmentVariable(EnvPathToHgExecutable);
-				if (path != null) return path;
+				if (!string.IsNullOrEmpty(path)) return path;
 				GuessAtLocationIfNotSetAlready();
 
 				if(string.IsNullOrEmpty(_pathToMercurialFolder))

--- a/src/LibChorus/MercurialLocation.cs
+++ b/src/LibChorus/MercurialLocation.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 using Chorus.Utilities;
 using SIL.Code;
 using SIL.PlatformUtilities;
@@ -11,8 +12,12 @@ namespace Chorus// DON'T MOVE THIS! It needs to be super easy for the client to 
 	/// </summary>
 	public class MercurialLocation
 	{
+		public const string EnvPathToHgExecutable = "CHORUS_PATH_TO_HG_EXECUTABLE";
+		public const string EnvPathToMercurialFolder = "CHORUS_PATH_TO_MERCURIAL_FOLDER";
+		public const string EnvHgExe = "CHORUS_HG_EXE";
+
 		private static string _pathToMercurialFolder;
-		private static string _hgExe = Platform.IsWindows ? "hg.exe" : "hg";
+		private static string _hgExe = Environment.GetEnvironmentVariable(EnvHgExe) ?? (Platform.IsWindows ? "hg.exe" : "hg");
 
 		/// <summary>
 		/// Clients can set this if they have their own private copy of Mercurial (recommended)
@@ -42,12 +47,14 @@ namespace Chorus// DON'T MOVE THIS! It needs to be super easy for the client to 
 		}
 
 		/// <summary>
-		/// Will use the PathToMercurialFolder, otherwise will just return "hg"
+		/// Will use the environment variable override if set, or will use PathToMercurialFolder if possible, otherwise will just return "hg" and rely on PATH
 		/// </summary>
 		public static string PathToHgExecutable
 		{
 			get
 			{
+				string path = Environment.GetEnvironmentVariable(EnvPathToHgExecutable);
+				if (path != null) return path;
 				GuessAtLocationIfNotSetAlready();
 
 				if(string.IsNullOrEmpty(_pathToMercurialFolder))
@@ -60,6 +67,13 @@ namespace Chorus// DON'T MOVE THIS! It needs to be super easy for the client to 
 		{
 			if (!string.IsNullOrEmpty(_pathToMercurialFolder))
 			{
+				return;
+			}
+
+			string path = Environment.GetEnvironmentVariable(EnvPathToMercurialFolder);
+			if (!string.IsNullOrEmpty(path))
+			{
+				PathToMercurialFolder = path;
 				return;
 			}
 


### PR DESCRIPTION
Fix #352.

Three env vars are defined, one that sets the path to the Mercurial executable directly (overriding both folder and exe name), one that just overrides the folder and lets Chorus pick the exe name, and one that just overrides the exe name and lets Chorus pick the folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/353)
<!-- Reviewable:end -->
