### PR TITLE
Run LibChorus hg-integration tests in parallel with logic tests on Windows

### DIFF
--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -28,23 +28,30 @@ jobs:
         os: [ubuntu-22.04, windows-latest]
         framework: [net462, net8.0]
         libchorus-split: ['']
+        # LibChorus test filter for each Windows job. The default runs the fast logic tests,
+        # i.e., everything except the hg-heavy namespaces. The 'include:' entries override
+        # it to run those namespaces in parallel.
+        libchorus-filter: ['TestCategory!=SkipOnBuildServer&FullyQualifiedName!~LibChorus.Tests.sync&FullyQualifiedName!~LibChorus.Tests.VcsDrivers']
         exclude:
-          # dotnet on Linux cannot build net461 without additional, unnecessary, work
           - os: ubuntu-22.04
             framework: net462
         include:
           - os: windows-latest
             framework: net462
-            libchorus-split: vcs
-          - os: windows-latest
-            framework: net8.0
-            libchorus-split: vcs
+            libchorus-split: sync
+            libchorus-filter: 'TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.sync'
           - os: windows-latest
             framework: net462
-            libchorus-split: sync
+            libchorus-split: vcs
+            libchorus-filter: 'TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.VcsDrivers'
           - os: windows-latest
             framework: net8.0
             libchorus-split: sync
+            libchorus-filter: 'TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.sync'
+          - os: windows-latest
+            framework: net8.0
+            libchorus-split: vcs
+            libchorus-filter: 'TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.VcsDrivers'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.libchorus-split }}
       cancel-in-progress: true
@@ -83,19 +90,12 @@ jobs:
       run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
       if: matrix['libchorus-split'] == ''
 
-    - name: Test LibChorus (VcsDrivers)
-      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'vcs'
-      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.VcsDrivers" -- NUnit.TestOutputXml=TestResults
+    - name: Test LibChorus (Windows)
+      if: runner.os == 'Windows'
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "${{ matrix['libchorus-filter'] }}" -- NUnit.TestOutputXml=TestResults
 
-    - name: Test LibChorus (sync)
-      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'sync'
-      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.sync" -- NUnit.TestOutputXml=TestResults
-
-    - name: Test LibChorus (remaining)
-      if: runner.os == 'Windows' && matrix['libchorus-split'] == ''
-      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName!~LibChorus.Tests.VcsDrivers&FullyQualifiedName!~LibChorus.Tests.sync" -- NUnit.TestOutputXml=TestResults
-
-    - name: Test LibChorus
+    - name: Test LibChorus (Linux)
+      # Linux runs the whole suite in one job; it is fast enough not to need the split.
       if: runner.os == 'Linux'
       run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -27,12 +27,20 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-latest]
         framework: [net462, net8.0]
+        libchorus-split: ['']
         exclude:
           # dotnet on Linux cannot build net461 without additional, unnecessary, work
           - os: ubuntu-22.04
             framework: net462
+        include:
+          - os: windows-latest
+            framework: net8.0
+            libchorus-split: hg
+          - os: windows-latest
+            framework: net462
+            libchorus-split: hg
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.framework }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.libchorus-split }}
       cancel-in-progress: true
 
     steps:
@@ -55,20 +63,30 @@ jobs:
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2
-      if: matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-22.04' && matrix['libchorus-split'] != 'hg'
 
     - name: Test Chorus
       run: dotnet test src/Chorus.Tests/Chorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix.framework == 'net462'
+      if: matrix.framework == 'net462' && matrix['libchorus-split'] != 'hg'
 
     - name: Test Chorus Hub
       run: dotnet test src/ChorusHubTests/ChorusHubTests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix.framework == 'net462'
+      if: matrix.framework == 'net462' && matrix['libchorus-split'] != 'hg'
 
     - name: Test ChorusMerge
       run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
+      if: matrix['libchorus-split'] != 'hg'
+
+    - name: Test LibChorus (VcsDrivers + sync)
+      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'hg'
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&(FullyQualifiedName~LibChorus.Tests.VcsDrivers|FullyQualifiedName~LibChorus.Tests.sync)" -- NUnit.TestOutputXml=TestResults
+
+    - name: Test LibChorus (merge, FileHandlers, utilities, Model)
+      if: runner.os == 'Windows' && matrix['libchorus-split'] != 'hg'
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName!~LibChorus.Tests.VcsDrivers&FullyQualifiedName!~LibChorus.Tests.sync" -- NUnit.TestOutputXml=TestResults
 
     - name: Test LibChorus
+      if: runner.os == 'Linux'
       run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
 
     # TODO: Give each test result its own name based on OS and framework and change the test-results.yml workflow accordingly, so that they don't overwrite each other
@@ -76,7 +94,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: Test Results (${{ matrix.framework }} on ${{matrix.os}})
+        name: Test Results (${{ matrix.framework }} on ${{ matrix.os }}${{ matrix['libchorus-split'] != '' && format(' [{0}]', matrix['libchorus-split']) || '' }})
         path: "**/TestResults/*.xml"
 
   build-installers:

--- a/.github/workflows/ci+cd.yml
+++ b/.github/workflows/ci+cd.yml
@@ -34,11 +34,17 @@ jobs:
             framework: net462
         include:
           - os: windows-latest
+            framework: net462
+            libchorus-split: vcs
+          - os: windows-latest
             framework: net8.0
-            libchorus-split: hg
+            libchorus-split: vcs
           - os: windows-latest
             framework: net462
-            libchorus-split: hg
+            libchorus-split: sync
+          - os: windows-latest
+            framework: net8.0
+            libchorus-split: sync
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.framework }}-${{ matrix.libchorus-split }}
       cancel-in-progress: true
@@ -63,26 +69,30 @@ jobs:
 
     - name: Install python2 for test execution
       run: sudo apt-get install python2
-      if: matrix.os == 'ubuntu-22.04' && matrix['libchorus-split'] != 'hg'
+      if: matrix.os == 'ubuntu-22.04'
 
     - name: Test Chorus
       run: dotnet test src/Chorus.Tests/Chorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix.framework == 'net462' && matrix['libchorus-split'] != 'hg'
+      if: matrix.framework == 'net462' && matrix['libchorus-split'] == ''
 
     - name: Test Chorus Hub
       run: dotnet test src/ChorusHubTests/ChorusHubTests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix.framework == 'net462' && matrix['libchorus-split'] != 'hg'
+      if: matrix.framework == 'net462' && matrix['libchorus-split'] == ''
 
     - name: Test ChorusMerge
       run: dotnet test src/ChorusMerge.Tests/ChorusMerge.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter TestCategory!=SkipOnBuildServer -- NUnit.TestOutputXml=TestResults
-      if: matrix['libchorus-split'] != 'hg'
+      if: matrix['libchorus-split'] == ''
 
-    - name: Test LibChorus (VcsDrivers + sync)
-      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'hg'
-      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&(FullyQualifiedName~LibChorus.Tests.VcsDrivers|FullyQualifiedName~LibChorus.Tests.sync)" -- NUnit.TestOutputXml=TestResults
+    - name: Test LibChorus (VcsDrivers)
+      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'vcs'
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.VcsDrivers" -- NUnit.TestOutputXml=TestResults
 
-    - name: Test LibChorus (merge, FileHandlers, utilities, Model)
-      if: runner.os == 'Windows' && matrix['libchorus-split'] != 'hg'
+    - name: Test LibChorus (sync)
+      if: runner.os == 'Windows' && matrix['libchorus-split'] == 'sync'
+      run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.sync" -- NUnit.TestOutputXml=TestResults
+
+    - name: Test LibChorus (remaining)
+      if: runner.os == 'Windows' && matrix['libchorus-split'] == ''
       run: dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f ${{ matrix.framework }} --no-build -c Release --filter "TestCategory!=SkipOnBuildServer&FullyQualifiedName!~LibChorus.Tests.VcsDrivers&FullyQualifiedName!~LibChorus.Tests.sync" -- NUnit.TestOutputXml=TestResults
 
     - name: Test LibChorus


### PR DESCRIPTION
## Problem

The \`build-and-test\` job on Windows takes ~57 minutes because the LibChorus test run serially spawns ~1,822 \`hg.exe\` processes across ~988 tests. The two hg-heavy namespaces are:

- \`LibChorus.Tests.VcsDrivers\` (~184 tests)
- \`LibChorus.Tests.sync\` (~84 tests)

The remaining ~665 tests are pure XML-diff logic and are fast. Running them all in one serial job means the fast logic tests wait behind the slow Mercurial I/O.

## Approach

Add a \`libchorus-split\` matrix dimension to the existing \`build-and-test\` job. Four extra Windows-only \`include\` entries inject \`libchorus-split: vcs\` and \`libchorus-split: sync\` jobs that run in parallel with the normal \`libchorus-split: ''\` jobs — no changes to source code or test projects required.

**Matrix layout after this change (Windows):**
| framework | libchorus-split | what runs |
|-----------|----------------|-----------|
| net462    | \`\` (empty)   | Chorus, ChorusHub, ChorusMerge, LibChorus remaining |
| net8.0    | \`\` (empty)   | ChorusMerge, LibChorus remaining |
| net462    | \`vcs\`        | LibChorus VcsDrivers only |
| net8.0    | \`vcs\`        | LibChorus VcsDrivers only |
| net462    | \`sync\`       | LibChorus sync only |
| net8.0    | \`sync\`       | LibChorus sync only |

Linux is unaffected — it still runs the full LibChorus suite in the single existing entry (no \`vcs\`/\`sync\` include entries are injected for Linux).

## Filter expressions used

VcsDrivers job:
\`\`\`
TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.VcsDrivers
\`\`\`

sync job:
\`\`\`
TestCategory!=SkipOnBuildServer&FullyQualifiedName~LibChorus.Tests.sync
\`\`\`

Remaining logic job (Windows):
\`\`\`
TestCategory!=SkipOnBuildServer&FullyQualifiedName!~LibChorus.Tests.VcsDrivers&FullyQualifiedName!~LibChorus.Tests.sync
\`\`\`

## Estimated impact

Each hg-heavy slice (~184 and ~84 tests respectively) runs in parallel with each other and with the logic slice. The logic slice (~665 tests, no hg) should finish in ~7 min. Running in parallel, the critical path drops from ~57 min to roughly ~30 min on Windows.

## Step guards

Steps skipped in the \`vcs\` and \`sync\` jobs to avoid wasted time: Test Chorus, Test Chorus Hub, Test ChorusMerge. The Restore, Build, and Upload Test Results steps still run in all job instances.

## Devin review

https://app.devin.ai/review/sillsdev/chorus/pull/386

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/386)
<!-- Reviewable:end -->
