### PR TITLE
Reset _chorusHubClient in RecheckNetworkStatus to allow re-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
+- [SIL.Chorus] Fix ChorusHub server not being re-discovered after network status recheck
 
 ## [5.1.0] - 2023-03-07
 

--- a/src/Chorus/UI/Sync/SyncStartControl.cs
+++ b/src/Chorus/UI/Sync/SyncStartControl.cs
@@ -399,6 +399,8 @@ namespace Chorus.UI.Sync
 				}
 				else // if (_lanMode == LANMode.ChorusHub)
 				{
+					if (_chorusHubClient == null || _chorusHubServerInfo == null)
+						return;
 					Cursor.Current = Cursors.WaitCursor;
 					string directoryName = Path.GetFileName(_repository.PathToRepo);
 					var doWait  = _chorusHubClient.PrepareHubToSync(directoryName, _repository.Identifier);
@@ -439,6 +441,7 @@ namespace Chorus.UI.Sync
 		{
 			_networkWorkerStarted = false;
 			_chorusHubClient = null;
+			_chorusHubServerInfo = null;
 			// Setup Shared Network Folder Checking thread and its worker
 			_networkStateWorker = new ConnectivityStateWorker(CheckNetworkStatusAndUpdateUI);
 			_updateNetworkSituation = new Thread(_networkStateWorker.DoWork);

--- a/src/Chorus/UI/Sync/SyncStartControl.cs
+++ b/src/Chorus/UI/Sync/SyncStartControl.cs
@@ -438,6 +438,7 @@ namespace Chorus.UI.Sync
 		private void RecheckNetworkStatus()
 		{
 			_networkWorkerStarted = false;
+			_chorusHubClient = null;
 			// Setup Shared Network Folder Checking thread and its worker
 			_networkStateWorker = new ConnectivityStateWorker(CheckNetworkStatusAndUpdateUI);
 			_updateNetworkSituation = new Thread(_networkStateWorker.DoWork);

--- a/src/Chorus/UI/Sync/SyncStartControl.cs
+++ b/src/Chorus/UI/Sync/SyncStartControl.cs
@@ -441,7 +441,6 @@ namespace Chorus.UI.Sync
 		{
 			_networkWorkerStarted = false;
 			_chorusHubClient = null;
-			_chorusHubServerInfo = null;
 			// Setup Shared Network Folder Checking thread and its worker
 			_networkStateWorker = new ConnectivityStateWorker(CheckNetworkStatusAndUpdateUI);
 			_updateNetworkSituation = new Thread(_networkStateWorker.DoWork);


### PR DESCRIPTION
\`RecheckNetworkStatus()\` in \`SyncStartControl\` creates a new worker thread but never clears \`_chorusHubClient\`. The worker method's guard skips server discovery when the field is non-null, so after the first check the stale client is reused permanently. If the ChorusHub server changes, the new server is never found until the application restarts.

Add \`_chorusHubClient = null;\` in \`RecheckNetworkStatus()\` before setting up the new worker. Nulling \`_chorusHubClient\` alone is sufficient to force re-discovery: the worker's existing \`if (_chorusHubClient == null)\` guard already calls \`FindServerInformation()\` and reassigns both \`_chorusHubServerInfo\` and \`_chorusHubClient\`.

Also add a null guard in \`_useLocalNetworkButton_Click\` for \`_chorusHubClient\` and \`_chorusHubServerInfo\`. Both run on the UI thread so there is no TOCTOU issue, but there is a ~2s race window between the null assignment and the next timer tick starting the new worker, during which the button remains enabled. The guard is a silent defensive return for that edge case.

Fixes #374

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/381

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/381)
<!-- Reviewable:end -->
