### PR TITLE
Run tests in parallel, one per framework

### DIFF
--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -61,14 +61,16 @@ jobs:
     # Unfortunately we need two test steps because we need different filters.
     # We could conditionally set an environment variable, but unfortunately
     # the syntax to access that is different on Windows vs Linux.
+    # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs
     - name: Test on Linux
-      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
+      run: dotnet test -f ${{ matrix.framework }} -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
       run: dotnet test --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'windows-latest'
 
+    # TODO: Give each test result its own name based on OS and framework and change the test-results.yml workflow accordingly, so that they don't overwrite each other
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -26,6 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        framework: [net461, net6.0, net8.0]
+        exclude:
+          # dotnet on Linux cannot build net461 without additional, unnecessary, work
+          - os: ubuntu-latest
+            framework: net461
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}
       cancel-in-progress: true
@@ -47,7 +52,7 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --no-restore -c Release
+      run: dotnet build -f ${{ matrix.framework }} --no-restore -c Release
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2
@@ -57,7 +62,7 @@ jobs:
     # We could conditionally set an environment variable, but unfortunately
     # the syntax to access that is different on Windows vs Linux.
     - name: Test on Linux
-      run: dotnet test --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
+      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
@@ -68,29 +73,30 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: Test Results (${{matrix.os}})
+        name: Test Results (${{ matrix.framework }} on ${{matrix.os}})
         path: "**/TestResults/*.xml"
 
+  build-installers:
+    name: "Build Windows installers"
+    runs-on: windows-latest
+    needs: build-and-test
+    steps:
     - name: Checkout Chorus Help # required for Chorus Merge Module
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         repository: sillsdev/chorushelp
         path: DistFiles/Help
-      if: matrix.os == 'windows-latest'
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # v1.1.3
-      if: matrix.os == 'windows-latest'
 
     # ChorusMergeModule.msm is used by FieldWorks, FLExBridge, and possibly WeSay installers (as of 2022.12).
     # CMM must be built after tests have been run, since the fixutf8.pyc files are generated only when the .py  files are run.
     - name: Build Merge Module
       run: msbuild src/Installer/ChorusMergeModule.wixproj
-      if: matrix.os == 'windows-latest'
 
     - name: Pack Merge Module
       run: msbuild src/Installer/ChorusMergeModule.wixproj -t:pack
-      if: matrix.os == 'windows-latest'
 
     - name: Upload Merge Module
       uses: actions/upload-artifact@v4
@@ -99,14 +105,12 @@ jobs:
         path: |
           output/Release/*.msm
           output/*.nupkg
-      if: matrix.os == 'windows-latest'
 
     - name: Build Chorus Hub Installer
       run: |
         msbuild src/Installer/ChorusHub.wixproj /t:Restore
         msbuild src/Installer/ChorusHub.wixproj /t:StampLicenseYear
         msbuild src/Installer/ChorusHub.wixproj /t:Build
-      if: matrix.os == 'windows-latest'
 
     - name: Upload Chorus Hub Installer
       uses: actions/upload-artifact@v4
@@ -114,7 +118,6 @@ jobs:
         name: chorus-hub-installer
         path: |
           output/Release/*.msi
-      if: matrix.os == 'windows-latest'
 
     - name: Pack
       run: dotnet pack --no-restore --no-build -c Release
@@ -126,12 +129,11 @@ jobs:
         path: |
           output/*.nupkg
           output/*.snupkg
-      if: matrix.os == 'ubuntu-latest'
 
   publish-nuget:
     name: "Publish NuGet package"
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: build-installers
     if: github.event_name == 'push'
     steps:
     - name: Download Artifacts

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -48,11 +48,14 @@ jobs:
           6.0.x
           8.0.x
 
+    # We skip restore and build steps on Linux due to a dotnet SDK bug - 2024-10-30 RM
     - name: Restore
       run: dotnet restore
+      if: matrix.os == 'windows-latest'
 
     - name: Build
       run: dotnet build --no-restore -c Release
+      if: matrix.os == 'windows-latest'
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2
@@ -61,7 +64,7 @@ jobs:
     # Unfortunately we need two test steps because we need different filters.
     # We could conditionally set an environment variable, but unfortunately
     # the syntax to access that is different on Windows vs Linux.
-    # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs
+    # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs - 2024-10-30 RM
     - name: Test on Linux
       run: dotnet test -f ${{ matrix.framework }} -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -66,7 +66,7 @@ jobs:
       run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 
     - name: Test LibChorus
-      run: dotnet test src/LibChorus.Tests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 
     # TODO: Give each test result its own name based on OS and framework and change the test-results.yml workflow accordingly, so that they don't overwrite each other
     - name: Upload Test Results

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -85,6 +85,17 @@ jobs:
     runs-on: windows-latest
     needs: build-and-test
     steps:
+    - name: Checkout
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      with:
+        fetch-depth: 0 # fetch full history for GitVersion
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore -c Release
+
     - name: Checkout Chorus Help # required for Chorus Merge Module
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -62,6 +62,10 @@ jobs:
       run: dotnet test src/Chorus.Tests/Chorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
       if: matrix.framework == 'net461'
 
+    - name: Test Chorus Hub
+      run: dotnet test src/ChorusHubTests/ChorusHubTests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      if: matrix.framework == 'net461'
+
     - name: Test ChorusMerge
       run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -48,14 +48,11 @@ jobs:
           6.0.x
           8.0.x
 
-    # We skip restore and build steps on Linux due to a dotnet SDK bug - 2024-10-30 RM
     - name: Restore
-      run: dotnet restore
-      if: matrix.os == 'windows-latest'
+      run: dotnet restore -p:TargetFramework=${{ matrix.framework }}
 
     - name: Build
-      run: dotnet build --no-restore -c Release
-      if: matrix.os == 'windows-latest'
+      run: dotnet build --no-restore -c Release -f ${{ matrix.framework }}
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -63,7 +63,7 @@ jobs:
     # the syntax to access that is different on Windows vs Linux.
     # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs - 2024-10-30 RM
     - name: Test on Linux
-      run: dotnet test -f ${{ matrix.framework }} --no-build --runtime linux-x64 -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
+      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [net461, net6.0, net8.0]
+        framework: [net461, net8.0]
         exclude:
           # dotnet on Linux cannot build net461 without additional, unnecessary, work
           - os: ubuntu-latest

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -32,7 +32,7 @@ jobs:
           - os: ubuntu-latest
             framework: net461
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.framework }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -58,17 +58,15 @@ jobs:
       run: sudo apt-get install python2
       if: matrix.os == 'ubuntu-latest'
 
-    # Unfortunately we need two test steps because we need different filters.
-    # We could conditionally set an environment variable, but unfortunately
-    # the syntax to access that is different on Windows vs Linux.
-    # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs - 2024-10-30 RM
-    - name: Test on Linux
-      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
-      if: matrix.os == 'ubuntu-latest'
+    - name: Test Chorus
+      run: dotnet test src/Chorus.Tests/Chorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      if: matrix.framework == 'net461'
 
-    - name: Test on Windows
-      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix.os == 'windows-latest'
+    - name: Test ChorusMerge
+      run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+
+    - name: Test LibChorus
+      run: dotnet test src/LibChorus.Tests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 
     # TODO: Give each test result its own name based on OS and framework and change the test-results.yml workflow accordingly, so that they don't overwrite each other
     - name: Upload Test Results

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -52,7 +52,7 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build -f ${{ matrix.framework }} --no-restore -c Release
+      run: dotnet build --no-restore -c Release
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -49,10 +49,10 @@ jobs:
           8.0.x
 
     - name: Restore
-      run: dotnet restore -p:TargetFramework=${{ matrix.framework }}
+      run: dotnet restore
 
     - name: Build
-      run: dotnet build --no-restore -c Release -f ${{ matrix.framework }}
+      run: dotnet build --no-restore -c Release
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2
@@ -63,11 +63,11 @@ jobs:
     # the syntax to access that is different on Windows vs Linux.
     # Note: we also omit `--no-build` on Linux due to dotnet SDK bug 29742, so that `dotnet test` won't complain about pre-built DLLs - 2024-10-30 RM
     - name: Test on Linux
-      run: dotnet test -f ${{ matrix.framework }} -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
+      run: dotnet test -f ${{ matrix.framework }} --no-build --runtime linux-x64 -c Release --filter TestCategory!=RequiresUI -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'ubuntu-latest'
 
     - name: Test on Windows
-      run: dotnet test --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      run: dotnet test -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
       if: matrix.os == 'windows-latest'
 
     # TODO: Give each test result its own name based on OS and framework and change the test-results.yml workflow accordingly, so that they don't overwrite each other

--- a/src/Chorus.Tests/Chorus.Tests.csproj
+++ b/src/Chorus.Tests/Chorus.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ChorusHubTests/ChorusHubTests.csproj
+++ b/src/ChorusHubTests/ChorusHubTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SIL.TestUtilities" Version="12.0.0-*" />
   </ItemGroup>
 

--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>ChorusMerge.Tests</RootNamespace>
     <AssemblyTitle>ChorusMerge.Tests</AssemblyTitle>
     <Description>Unit tests for LibChorus.dll</Description>
+    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>ChorusMerge.Tests</RootNamespace>
     <AssemblyTitle>ChorusMerge.Tests</AssemblyTitle>
     <Description>Unit tests for LibChorus.dll</Description>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ChorusMerge/ChorusMerge.csproj
+++ b/src/ChorusMerge/ChorusMerge.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>ChorusMerge</AssemblyTitle>
     <PackageId>SIL.Chorus.ChorusMerge</PackageId>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RepositoryUrl>https://github.com/sillsdev/chorus.git</RepositoryUrl>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2"/>
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SIL.Core" Version="12.0.0-*" />
     <PackageReference Include="SIL.TestUtilities" Version="12.0.0-*" />

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>LibChorus.Tests</RootNamespace>
     <AssemblyTitle>LibChorus.Tests</AssemblyTitle>
     <Description>Unit tests for LibChorus.dll</Description>
-    <TargetFrameworks>net461;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Now that tests run on three frameworks (net461, net6.0, net8.0), we can save a lot of build time by running each framework's tests in parallel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/354)
<!-- Reviewable:end -->
