### PR TITLE
Fix thread safety race in UsbDrives property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
+- [SIL.Chorus] Fix collection-modified exception when UsbDrives property is read while background scan thread updates the list
 
 ## [5.1.0] - 2023-03-07
 

--- a/src/Chorus/UI/UsbDriveLocator.cs
+++ b/src/Chorus/UI/UsbDriveLocator.cs
@@ -59,9 +59,12 @@ namespace Chorus.UI
 
 		private void ScanForUsbDrives()
 		{
-			while (_keepRunning)
+			// https://github.com/sillsdev/chorus/issues/261
+			// some users have problems with their USB drive (hardware?) such that GetDrives throws
+			//	an exception, which if not caught, results in a fatal exception for Chorus
+			try
 			{
-				try
+				while (_keepRunning)
 				{
 					var usbRoots = new SIL.UsbDrive.RetrieveUsbDriveInfo().GetDrives()
 						.Select(u => u.RootDirectory.FullName);
@@ -78,15 +81,13 @@ namespace Chorus.UI
 						_usbDrives.Clear();
 						_usbDrives.AddRange(usbDrives);
 					}
-				}
-				catch (Exception ex)
-				{
-					// Faulty USB hardware (e.g. ManagementException "Invalid class") can cause
-					// GetDrives to throw. Log quietly and retry next cycle so scanning keeps running.
-					SIL.Reporting.Logger.WriteEvent("UsbDriveLocator: {0}", ex.ToString());
-				}
 
-				Thread.Sleep(3000); // check again after 3 second
+					Thread.Sleep(3000); // check again after 3 second
+				}
+			}
+			catch (Exception ex)
+			{
+				ErrorReport.ReportNonFatalException(ex);
 			}
 		}
 

--- a/src/Chorus/UI/UsbDriveLocator.cs
+++ b/src/Chorus/UI/UsbDriveLocator.cs
@@ -59,12 +59,9 @@ namespace Chorus.UI
 
 		private void ScanForUsbDrives()
 		{
-			// https://github.com/sillsdev/chorus/issues/261
-			// some users have problems with their USB drive (hardware?) such that GetDrives throws
-			//	an exception, which if not caught, results in a fatal exception for Chorus
-			try
+			while (_keepRunning)
 			{
-				while (_keepRunning)
+				try
 				{
 					var usbRoots = new SIL.UsbDrive.RetrieveUsbDriveInfo().GetDrives()
 						.Select(u => u.RootDirectory.FullName);
@@ -81,13 +78,15 @@ namespace Chorus.UI
 						_usbDrives.Clear();
 						_usbDrives.AddRange(usbDrives);
 					}
-
-					Thread.Sleep(3000); // check again after 3 second
 				}
-			}
-			catch (Exception ex)
-			{
-				ErrorReport.ReportNonFatalException(ex);
+				catch (Exception ex)
+				{
+					// Faulty USB hardware (e.g. ManagementException "Invalid class") can cause
+					// GetDrives to throw. Log quietly and retry next cycle so scanning keeps running.
+					SIL.Reporting.Logger.WriteEvent("UsbDriveLocator: {0}", ex.Message);
+				}
+
+				Thread.Sleep(3000); // check again after 3 second
 			}
 		}
 

--- a/src/Chorus/UI/UsbDriveLocator.cs
+++ b/src/Chorus/UI/UsbDriveLocator.cs
@@ -83,7 +83,7 @@ namespace Chorus.UI
 				{
 					// Faulty USB hardware (e.g. ManagementException "Invalid class") can cause
 					// GetDrives to throw. Log quietly and retry next cycle so scanning keeps running.
-					SIL.Reporting.Logger.WriteEvent("UsbDriveLocator: {0}", ex.Message);
+					SIL.Reporting.Logger.WriteEvent("UsbDriveLocator: {0}", ex.ToString());
 				}
 
 				Thread.Sleep(3000); // check again after 3 second
@@ -96,7 +96,7 @@ namespace Chorus.UI
 			{
 				lock (_usbDrives)
 				{
-					return _usbDrives;
+					return _usbDrives.ToList();
 				}
 			}
 		}


### PR DESCRIPTION
The \`UsbDrives\` property returned the live \`List<DriveInfo>\` reference while holding the lock, but callers (e.g. \`SyncStartModel\`) enumerated the result after the lock was released. The background scan thread can concurrently call \`Clear()\`/\`AddRange()\` during that enumeration, causing \`InvalidOperationException: Collection was modified during enumeration\`.

Return \`_usbDrives.ToList()\` inside the lock so callers get a snapshot.

(This is a pre-existing issue unrelated to #261, which was already addressed in #272.)

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/383

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/383)
<!-- Reviewable:end -->
