### PR TITLE
Replace Platform.IsMono with actual OS checks

### DIFF
--- a/src/Chorus/UI/Sync/SyncStartModel.cs
+++ b/src/Chorus/UI/Sync/SyncStartModel.cs
@@ -165,7 +165,7 @@ namespace Chorus.UI.Sync
 				try
 				{
 					var first = usbDrives[0];
-					if (!Platform.IsMono)
+					if (Platform.IsWindows)
 					{
 						message = string.Format(LocalizationManager.GetString(
 								"GetUsbStatus.DriveInfoAndFreeSpace",

--- a/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
@@ -17,6 +17,8 @@ namespace Chorus.FileTypeHandlers.text
 	[Export(typeof(IChorusFileTypeHandler))]
 	public class TextFileTypeHandler : IChorusFileTypeHandler
 	{
+		//NB: there is a post-build step in this project which copies the diff3 folder into the output on Windows
+		private static string _diff3Exe = Platform.IsWindows ? "diff3/bin/diff3.exe" : "diff3";
 		internal TextFileTypeHandler()
 		{}
 
@@ -64,7 +66,7 @@ namespace Chorus.FileTypeHandlers.text
 		{
 			//NB: surrounding with quotes didn't cut it to get past paths with spaces
 
-			return RunProcess("diff3/bin/diff3.exe", "-m " + LongToShortConverter.GetShortPath(oursPath) + " " +
+			return RunProcess(_diff3Exe, "-m " + LongToShortConverter.GetShortPath(oursPath) + " " +
 				LongToShortConverter.GetShortPath(commonPath) + " " +
 				LongToShortConverter.GetShortPath(theirPath));
 		}
@@ -81,7 +83,6 @@ namespace Chorus.FileTypeHandlers.text
 			p.StartInfo.RedirectStandardError = true;
 			p.StartInfo.RedirectStandardOutput = true;
 
-			//NB: there is a post-build step in this project which copies the diff3 folder into the output
 			p.StartInfo.FileName = filePath;
 			p.StartInfo.Arguments = arguments;
 			p.StartInfo.CreateNoWindow = true;

--- a/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
@@ -154,7 +154,7 @@ namespace Chorus.FileTypeHandlers.text
 
 		public static string GetShortPath(string path)
 		{
-			if (Platform.IsMono)
+			if (!Platform.IsWindows)
 				return path;
 
 			var shortPath = new StringBuilder(255);

--- a/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
@@ -79,7 +79,6 @@ namespace Chorus.FileTypeHandlers.text
 		public static string RunProcess(string filePath, string[] arguments)
 		{
 			Process p = new Process();
-			ProcessStartInfo startInfo = new ProcessStartInfo();
 			p.StartInfo.UseShellExecute = false;
 			p.StartInfo.RedirectStandardError = true;
 			p.StartInfo.RedirectStandardOutput = true;

--- a/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
+++ b/src/LibChorus/FileTypeHandlers/text/TextFileTypeHandler.cs
@@ -66,17 +66,21 @@ namespace Chorus.FileTypeHandlers.text
 		{
 			//NB: surrounding with quotes didn't cut it to get past paths with spaces
 
-			return RunProcess(_diff3Exe, new string[] {"-m", LongToShortConverter.GetShortPath(oursPath),
-				LongToShortConverter.GetShortPath(commonPath),
-				LongToShortConverter.GetShortPath(theirPath) });
+			return RunProcess(_diff3Exe, "-m" + QuoteIfNeeded(LongToShortConverter.GetShortPath(oursPath))
+				+ " " + QuoteIfNeeded(LongToShortConverter.GetShortPath(commonPath))
+				+ " " + QuoteIfNeeded(LongToShortConverter.GetShortPath(theirPath)));
 		}
 
-		protected static string SurroundWithQuotes(string path)
+		protected static string QuoteIfNeeded(string arg)
 		{
-			return "\"" + path + "\"";
+			if (arg.Contains(" ")) {
+				return "\"" + arg.Replace("\"", "\\\"") + "\"";
+			} else {
+				return arg;
+			}
 		}
 
-		public static string RunProcess(string filePath, string[] arguments)
+		public static string RunProcess(string filePath, string arguments)
 		{
 			Process p = new Process();
 			p.StartInfo.UseShellExecute = false;
@@ -84,17 +88,7 @@ namespace Chorus.FileTypeHandlers.text
 			p.StartInfo.RedirectStandardOutput = true;
 
 			p.StartInfo.FileName = filePath;
-			// netstandard2.1 has p.StartInfo.ArgumentList that would solve all our problems, but we have to target netstandard2.0 so we have to do this ourselves
-			var quotedArgs = new List<string>(arguments.Length);
-			foreach (var arg in arguments)
-			{
-				if (arg.Contains(" ")) {
-					quotedArgs.Add("\"" + arg.Replace("\"", "\\\"") + "\"");
-				} else {
-					quotedArgs.Add(arg);
-				}
-			}
-			p.StartInfo.Arguments = string.Join(" ", quotedArgs);
+			p.StartInfo.Arguments = arguments;
 			p.StartInfo.CreateNoWindow = true;
 			p.Start();
 			p.WaitForExit();

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -1138,7 +1138,7 @@ namespace Chorus.VcsDrivers.Mercurial
 					switch (label)
 					{
 						default:
-							if (Platform.IsMono)
+							if (Platform.IsLinux)
 								infiniteLoopChecker++;
 							break;
 						case "changeset":

--- a/src/LibChorus/merge/text/PartialTextMerger.cs
+++ b/src/LibChorus/merge/text/PartialTextMerger.cs
@@ -183,7 +183,8 @@ namespace Chorus.merge.text
 			p.StartInfo.RedirectStandardOutput = true;
 
 			//NB: there is a post-build step in this project which copies the diff3 folder into the output
-			p.StartInfo.FileName = "diff3/bin/diff3.exe";
+			var filename = File.Exists("diff3/bin/diff3.exe") ? "diff3/bin/diff3.exe" : "diff3"; // On Linux, just use diff3 from the PATH
+			p.StartInfo.FileName = filename;
 			p.StartInfo.Arguments = "-m " + oursPath + " "+commonPath+" "+theirPath;
 			p.StartInfo.CreateNoWindow = true;
 			p.Start();

--- a/src/LibChorusTests/VcsDrivers/Mercurial/MercurialTestUtilities.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/MercurialTestUtilities.cs
@@ -30,7 +30,7 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 		private static void UpdateExtensions()
 		{
 			var extensions = new Dictionary<string, string>();
-			if (!Platform.IsMono)
+			if (Platform.IsWindows)
 				extensions.Add("eol", ""); //for converting line endings on windows machines
 			extensions.Add("hgext.graphlog", ""); //for more easily readable diagnostic logs
 			extensions.Add("convert", ""); //for catastrophic repair in case of repo corruption


### PR DESCRIPTION
Fix #355.

Some cases of Platform.IsMono are workarounds for bugs in older versions of mono. Those can probably be removed, but for safety's sake, we'll leave them alone for now.

Other cases are clearly trying to check the platform, to run Linux-only or Windows-only code. Those cases should be replaced by Platform.IsUnix or Platform.IsWindows as appropriate, because nearly everywhere that Chorus is being run on Linux these days, it's running under dotnet rather than mono, and the Platform.IsMono check returns false.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/356)
<!-- Reviewable:end -->
