### PR TITLE
WIP: [API] Update URL format for Test Lexbox

### DIFF
--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -334,7 +334,7 @@ namespace Chorus.Model
 		private WebResponse LogIn()
 		{
 			var privateQuery = IsPrivateServer ? "?private=true" : string.Empty;
-			var request = WebRequest.Create($"https://admin{LanguageForgeServer}/api/user/{Username}/projects{privateQuery}");
+			var request = WebRequest.Create($"https://{LanguageForgeServer.TrimStart('-', '.')}/api/user/{Username}/projects{privateQuery}");
 			request.Method = "POST";
 			var passwordBytes = Encoding.UTF8.GetBytes($"password={HttpUtility.UrlEncode(Password)}");
 			request.ContentType = "application/x-www-form-urlencoded";


### PR DESCRIPTION
Before, production users could log in and list projects by API: https://admin.languagedepot.org/api/user/{Username}/projects and test users by
https://admin-qa.languagedepot.org/api/user/{Username}/projects Now, the 'admin' prefix is obsolete and available only in production. I assume but have not verified that production users can use https://languagedepot.org/api/user/{Username}/projects and testers
https://staging.languagedepot.org/api/user/{Username}/projects

Trim the leading '.' or '-' needed for prepending remaining subdomains in API calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/369)
<!-- Reviewable:end -->
