### PR TITLE
Start tracing send recieve

### DIFF
--- a/src/LibChorus/LibChorus.csproj
+++ b/src/LibChorus/LibChorus.csproj
@@ -6,6 +6,7 @@
     <PackageId>SIL.Chorus.LibChorus</PackageId>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RepositoryUrl>https://github.com/sillsdev/chorus.git</RepositoryUrl>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
     <PackageReference Include="SIL.Lift" Version="15.0.0-*" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>

--- a/src/LibChorus/LibChorusActivitySource.cs
+++ b/src/LibChorus/LibChorusActivitySource.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Chorus.VcsDrivers.Mercurial;
+using JetBrains.Annotations;
 
 namespace Chorus
 {
@@ -13,6 +14,7 @@ namespace Chorus
 
 		public static void TagResumableParameters(this Activity activity, string direction, HgResumeApiParameters request)
 		{
+			if (activity is null) return;
 			activity.SetTag($"app.chorus.resumable.{direction}.chunk-size", request.ChunkSize);
 			activity.SetTag($"app.chorus.resumable.{direction}.bundle-size", request.BundleSize);
 			activity.SetTag($"app.chorus.resumable.{direction}.start-of-window", request.StartOfWindow);

--- a/src/LibChorus/LibChorusActivitySource.cs
+++ b/src/LibChorus/LibChorusActivitySource.cs
@@ -1,5 +1,5 @@
-﻿// // Copyright (c) 2025-2025 SIL International
-// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+﻿// Copyright (c) 2025-2025 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Diagnostics;
 using Chorus.VcsDrivers.Mercurial;

--- a/src/LibChorus/LibChorusActivitySource.cs
+++ b/src/LibChorus/LibChorusActivitySource.cs
@@ -1,0 +1,13 @@
+﻿// // Copyright (c) 2025-2025 SIL International
+// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Diagnostics;
+
+namespace Chorus
+{
+	public static class LibChorusActivitySource
+	{
+		public const string ActivitySourceName = "SIL.LibChorus";
+		internal static readonly ActivitySource Value = new ActivitySource(ActivitySourceName);
+	}
+}

--- a/src/LibChorus/LibChorusActivitySource.cs
+++ b/src/LibChorus/LibChorusActivitySource.cs
@@ -2,6 +2,7 @@
 // // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Diagnostics;
+using Chorus.VcsDrivers.Mercurial;
 
 namespace Chorus
 {
@@ -9,5 +10,15 @@ namespace Chorus
 	{
 		public const string ActivitySourceName = "SIL.LibChorus";
 		internal static readonly ActivitySource Value = new ActivitySource(ActivitySourceName);
+
+		public static void TagResumableParameters(this Activity activity, string direction, HgResumeApiParameters request)
+		{
+			activity.SetTag($"app.chorus.resumable.{direction}.chunk-size", request.ChunkSize);
+			activity.SetTag($"app.chorus.resumable.{direction}.bundle-size", request.BundleSize);
+			activity.SetTag($"app.chorus.resumable.{direction}.start-of-window", request.StartOfWindow);
+			activity.SetTag($"app.chorus.resumable.{direction}.trans-id", request.TransId);
+			activity.SetTag($"app.chorus.resumable.{direction}.repo-id", request.RepoId);
+			activity.SetTag($"app.chorus.resumable.{direction}.quantity", request.Quantity);
+		}
 	}
 }

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -505,6 +505,9 @@ namespace Chorus.VcsDrivers.Mercurial
 
 		private PushResponse PushOneChunk(HgResumeApiParameters request, byte[] dataToPush)
 		{
+			using var activity = LibChorusActivitySource.Value.StartActivity();
+			activity?.TagResumableParameters("push", request);
+
 			var pushResponse = new PushResponse(PushStatus.Fail);
 			try
 			{
@@ -810,6 +813,8 @@ namespace Chorus.VcsDrivers.Mercurial
 
 		private PullResponse PullOneChunk(HgResumeApiParameters request)
 		{
+			using var activity = LibChorusActivitySource.Value.StartActivity();
+			activity?.TagResumableParameters("pull", request);
 			var pullResponse = new PullResponse(PullStatus.Fail);
 			try
 			{

--- a/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgResumeTransport.cs
@@ -815,6 +815,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		{
 			using var activity = LibChorusActivitySource.Value.StartActivity();
 			activity?.TagResumableParameters("pull", request);
+
 			var pullResponse = new PullResponse(PullStatus.Fail);
 			try
 			{


### PR DESCRIPTION
the package System.Diagnostics.DiagnosticSource supports all the way back to net462 and lets use configure some distributed tracing which can then be instrumented by our applications. After tracing our sync code in Lexbox, I would like to get a little more insight into what's going on in chorus. I've trace the following:

- SyncNow which is the main entry point for S&R
- push, pull, merge which are called by SyncNow
- HgRunner to trace calls to hg
- Hg resumable calls split up by chunks (I didn't go to the request level here because that's already traced by dotnet)

Tracing is similar to logging so that when no one is listening to the activity source then no activity will be created and it'll be a noop for the code in question. In order to listen to those events with OTEL, you can do something like `service.AddOpenTelemetry().WithTracing(b => b.AddSource(LibChorusActivitySource.ActivitySourceName));`
then all the activities configured in this PR will be emit traces and logged in OTEL. I suspect other application tracing frameworks would also tap in to these traces. It could also be used for analytics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/360)
<!-- Reviewable:end -->
