### PR TITLE
Handle revision summaries without closing ']' in history view

### DIFF
--- a/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
+++ b/src/Chorus/UI/Review/RevisionsInRepository/RevisionsInRepositoryView.cs
@@ -183,7 +183,8 @@ namespace Chorus.UI.Review.RevisionsInRepository
 
 		private string GetDescriptionForListView(Revision rev)
 		{
-			var s = rev.Summary.Substring(rev.Summary.IndexOf(']')+1).Trim();
+			int idx = rev.Summary.IndexOf(']');
+			var s = idx >= 0 ? rev.Summary.Substring(idx + 1).Trim() : rev.Summary.Trim();
 			if(s=="auto")
 				return string.Empty;
 			return s;


### PR DESCRIPTION
\`GetDescriptionForListView\` used \`IndexOf(']')\` without guarding against -1. When the revision summary does not contain \`]\`, \`Substring(-1 + 1)\` equals \`Substring(0)\` and returns the full raw summary instead of handling it gracefully.

Guard the substring so that summaries not following the \`[AppName] description\` format are returned trimmed as-is rather than showing unexpected content.

Fixes #375

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/382

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/382)
<!-- Reviewable:end -->
