### PR TITLE
Exceptions during hg push should be errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .vs/
 *.files
+*.lscache
 *.mdb
 *.nupkg
 *.orig

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -294,17 +294,9 @@ namespace Chorus.VcsDrivers.Mercurial
 
 		public void PushToTarget(string targetLabel, string targetUri)
 		{
-			try
-			{
-				CheckAndUpdateHgrc();
-				Execute(false, _mercurialTwoCompatible,SecondsBeforeTimeoutOnRemoteOperation, "push --new-branch " + GetProxyConfigParameterString(targetUri), SurroundWithQuotes(targetUri));
-			}
-			catch (Exception err)
-			{
-				_progress.WriteMessageWithColor("OrangeRed",
-					$"Could not send to {ServerSettingsModel.RemovePasswordForLog(targetUri)}");
-				_progress.WriteException(err);
-			}
+			CheckAndUpdateHgrc();
+			Execute(false, _mercurialTwoCompatible, SecondsBeforeTimeoutOnRemoteOperation,
+				"push --new-branch " + GetProxyConfigParameterString(targetUri), SurroundWithQuotes(targetUri));
 
 			if (GetIsLocalUri(targetUri))
 			{
@@ -314,9 +306,9 @@ namespace Chorus.VcsDrivers.Mercurial
 				}
 				catch (Exception err)
 				{
-					_progress.WriteMessageWithColor("OrangeRed",
-						$"Could not update the actual files after a pushing to {ServerSettingsModel.RemovePasswordForLog(targetUri)}");
-					_progress.WriteException(err);
+					throw new ApplicationException(
+						$"Could not update the actual files after pushing to {ServerSettingsModel.RemovePasswordForLog(targetUri)}",
+						err);
 				}
 			}
 		}

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -302,7 +302,8 @@ namespace Chorus.VcsDrivers.Mercurial
 			catch (Exception err)
 			{
 				_progress.WriteMessageWithColor("OrangeRed",
-					$"Could not send to {ServerSettingsModel.RemovePasswordForLog(targetUri)}{Environment.NewLine}{err.Message}");
+					$"Could not send to {ServerSettingsModel.RemovePasswordForLog(targetUri)}");
+				_progress.WriteException(err);
 			}
 
 			if (GetIsLocalUri(targetUri))
@@ -314,7 +315,8 @@ namespace Chorus.VcsDrivers.Mercurial
 				catch (Exception err)
 				{
 					_progress.WriteMessageWithColor("OrangeRed",
-						$"Could not update the actual files after a pushing to {ServerSettingsModel.RemovePasswordForLog(targetUri)}{Environment.NewLine}{err.Message}");
+						$"Could not update the actual files after a pushing to {ServerSettingsModel.RemovePasswordForLog(targetUri)}");
+					_progress.WriteException(err);
 				}
 			}
 		}

--- a/src/LibChorus/sync/Synchronizer.cs
+++ b/src/LibChorus/sync/Synchronizer.cs
@@ -251,16 +251,39 @@ namespace Chorus.sync
 	   private void SendToOthers(HgRepository repo, List<RepositoryAddress> sourcesToTry, Dictionary<RepositoryAddress, bool> connectionAttempt)
 		{
 			using var activity = LibChorusActivitySource.Value.StartActivity();
+			List<Exception> errors = new List<Exception>();
+			bool atLeastOneSucceeded = false;
 			foreach (RepositoryAddress address in sourcesToTry)
 			{
 				ThrowIfCancelPending();
 
 				if (!address.IsReadOnly)
 				{
-					SendToOneOther(address, connectionAttempt, repo);
+					try
+					{
+						SendToOneOther(address, connectionAttempt, repo);
+						atLeastOneSucceeded = true;
+					}
+					catch (UserCancelledException)
+					{
+						throw;
+					}
+					catch (Exception e)
+					{
+						_progress.WriteException(e);
+						_progress.WriteError(e.Message);
+						errors.Add(e);
+					}
 				}
 			}
 			ThrowIfCancelPending();
+
+			// Only throw and fail the sync if every writable target failed; partial success still counts as success.
+			if (errors.Any() && !atLeastOneSucceeded)
+			{
+				var error = errors.Count == 1 ? errors.Single() : new AggregateException(errors);
+				throw new SynchronizationException(error, WhatToDo.CheckAddressAndConnection, "Failed to send changes");
+			}
 		}
 
 		private void ThrowIfCancelPending()

--- a/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
+++ b/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
@@ -69,13 +69,65 @@ namespace LibChorus.Tests.sync
 					DoPullFromOthers = false,
 					DoSendToOthers = true,
 				};
-				options.RepositorySourcesToTry.Add(new PretendConnectableHttpRepositoryAddress());
+				options.RepositorySourcesToTry.Add(new FailingConnectableHttpRepositoryAddress("test-repo"));
 
 				var result = sender.SyncWithOptions(options);
 				Assert.That(result.Succeeded, Is.False);
 				Assert.That(result.ErrorEncountered, Is.Not.Null);
-				Assert.That(result.ErrorEncountered.Message, Does.Contain("Failed to send to"));
-				Assert.That(sender.GetProgressString(), Does.Contain("Failed to send to"));
+				Assert.That(result.ErrorEncountered.Message, Does.Contain("Failed to send changes"));
+				Assert.That(sender.GetProgressString(), Does.Contain("Failed to send to test-repo"));
+			}
+		}
+
+		[Test]
+		public void Sync_FirstPushFails_OtherSourcesStillTried()
+		{
+			using (var sender = new RepositorySetup("sender"))
+			{
+				sender.AddAndCheckinFile("one.txt", "sender's content");
+
+				var options = new SyncOptions
+				{
+					DoMergeWithOthers = false,
+					DoPullFromOthers = false,
+					DoSendToOthers = true,
+				};
+				options.RepositorySourcesToTry.Add(new FailingConnectableHttpRepositoryAddress("first-test-repo"));
+				options.RepositorySourcesToTry.Add(new FailingConnectableHttpRepositoryAddress("second-test-repo"));
+
+				var result = sender.SyncWithOptions(options);
+				Assert.That(result.Succeeded, Is.False);
+				Assert.That(result.ErrorEncountered, Is.Not.Null);
+				// Both targets should have been attempted even though the first failed.
+				var progress = sender.GetProgressString();
+				Assert.That(progress, Does.Contain("Failed to send to first-test-repo"));
+				Assert.That(progress, Does.Contain("Failed to send to second-test-repo"));
+			}
+		}
+
+		[Test]
+		public void Sync_OneOfMultiplePushTargetsFails_SyncStillSucceeds()
+		{
+			using (var sender = new RepositorySetup("sender"))
+			{
+				sender.AddAndCheckinFile("one.txt", "sender's content");
+
+				using (var receiver = new RepositorySetup("receiver", sender))
+				{
+					var options = new SyncOptions
+					{
+						DoMergeWithOthers = false,
+						DoPullFromOthers = false,
+						DoSendToOthers = true,
+					};
+					options.RepositorySourcesToTry.Add(new FailingConnectableHttpRepositoryAddress("test-repo"));
+					options.RepositorySourcesToTry.Add(receiver.GetRepositoryAddress());
+
+					var result = sender.SyncWithOptions(options);
+					Assert.That(result.Succeeded, Is.True);
+					Assert.That(result.ErrorEncountered, Is.Null);
+					Assert.That(sender.GetProgressString(), Does.Contain("Failed to send to test-repo"));
+				}
 			}
 		}
 
@@ -548,9 +600,9 @@ namespace LibChorus.Tests.sync
 		/// sync operations from executing. This allows CanConnect() to return true while sync operations
 		/// fail, enabling tests of sync failure scenarios (push/pull/merge failures).
 		/// </summary>
-		private class PretendConnectableHttpRepositoryAddress : RepositoryAddress
+		private class FailingConnectableHttpRepositoryAddress : RepositoryAddress
 		{
-			public PretendConnectableHttpRepositoryAddress() : base("unknownname", "http://127.0.0.1:1/test-project", false)
+			public FailingConnectableHttpRepositoryAddress(string name) : base(name, "http://127.0.0.1:1/test-project", false)
 			{
 			}
 

--- a/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
+++ b/src/LibChorusTests/sync/Synchronizer.BadSituationTests.cs
@@ -4,6 +4,7 @@ using Chorus.FileTypeHandlers.test;
 using Chorus.merge;
 using Chorus.sync;
 using Chorus.Utilities;
+using Chorus.VcsDrivers;
 using Chorus.VcsDrivers.Mercurial;
 using LibChorus.TestUtilities;
 using NUnit.Framework;
@@ -52,6 +53,29 @@ namespace LibChorus.Tests.sync
 					var results = setup.CheckinAndPullAndMerge();
 					Assert.That(results.Succeeded, Is.False);
 				}
+			}
+		}
+
+		[Test]
+		public void Sync_PushFails_ErrorEncounteredIsSet()
+		{
+			using (var sender = new RepositorySetup("sender"))
+			{
+				sender.AddAndCheckinFile("one.txt", "sender's content");
+
+				var options = new SyncOptions
+				{
+					DoMergeWithOthers = false,
+					DoPullFromOthers = false,
+					DoSendToOthers = true,
+				};
+				options.RepositorySourcesToTry.Add(new PretendConnectableHttpRepositoryAddress());
+
+				var result = sender.SyncWithOptions(options);
+				Assert.That(result.Succeeded, Is.False);
+				Assert.That(result.ErrorEncountered, Is.Not.Null);
+				Assert.That(result.ErrorEncountered.Message, Does.Contain("Failed to send to"));
+				Assert.That(sender.GetProgressString(), Does.Contain("Failed to send to"));
 			}
 		}
 
@@ -518,5 +542,27 @@ namespace LibChorus.Tests.sync
 			}
 		}
 
+		/// <summary>
+		/// Test double that bypasses HttpRepositoryPath's remote validation.
+		/// HttpRepositoryPath.CanConnect() validates the endpoint and aborts if invalid, preventing
+		/// sync operations from executing. This allows CanConnect() to return true while sync operations
+		/// fail, enabling tests of sync failure scenarios (push/pull/merge failures).
+		/// </summary>
+		private class PretendConnectableHttpRepositoryAddress : RepositoryAddress
+		{
+			public PretendConnectableHttpRepositoryAddress() : base("unknownname", "http://127.0.0.1:1/test-project", false)
+			{
+			}
+
+			public override bool CanConnect(HgRepository localRepository, string projectName, IProgress progress)
+			{
+				return true;
+			}
+
+			public override string GetPotentialRepoUri(string repoIdentifier, string projectName, IProgress progress)
+			{
+				return URI;
+			}
+		}
 	}
 }


### PR DESCRIPTION
The IProgress implementations have an ErrorEncountered flag that is set when their WriteException or WriteError methods are called. But PushToTarget was only calling WriteMessageWithColor, so if the only exception during a Send/Receive was happening during the hg push step, then ErrorEncountered was incorrectly still false.

Fixes #366.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/367)
<!-- Reviewable:end -->
