### PR TITLE
Fix silent data loss when record identifier is missing in XmlMergeService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
+- [SIL.Chorus.LibChorus] Fix null-key insertion when XML record identifier attribute is absent in XmlMergeService
 
 ## [5.1.0] - 2023-03-07
 

--- a/src/LibChorus/merge/xml/generic/XmlMergeService.cs
+++ b/src/LibChorus/merge/xml/generic/XmlMergeService.cs
@@ -786,7 +786,7 @@ namespace Chorus.merge.xml.generic
 							continue;
 
 						var identifier = attrValues[identifierAttribute];
-						if (string.IsNullOrEmpty(identifierAttribute))
+						if (string.IsNullOrEmpty(identifier))
 						{
 							mainMergeEventListener.WarningOccurred(
 								new MergeWarning(string.Format("{0}: There was no identifier for the record", pathname)));


### PR DESCRIPTION
In \`XmlMergeService.MakeRecordDictionary\`, the null-guard tested \`identifierAttribute\` (the parameter, always validated non-empty) instead of \`identifier\` (the value read from XML). Records whose identifier attribute was absent in the XML were silently added to the dictionary under a \`null\` key instead of triggering a warning and being skipped.

Change \`identifierAttribute\` to \`identifier\` in the \`string.IsNullOrEmpty\` call.

Fixes #373

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/380

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/380)
<!-- Reviewable:end -->
