### PR TITLE
Update GitVersion dependency to 6.3.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,20 +3,21 @@ assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:GITVERSION_BUILD_
 mode: ContinuousDeployment
 branches:
   master:
-    tag: beta
+    label: beta
     regex: (origin/)?master
   hotfix:
-    tag: beta
+    label: beta
     regex: (origin/)?hotfix[/-]
     increment: Patch
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
     tracks-release-branches: false
     is-release-branch: false
   pull-request:
     mode: ContinuousDeployment
-    tag: PR
+    label: PR
   feature:
     regex: feature[/-]
     mode: ContinuousDeployment
-    tag: alpha
+    label: alpha

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -4,7 +4,7 @@
     <TargetFrameworks/>
     <TargetFramework>netframework4.8</TargetFramework>
     <PackageId>SIL.Chorus.l10ns</PackageId>
-    <Version>$(GitVersion_NuGetVersion)</Version>
+    <Version>$(GitVersion_SemVer)</Version>
     <Authors>Jason Naylor</Authors>
     <Company>SIL International</Company>
 	<RestartBuild Condition="'$(PkgGitVersion_GitVersion_MsBuild)' == ''
@@ -14,7 +14,7 @@
 	  OR '$(PkgSIL_BuildTasks)' == ''">true</RestartBuild>
 	<RestartBuild Condition="'$(RestartBuild)' == ''">false</RestartBuild>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0" GeneratePathProperty="true">
       <PrivateAssets>All</PrivateAssets>
@@ -24,19 +24,19 @@
     <PackageReference Include="NuGet.CommandLine" Version="6.7.0" GeneratePathProperty="true" />
     <PackageReference Include="SIL.BuildTasks" Version="2.6.0-beta0030" GeneratePathProperty="true" />
   </ItemGroup>
-  
+
   <UsingTask TaskName="NormalizeLocales" AssemblyFile="$(PkgSIL_BuildTasks)\tools\SIL.BuildTasks.dll" />
-  
+
   <Target Name="UpdateCrowdin">
 	<Message Text="RestartBuild=$(RestartBuild)"/>
 	<CallTarget Targets="RestoreBuildDependencies"/>
 	<CallTarget Targets="UpdateCrowdinInternal" Condition="!$(RestartBuild)" />
 	<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="UpdateCrowdinInternal" Properties="Configuration=$(Configuration)" Condition="$(RestartBuild)" />
   </Target>
-  
+
   <Target Name="RestoreBuildDependencies" DependsOnTargets="restore">
   </Target>
-	
+
   <Target Name="UpdateCrowdinInternal" DependsOnTargets="GetVersion">
 	<!-- Remove "not found" messages that are appended each run (Can't MatchWholeLine because leading spaces are trimmed from Lines).
 		These messages accumulate linearly and inifinitely at each ExtractXliff run and are not removed if the string is later found.
@@ -46,12 +46,12 @@
 	  Lines="        &lt;note xml:lang=&quot;en&quot;&gt;Not found in static scan of compiled code (version 0.0.0)&lt;/note&gt;"/>
 	<!-- Build and extract strings -->
 	<Exec Command="dotnet build -c Release" WorkingDirectory=".."/>
-	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL -o Chorus.dll -b Chorus.en.xlf -x Chorus.en.xlf -p $(GitVersion_NuGetVersion) -m SIL.Localizer.GetString -m SIL.Localizer.Localize -g ../Output/Release/net462/SIL.*.dll" />
+	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL -o Chorus.dll -b Chorus.en.xlf -x Chorus.en.xlf -p $(GitVersion_SemVer) -m SIL.Localizer.GetString -m SIL.Localizer.Localize -g ../Output/Release/net462/SIL.*.dll" />
   </Target>
-  
+
   <Target Name="PackageL10ns" DependsOnTargets="restore;GetVersion">
 	<!-- Expects `crowdin download -i CROWDIN_PROJECT_ID -T CROWDIN_ACCESS_TOKEN` to have been run first -->
 	<NormalizeLocales L10nsDirectory="." />
-	<Exec Command="&quot;$(PkgNuGet_CommandLine)\tools\NuGet.exe&quot; pack l10ns.nuspec -Version $(GitVersion_NuGetVersion)" />
+	<Exec Command="&quot;$(PkgNuGet_CommandLine)\tools\NuGet.exe&quot; pack l10ns.nuspec -Version $(GitVersion_SemVer)" />
   </Target>
 </Project>

--- a/src/Chorus.Tests/Chorus.Tests.csproj
+++ b/src/Chorus.Tests/Chorus.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/Chorus/Chorus.csproj
+++ b/src/Chorus/Chorus.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.Windows.Forms" Version="15.0.0-*" />

--- a/src/ChorusHub/ChorusHub.csproj
+++ b/src/ChorusHub/ChorusHub.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.BuildTasks" Version="3.0.0" PrivateAssets="All" />

--- a/src/ChorusHubApp/ChorusHubApp.csproj
+++ b/src/ChorusHubApp/ChorusHubApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.Windows.Forms" Version="15.0.0-*" />

--- a/src/ChorusHubTests/ChorusHubTests.csproj
+++ b/src/ChorusHubTests/ChorusHubTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
+++ b/src/ChorusMerge.Tests/ChorusMerge.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/ChorusMerge/ChorusMerge.csproj
+++ b/src/ChorusMerge/ChorusMerge.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/Installer/ChorusMergeModule.wixproj
+++ b/src/Installer/ChorusMergeModule.wixproj
@@ -39,12 +39,12 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	<PackageId>SIL.Chorus.ChorusMergeModule</PackageId>
-	<Version>$(GitVersion_NuGetVersion)</Version>
+	<Version>$(GitVersion_SemVer)</Version>
 	<Year>$([System.DateTime]::Now.ToString(yyyy))</Year>
   </PropertyGroup>
 
   <Target Name="pack" DependsOnTargets="CheckPrerequisites">
-	<Exec Command="$(NuGetCommand) pack ChorusMergeModule.nuspec -Version $(GitVersion_NuGetVersion) -p PackageId=$(PackageId);Year=$(Year)" />
+	<Exec Command="$(NuGetCommand) pack ChorusMergeModule.nuspec -Version $(GitVersion_SemVer) -p PackageId=$(PackageId);Year=$(Year)" />
 	<Copy SourceFiles="$(PackageId).$(Version).nupkg" DestinationFolder="$(MSBuildThisFileDirectory)../../output" />
   </Target>
 </Project>

--- a/src/LibChorus.TestUtilities/LibChorus.TestUtilities.csproj
+++ b/src/LibChorus.TestUtilities/LibChorus.TestUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="SIL.Core" Version="15.0.0-*" />

--- a/src/LibChorus/LibChorus.csproj
+++ b/src/LibChorus/LibChorus.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="icu.net" Version="3.0.0-*" />
     <PackageReference Include="Icu4c.Win.Min" Version="59.1.7" IncludeAssets="build" />
     <PackageReference Include="L10NSharp" Version="8.0.0-beta0005" />

--- a/src/LibChorusTests/LibChorus.Tests.csproj
+++ b/src/LibChorusTests/LibChorus.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>

--- a/src/Tests-ChorusPlugin/Tests-ChorusPlugin.csproj
+++ b/src/Tests-ChorusPlugin/Tests-ChorusPlugin.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.10.3" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #363.

Requires a couple changes to GitVersion.yml since GitVersion 6 renamed some of the properties we use: `tag` becomes `label`, and `prevent-increment-of-merged-branch-version` has been split into `prevent-increment.of-merged-branch` (note the period). There's also `prevent-increment.when-current-commit-tagged` which we aren't currently using.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/364)
<!-- Reviewable:end -->
