### PR TITLE
Remove L10NSharp.Windows.Forms from LibChorus

### DIFF
--- a/src/ChorusHub/ChorusHub.csproj
+++ b/src/ChorusHub/ChorusHub.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration.Install" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
 

--- a/src/LibChorus/LibChorus.csproj
+++ b/src/LibChorus/LibChorus.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="icu.net" Version="3.0.1" />
     <PackageReference Include="Icu4c.Win.Min" Version="59.1.7" IncludeAssets="build" />
     <PackageReference Include="L10NSharp" Version="10.0.0-*" />
-    <PackageReference Include="L10NSharp.Windows.Forms" Version="10.0.0-*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.*" IncludeAssets="build" />
@@ -26,6 +25,10 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Reference Include="System.ServiceModel" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Remove unused `L10NSharp.Windows.Forms` package reference from `SIL.Chorus.LibChorus`
- Add explicit `System.ServiceModel` framework references for `net462` in LibChorus and ChorusHub, replacing the transitive reference that the WinForms package was accidentally providing

## Test plan
- [x] `dotnet build -c Release` succeeds locally
- [x] CI build and test pass on Windows and Linux

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/388)
<!-- Reviewable:end -->
