### PR TITLE
Prevent ProtectedData crash on Linux by catching PlatformNotSupportedException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
-- [SIL.Chorus.LibChorus] Fix crash in password encryption/decryption on Linux and on Windows data-protection failure
+- [SIL.Chorus.LibChorus] Fix crash in password encryption/decryption on non-Windows platforms and on Windows data-protection failure
 
 ## [5.1.0] - 2023-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
+- [SIL.Chorus.LibChorus] Fix crash in password encryption/decryption on Linux and on Windows data-protection failure
 
 ## [5.1.0] - 2023-03-07
 

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -374,8 +374,10 @@ namespace Chorus.Model
 			if (string.IsNullOrEmpty(encryptMe))
 				return encryptMe;
 
+#if !NETFRAMEWORK
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				return null;
+#endif
 
 			try
 			{
@@ -396,8 +398,10 @@ namespace Chorus.Model
 			if (string.IsNullOrEmpty(decryptMe))
 				return decryptMe;
 
+#if !NETFRAMEWORK
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				return null;
+#endif
 
 			try
 			{

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -375,10 +375,17 @@ namespace Chorus.Model
 				return encryptMe;
 			}
 
-			// Password encryption/decryption not supported on .NET6 in Linux
-			var encryptedData = ProtectedData.Protect(Encoding.Unicode.GetBytes(encryptMe),
-				Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
-			return Convert.ToBase64String(encryptedData);
+			try
+			{
+				var encryptedData = ProtectedData.Protect(Encoding.Unicode.GetBytes(encryptMe),
+					Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
+				return Convert.ToBase64String(encryptedData);
+			}
+			catch (PlatformNotSupportedException)
+			{
+				// ProtectedData is not supported on Linux (.NET 6+); treat as RememberPassword=false
+				return null;
+			}
 		}
 
 		internal static string DecryptPassword(string decryptMe)
@@ -388,10 +395,17 @@ namespace Chorus.Model
 				return decryptMe;
 			}
 
-			// Password encryption/decryption not supported on .NET6 in Linux
-			var decryptedData = ProtectedData.Unprotect(Convert.FromBase64String(decryptMe),
-				Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
-			return Encoding.Unicode.GetString(decryptedData);
+			try
+			{
+				var decryptedData = ProtectedData.Unprotect(Convert.FromBase64String(decryptMe),
+					Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
+				return Encoding.Unicode.GetString(decryptedData);
+			}
+			catch (PlatformNotSupportedException)
+			{
+				// ProtectedData is not supported on Linux (.NET 6+); return input unmodified
+				return decryptMe;
+			}
 		}
 
 		/// <summary>

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -408,6 +408,12 @@ namespace Chorus.Model
 				// Windows-to-Linux settings migration, causing silent auth failures.
 				return null;
 			}
+			catch (CryptographicException)
+			{
+				// Unprotect can fail if the data was encrypted by a different Windows user
+				// account, after an OS reinstall, or if the stored value is corrupted.
+				return null;
+			}
 		}
 
 		/// <summary>

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -403,8 +403,10 @@ namespace Chorus.Model
 			}
 			catch (PlatformNotSupportedException)
 			{
-				// ProtectedData is not supported on Linux (.NET 6+); return input unmodified
-				return decryptMe;
+				// ProtectedData is not supported on Linux (.NET 6+); treat as no saved password.
+				// Returning decryptMe would pass a raw DPAPI blob as a credential on
+				// Windows-to-Linux settings migration, causing silent auth failures.
+				return null;
 			}
 		}
 

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Web;
@@ -371,20 +372,16 @@ namespace Chorus.Model
 		internal static string EncryptPassword(string encryptMe)
 		{
 			if (string.IsNullOrEmpty(encryptMe))
-			{
 				return encryptMe;
-			}
+
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return null;
 
 			try
 			{
 				var encryptedData = ProtectedData.Protect(Encoding.Unicode.GetBytes(encryptMe),
 					Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
 				return Convert.ToBase64String(encryptedData);
-			}
-			catch (PlatformNotSupportedException)
-			{
-				// ProtectedData is not supported on Linux (.NET 6+); treat as RememberPassword=false
-				return null;
 			}
 			catch (CryptographicException)
 			{
@@ -397,22 +394,16 @@ namespace Chorus.Model
 		internal static string DecryptPassword(string decryptMe)
 		{
 			if (string.IsNullOrEmpty(decryptMe))
-			{
 				return decryptMe;
-			}
+
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return null;
 
 			try
 			{
 				var decryptedData = ProtectedData.Unprotect(Convert.FromBase64String(decryptMe),
 					Encoding.Unicode.GetBytes(EntropyValue), DataProtectionScope.CurrentUser);
 				return Encoding.Unicode.GetString(decryptedData);
-			}
-			catch (PlatformNotSupportedException)
-			{
-				// ProtectedData is not supported on Linux (.NET 6+); treat as no saved password.
-				// Returning decryptMe would pass a raw DPAPI blob as a credential on
-				// Windows-to-Linux settings migration, causing silent auth failures.
-				return null;
 			}
 			catch (CryptographicException)
 			{

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -386,6 +386,12 @@ namespace Chorus.Model
 				// ProtectedData is not supported on Linux (.NET 6+); treat as RememberPassword=false
 				return null;
 			}
+			catch (CryptographicException)
+			{
+				// Protect can fail if the DPAPI subsystem is broken; treat as RememberPassword=false
+				// rather than crashing the save operation.
+				return null;
+			}
 		}
 
 		internal static string DecryptPassword(string decryptMe)
@@ -411,7 +417,13 @@ namespace Chorus.Model
 			catch (CryptographicException)
 			{
 				// Unprotect can fail if the data was encrypted by a different Windows user
-				// account, after an OS reinstall, or if the stored value is corrupted.
+				// account or after an OS reinstall.
+				return null;
+			}
+			catch (FormatException)
+			{
+				// Convert.FromBase64String throws if the stored value is not valid Base64
+				// (e.g. manual settings file corruption).
 				return null;
 			}
 		}

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -486,7 +486,6 @@ namespace LibChorus.Tests.Model
 		[Test]
 		public void DecryptPassword_InvalidBase64_ReturnsNull()
 		{
-			// FormatException from Convert.FromBase64String was unhandled before the fix.
 			Assert.That(ServerSettingsModel.DecryptPassword("not-valid-base64!!!"), Is.Null);
 		}
 

--- a/src/LibChorusTests/Model/ServerSettingsModelTests.cs
+++ b/src/LibChorusTests/Model/ServerSettingsModelTests.cs
@@ -484,6 +484,13 @@ namespace LibChorus.Tests.Model
 		}
 
 		[Test]
+		public void DecryptPassword_InvalidBase64_ReturnsNull()
+		{
+			// FormatException from Convert.FromBase64String was unhandled before the fix.
+			Assert.That(ServerSettingsModel.DecryptPassword("not-valid-base64!!!"), Is.Null);
+		}
+
+		[Test]
 		[Platform(Exclude = "Linux", Reason = "Windows Data Protection API (DPAPI) is not supported on this platform")]
 		public void EncryptPassword_RoundTrips()
 		{


### PR DESCRIPTION
\`ServerSettingsModel.EncryptPassword\` and \`DecryptPassword\` use \`System.Security.Cryptography.ProtectedData\`, which compiles for .NET 6 but throws \`PlatformNotSupportedException\` at runtime on Linux.

Guard both methods with \`!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)\` and return \`null\` early on non-Windows platforms, following the same pattern [ProtectedData itself uses](https://github.com/dotnet/dotnet/blob/f7b4c5716faaee8fb8a289aed29118cad955c45f/src/runtime/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs#L421). This avoids using exceptions for predictable control flow.

On Windows, both methods also catch runtime failures:
- \`EncryptPassword\` returns \`null\` on \`CryptographicException\` (broken DPAPI subsystem) — same effect as \`RememberPassword = false\`.
- \`DecryptPassword\` returns \`null\` on \`CryptographicException\` (different Windows user account, OS reinstall) and \`FormatException\` (invalid Base64 in the stored value) rather than the raw input. Returning the input unmodified would pass a DPAPI-encrypted base64 blob as a credential on a Windows-to-Linux settings migration, causing silent auth failures.

**Known limitation**: on non-Windows platforms, \`RememberPassword = true\` silently becomes a no-op — the preference is lost on restart with no UI feedback. Addressing that properly (disabling the checkbox or surfacing a message on unsupported platforms) requires UI changes and is left for a follow-up.

**Trade-off**: when \`EncryptPassword\` catches \`CryptographicException\` on Windows and returns \`null\`, \`SaveUserSettings\` will store \`null\` and call \`Settings.Default.Save()\`, permanently wiping a previously persisted password. Before this PR, the exception would propagate and \`Save()\` would never execute, preserving the old encrypted value. \`CryptographicException\` from \`ProtectedData.Protect\` is rare on healthy Windows systems, and the password remains available in-memory via \`PasswordForSession\` for the current session, but the user will not realize their saved password was dropped until the next restart.

Mitigates #298

Devin review: https://app.devin.ai/review/sillsdev/chorus/pull/384

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/384)
<!-- Reviewable:end -->