### PR TITLE
Fix IndexOutOfRangeException for query segments without '=' in ChorusHubServerInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Chorus] Fix collection-modified exception when UsbDrives property is read while background scan thread updates the list
 - [SIL.Chorus.LibChorus] Fix null-key insertion when XML record identifier attribute is absent in XmlMergeService
 - [SIL.Chorus.LibChorus] Fix crash in password encryption/decryption on non-Windows platforms and on Windows data-protection failure
+- [SIL.Chorus.LibChorus] Fix IndexOutOfRangeException parsing ChorusHub query parameters without '=', and preserve values containing '='
 
 ## [5.1.0] - 2023-03-07
 

--- a/src/ChorusHubTests/ChorusHubTests.cs
+++ b/src/ChorusHubTests/ChorusHubTests.cs
@@ -247,7 +247,6 @@ namespace ChorusHubTests
 		[Test]
 		public void Parse_SegmentWithoutEquals_DoesNotThrow()
 		{
-			// A bare flag segment (no '=') previously caused IndexOutOfRangeException on parts[1].
 			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname=mypc&flag";
 			Assert.DoesNotThrow(() => ChorusHubServerInfo.Parse(input));
 		}
@@ -263,8 +262,6 @@ namespace ChorusHubTests
 		[Test]
 		public void Parse_ValueContainsEquals_FullValuePreserved()
 		{
-			// Previously Split('=') on "hostname=my=pc" produced ["hostname","my","pc"];
-			// only parts[1] was used, silently dropping "=pc".
 			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname=my=pc";
 			var info = ChorusHubServerInfo.Parse(input);
 			Assert.That(info.HostName, Is.EqualTo("my=pc"));

--- a/src/ChorusHubTests/ChorusHubTests.cs
+++ b/src/ChorusHubTests/ChorusHubTests.cs
@@ -266,5 +266,13 @@ namespace ChorusHubTests
 			var info = ChorusHubServerInfo.Parse(input);
 			Assert.That(info.HostName, Is.EqualTo("my=pc"));
 		}
+
+		[Test]
+		public void Parse_SegmentWithoutEquals_ParsedWithEmptyValue()
+		{
+			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname";
+			var info = ChorusHubServerInfo.Parse(input);
+			Assert.That(info.HostName, Is.EqualTo(""));
+		}
 	}
 }

--- a/src/ChorusHubTests/ChorusHubTests.cs
+++ b/src/ChorusHubTests/ChorusHubTests.cs
@@ -240,4 +240,34 @@ namespace ChorusHubTests
 			}
 		}
 	}
+
+	[TestFixture]
+	public class ChorusHubServerInfoParseTests
+	{
+		[Test]
+		public void Parse_SegmentWithoutEquals_DoesNotThrow()
+		{
+			// A bare flag segment (no '=') previously caused IndexOutOfRangeException on parts[1].
+			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname=mypc&flag";
+			Assert.DoesNotThrow(() => ChorusHubServerInfo.Parse(input));
+		}
+
+		[Test]
+		public void Parse_SegmentWithoutEquals_OtherValuesStillParsed()
+		{
+			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname=mypc&flag";
+			var info = ChorusHubServerInfo.Parse(input);
+			Assert.That(info.HostName, Is.EqualTo("mypc"));
+		}
+
+		[Test]
+		public void Parse_ValueContainsEquals_FullValuePreserved()
+		{
+			// Previously Split('=') on "hostname=my=pc" produced ["hostname","my","pc"];
+			// only parts[1] was used, silently dropping "=pc".
+			const string input = "ChorusHubInfo?version=3&address=192.168.1.1&port=5912&hostname=my=pc";
+			var info = ChorusHubServerInfo.Parse(input);
+			Assert.That(info.HostName, Is.EqualTo("my=pc"));
+		}
+	}
 }

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Web;
 
 namespace Chorus.ChorusHub
 {
@@ -52,21 +53,8 @@ namespace Chorus.ChorusHub
 
 		private static string GetValue(string parameters, string name)
 		{
-			var queryParameters = new NameValueCollection();
-			var querySegments = parameters.Split('&');
-			foreach (var segment in querySegments)
-			{
-				var parts = segment.Split(new[] { '=' }, 2);
-				if (parts.Length < 2)
-					continue;
-
-				var key = parts[0].Trim(new[] { '?', ' ' });
-				var val = parts[1].Trim();
-
-				queryParameters.Add(key, val);
-			}
-
-			var r = queryParameters.GetValues(name);
+			var parsed = HttpUtility.ParseQueryString(parameters.TrimStart('?'));
+			var r = parsed.GetValues(name);
 			return r == null ? "?" : r.First();
 		}
 

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
-using System.Web;
 
 namespace Chorus.ChorusHub
 {
@@ -52,8 +52,20 @@ namespace Chorus.ChorusHub
 
 		private static string GetValue(string parameters, string name)
 		{
-			var parsed = HttpUtility.ParseQueryString(parameters.TrimStart('?'));
-			var r = parsed.GetValues(name);
+			var queryParameters = new NameValueCollection();
+			foreach (var segment in parameters.Split('&'))
+			{
+				var parts = segment.Split(new[] { '=' }, 2);
+				if (parts.Length < 2)
+					continue;
+
+				var key = parts[0].Trim(new[] { '?', ' ' });
+				var val = parts[1].Trim();
+
+				queryParameters.Add(key, val);
+			}
+
+			var r = queryParameters.GetValues(name);
 			return r == null ? "?" : r.First();
 		}
 
@@ -68,7 +80,7 @@ namespace Chorus.ChorusHub
 		/// <inheritdoc />
 		public override string ToString()
 		{
-			return $"ChorusHubInfo?version={VersionOfThisCode}&address={Uri.EscapeDataString(_ipAddress)}&port={Uri.EscapeDataString(_port)}&hostname={Uri.EscapeDataString(HostName)}";
+			return $"ChorusHubInfo?version={VersionOfThisCode}&address={_ipAddress}&port={_port}&hostname={HostName}";
 		}
 
 		public string ServiceUri => $"net.tcp://{_ipAddress}:{ChorusHubOptions.ServicePort}";

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -69,7 +68,7 @@ namespace Chorus.ChorusHub
 		/// <inheritdoc />
 		public override string ToString()
 		{
-			return $"ChorusHubInfo?version={VersionOfThisCode}&address={_ipAddress}&port={_port}&hostname={HostName}";
+			return $"ChorusHubInfo?version={VersionOfThisCode}&address={Uri.EscapeDataString(_ipAddress)}&port={Uri.EscapeDataString(_port)}&hostname={Uri.EscapeDataString(HostName)}";
 		}
 
 		public string ServiceUri => $"net.tcp://{_ipAddress}:{ChorusHubOptions.ServicePort}";

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -56,11 +56,8 @@ namespace Chorus.ChorusHub
 			foreach (var segment in parameters.Split('&'))
 			{
 				var parts = segment.Split(new[] { '=' }, 2);
-				if (parts.Length < 2)
-					continue;
-
 				var key = parts[0].Trim(new[] { '?', ' ' });
-				var val = parts[1].Trim();
+				var val = parts.Length < 2 ? "" : parts[1].Trim();
 
 				queryParameters.Add(key, val);
 			}

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -57,7 +57,7 @@ namespace Chorus.ChorusHub
 			foreach (var segment in querySegments)
 			{
 				var parts = segment.Split('=');
-				if (parts.Length < 1)
+				if (parts.Length < 2)
 					continue;
 
 				var key = parts[0].Trim(new[] { '?', ' ' });

--- a/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
+++ b/src/LibChorus/ChorusHub/ChorusHubServerInfo.cs
@@ -56,7 +56,7 @@ namespace Chorus.ChorusHub
 			var querySegments = parameters.Split('&');
 			foreach (var segment in querySegments)
 			{
-				var parts = segment.Split('=');
+				var parts = segment.Split(new[] { '=' }, 2);
 				if (parts.Length < 2)
 					continue;
 


### PR DESCRIPTION
Two bugs in the manual query-string parser in \`ChorusHubServerInfo.GetValue\`:

1. **Unreachable guard**: \`parts.Length < 1\` was never true — \`String.Split\` always returns at least one element. A bare flag segment (no \`=\`) would throw \`IndexOutOfRangeException\` on \`parts[1]\`. Fix: change the guard to \`parts.Length < 2\`.

2. **Truncated values**: Splitting on all \`=\` characters turned \`key=val=ue\` into a 3-element array; only \`parts[1]\` was used, silently dropping everything after the second \`=\`. Fix: use \`Split(new[] { '=' }, 2)\` so the full remainder becomes \`parts[1]\`.

\`HttpUtility.ParseQueryString\` was considered but rejected: it URL-decodes values while \`ToString()\` does not URL-encode them, creating a round-trip asymmetry. Fixing that with \`Uri.EscapeDataString\` would encode colons in IPv6 addresses, breaking old clients. Since all values are machine-generated and will never contain \`+\` or \`%\`, the manual parser is correct with just these two fixes.

Fixes #372

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/379

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/379)
<!-- Reviewable:end -->
