### PR TITLE
Show Lexbox instead of Language Forge/Depot in send/receive UI

### DIFF
--- a/src/Chorus.Tests/UI/Misc/ServerSettingsDialogTests.cs
+++ b/src/Chorus.Tests/UI/Misc/ServerSettingsDialogTests.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Windows.Forms;
 using Chorus.Model;
 using Chorus.UI.Misc;
 using NUnit.Framework;
@@ -5,8 +7,15 @@ using NUnit.Framework;
 namespace Chorus.Tests.UI.Misc
 {
 	[TestFixture]
+	[Apartment(ApartmentState.STA)]
 	public class ServerSettingsDialogTests
 	{
+		[SetUp]
+		public void Setup()
+		{
+			Application.EnableVisualStyles();
+		}
+
 		[Test, Ignore("Run by hand only")]
 		public void LaunchDialog_FullAddress()
 		{

--- a/src/Chorus.Tests/UI/Sync/SyncDialogTests.cs
+++ b/src/Chorus.Tests/UI/Sync/SyncDialogTests.cs
@@ -35,7 +35,7 @@ namespace Chorus.Tests.UI.Sync
 			{
 				setup.Repository.SetKnownRepositoryAddresses(new RepositoryAddress[]
 																 {
-																	 RepositoryAddress.Create("language forge", "https://hg-public.languageforge.org"),
+																	 RepositoryAddress.Create("Lexbox", "https://hg-public.languageforge.org"),
 																	 RepositoryAddress.Create("joe's mac", "\\\\suzie-pc\\public\\chorusTest")
 																 });
 
@@ -58,7 +58,7 @@ namespace Chorus.Tests.UI.Sync
 			{
 				setup.Repository.SetKnownRepositoryAddresses(new RepositoryAddress[]
 																 {
-																	 RepositoryAddress.Create("language forge", "https://hg-public.languageforge.org"),
+																	 RepositoryAddress.Create("Lexbox", "https://hg-public.languageforge.org"),
 																	 RepositoryAddress.Create("joe's mac", "//suzie-pc/public/chorusTest")
 																 });
 
@@ -80,9 +80,9 @@ namespace Chorus.Tests.UI.Sync
 
 				setup.Repository.SetKnownRepositoryAddresses(new RepositoryAddress[]
 																 {
-																	 RepositoryAddress.Create("language forge", "https://pedro:mypassword@hg-public.languageforge.org"),
+																	 RepositoryAddress.Create("Lexbox", "https://pedro:mypassword@hg-public.languageforge.org"),
 																 });
-				setup.Repository.SetDefaultSyncRepositoryAliases(new[] {"language forge"});
+				setup.Repository.SetDefaultSyncRepositoryAliases(new[] {"Lexbox"});
 
 				using (var dlg = new SyncDialog(setup.ProjectFolderConfig,
 												SyncUIDialogBehaviors.StartImmediatelyAndCloseWhenFinished,
@@ -102,9 +102,9 @@ namespace Chorus.Tests.UI.Sync
 
 				setup.Repository.SetKnownRepositoryAddresses(new RepositoryAddress[]
 																 {
-																	 RepositoryAddress.Create("language forge", "https://automatedtest:testing@hg-public.languageforge.org/tpi"),
+																	 RepositoryAddress.Create("Lexbox", "https://automatedtest:testing@hg-public.languageforge.org/tpi"),
 																 });
-				setup.Repository.SetDefaultSyncRepositoryAliases(new[] { "language forge" });
+				setup.Repository.SetDefaultSyncRepositoryAliases(new[] { "Lexbox" });
 
 				using (var dlg = new SyncDialog(setup.ProjectFolderConfig,
 												SyncUIDialogBehaviors.StartImmediately,

--- a/src/Chorus/Program.cs
+++ b/src/Chorus/Program.cs
@@ -74,9 +74,11 @@ namespace Chorus
 			var installedTranslations = Path.Combine(AppContext.BaseDirectory, "localizations");
 			if (Directory.Exists(Path.Combine(installedTranslations, "Chorus")))
 			{
+				// Pass the app's settings root; SetUpLocalization appends "Chorus" itself, so passing
+				// "SIL" (not "SIL\Chorus") avoids a redundant nested Chorus\Chorus directory.
 				var userTranslations = Path.Combine(
 					Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-					"SIL", "Chorus");
+					"SIL");
 				Directory.CreateDirectory(userTranslations);
 				ChorusSystem.SetUpLocalization("en", installedTranslations, userTranslations);
 			}

--- a/src/Chorus/Program.cs
+++ b/src/Chorus/Program.cs
@@ -20,6 +20,7 @@ namespace Chorus
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 
+			SetUpLocalization();
 			SetUpErrorHandling();
 
 			//Xpcom.Initialize(XULRunnerLocator.GetXULRunnerLocation());
@@ -64,6 +65,21 @@ namespace Chorus
 
 			Properties.Settings.Default.Save();
 			Application.Exit ();
+		}
+
+		private static void SetUpLocalization()
+		{
+			// Standalone Chorus.exe has no host app to initialize L10NSharp; use English defaults unless XLF files are deployed.
+			LocalizationManager.StrictInitializationMode = false;
+			var installedTranslations = Path.Combine(AppContext.BaseDirectory, "localizations");
+			if (Directory.Exists(Path.Combine(installedTranslations, "Chorus")))
+			{
+				var userTranslations = Path.Combine(
+					Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+					"SIL", "Chorus");
+				Directory.CreateDirectory(userTranslations);
+				ChorusSystem.SetUpLocalization("en", installedTranslations, userTranslations);
+			}
 		}
 
 		private static void SetUpErrorHandling()

--- a/src/Chorus/Program.cs
+++ b/src/Chorus/Program.cs
@@ -20,7 +20,7 @@ namespace Chorus
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 
-			SetUpLocalization();
+			SetupExeLocalization();
 			SetUpErrorHandling();
 
 			//Xpcom.Initialize(XULRunnerLocator.GetXULRunnerLocation());
@@ -67,7 +67,7 @@ namespace Chorus
 			Application.Exit ();
 		}
 
-		private static void SetUpLocalization()
+		private static void SetupExeLocalization()
 		{
 			// Standalone Chorus.exe has no host app to initialize L10NSharp; use English defaults unless XLF files are deployed.
 			LocalizationManager.StrictInitializationMode = false;

--- a/src/Chorus/UI/Misc/ReadinessPanel.cs
+++ b/src/Chorus/UI/Misc/ReadinessPanel.cs
@@ -12,7 +12,7 @@ namespace Chorus.UI.Misc
 {
 	/// <summary>
 	/// Show this control somewhere in the setup UI of your application.
-	/// It will help people know if the project is ready to use LanguageDepot, and
+	/// It will help people know if the project is ready to use Lexbox, and
 	/// gives them a button to edit the relevant settings.
 	/// </summary>
 	public partial class ReadinessPanel : UserControl

--- a/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
@@ -289,15 +289,14 @@ namespace Chorus.UI.Misc
 			this._serverLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
 			this._serverLabel.AutoSize = true;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._serverLabel, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this._serverLabel, "This adds information after the \"Log in\" button. Together, these two strings form" +
-        " a sentence. {0} is a URL, such as public.languageforge.org");
+			this.l10NSharpExtender1.SetLocalizationComment(this._serverLabel, "This adds information after the \"Log in\" button. Together, these two strings form a sentence.");
 			this.l10NSharpExtender1.SetLocalizationPriority(this._serverLabel, L10NSharp.LocalizationPriority.Low);
 			this.l10NSharpExtender1.SetLocalizingId(this._serverLabel, "ServerSettingsControl.ServerInfo");
 			this._serverLabel.Location = new System.Drawing.Point(111, 10);
 			this._serverLabel.Name = "_serverLabel";
 			this._serverLabel.Size = new System.Drawing.Size(122, 13);
 			this._serverLabel.TabIndex = 18;
-			this._serverLabel.Text = "to {0} (Lexbox)";
+			this._serverLabel.Text = "to Lexbox";
 			// 
 			// _tlpPassword
 			// 

--- a/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.Designer.cs
@@ -78,7 +78,7 @@ namespace Chorus.UI.Misc
 			this._accountLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
 			this._accountLabel.AutoSize = true;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._accountLabel, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this._accountLabel, "This is a username. On Language Depot, it is called a \"login.\"");
+			this.l10NSharpExtender1.SetLocalizationComment(this._accountLabel, "This is a username. On Lexbox, it is called a \"login.\"");
 			this.l10NSharpExtender1.SetLocalizingId(this._accountLabel, "ServerSettingsControl.Login");
 			this._accountLabel.Location = new System.Drawing.Point(37, 44);
 			this._accountLabel.Name = "_accountLabel";
@@ -297,7 +297,7 @@ namespace Chorus.UI.Misc
 			this._serverLabel.Name = "_serverLabel";
 			this._serverLabel.Size = new System.Drawing.Size(122, 13);
 			this._serverLabel.TabIndex = 18;
-			this._serverLabel.Text = "to {0} (Language Depot)";
+			this._serverLabel.Text = "to {0} (Lexbox)";
 			// 
 			// _tlpPassword
 			// 

--- a/src/Chorus/UI/Misc/ServerSettingsControl.cs
+++ b/src/Chorus/UI/Misc/ServerSettingsControl.cs
@@ -20,9 +20,6 @@ namespace Chorus.UI.Misc
 		{
 			InitializeComponent();
 
-			// format the string with the server URL. We build our own URL because 'resumable' is not helpful here.
-			_serverLabel.Text = string.Format(_serverLabel.Text, $"{(ServerSettingsModel.IsPrivateServer ? "private" : "public")}{ServerSettingsModel.LanguageForgeServer}");
-
 			_bandwidth.Items.AddRange(ServerSettingsModel.Bandwidths);
 		}
 

--- a/src/Chorus/UI/Settings/SettingsView.resx
+++ b/src/Chorus/UI/Settings/SettingsView.resx
@@ -156,6 +156,6 @@ suzie = \\SUZIE-PC\TokPisin
 For an internet server, include your username and password like this:
 online = https://JoeSmith:mypassword@hg-public.languageforge.org/tpi
 
-For a free internet repository, visit https://public.languageforge.org</value>
+For a free Lexbox internet repository, visit https://public.languageforge.org</value>
   </data>
 </root>

--- a/src/Chorus/UI/Settings/SettingsView.resx
+++ b/src/Chorus/UI/Settings/SettingsView.resx
@@ -156,6 +156,6 @@ suzie = \\SUZIE-PC\TokPisin
 For an internet server, include your username and password like this:
 online = https://JoeSmith:mypassword@hg-public.languageforge.org/tpi
 
-For a free Lexbox internet repository, visit https://public.languageforge.org</value>
+For a free Lexbox internet repository, visit https://lexbox.org</value>
   </data>
 </root>

--- a/src/LibChorus/Model/InternetCloneSettingsModel.cs
+++ b/src/LibChorus/Model/InternetCloneSettingsModel.cs
@@ -94,7 +94,7 @@ namespace Chorus.Model
 			}
 			else if (name.ToLower().EndsWith(@"languageforge.org"))
 			{
-				name = @"LanguageForge";
+				name = @"Lexbox";
 			}
 
 			var address = RepositoryAddress.Create(name, URL);

--- a/src/LibChorus/Model/ServerSettingsModel.cs
+++ b/src/LibChorus/Model/ServerSettingsModel.cs
@@ -365,7 +365,7 @@ namespace Chorus.Model
 					return "custom";
 				}
 
-				return $"languageForge.org [{Bandwidth}]";
+				return $"Lexbox [{Bandwidth}]";
 			}
 		}
 
@@ -427,12 +427,12 @@ namespace Chorus.Model
 		/// URL-encoded password to use for the current Send and Receive session. <see cref="PasswordForSession"/>
 		/// </summary>
 		/// <remarks>
-		/// UrlEncode encodes spaces as "+" and "+" as "%2b". LanguageDepot fails to decode plus-encoded spaces. Encode spaces as "%20"
+		/// UrlEncode encodes spaces as "+" and "+" as "%2b". Lexbox fails to decode plus-encoded spaces. Encode spaces as "%20"
 		/// </remarks>
 		public static string EncodedPasswordForSession => WebUtility.UrlEncode(PasswordForSession)?.Replace("+", "%20");
 
 		/// <summary>
-		/// URL-encoded language forge username
+		/// URL-encoded Lexbox username
 		/// </summary>
 		public static string EncodedLanguageForgeUser => WebUtility.UrlEncode(Settings.Default.LanguageForgeUser);
 

--- a/src/LibChorus/VcsDrivers/Mercurial/HgExceptions.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgExceptions.cs
@@ -77,7 +77,7 @@ namespace Chorus.VcsDrivers.Mercurial
 				}
 				else if(_targetUri.ToLower().Contains("languageforge"))
 				{
-					return "Your computer could reach LanguageForge.org, but couldn't communicate with the Chorus server there. Possible causes:\r\n1) The Chorus server on LanguageForge might be temporarily out of order. If it is, try again later/tomorrow. \r\n2) A firewall on your machine or on your network is blocking the communication with LanguageForge.org.";
+					return "Your computer could reach Lexbox, but couldn't communicate with the Chorus server there. Possible causes:\r\n1) The Chorus server on Lexbox might be temporarily out of order. If it is, try again later/tomorrow. \r\n2) A firewall on your machine or on your network is blocking the communication with Lexbox.";
 				}
 				else
 				{

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -1498,6 +1498,19 @@ namespace Chorus.VcsDrivers.Mercurial
 			if(match!=null)
 			{
 				addresses.Remove(match);
+				// If the alias name changed (e.g. because the default server was rebranded), migrate the
+				// matching entry in [ChorusDefaultRepositories] as well. Default-sync membership is matched
+				// by alias name, so leaving the old name behind would silently drop this repository from
+				// default sync operations.
+				if (match.Name != address.Name)
+				{
+					var defaultSyncAliases = GetDefaultSyncAliases();
+					if (defaultSyncAliases.Remove(match.Name))
+					{
+						defaultSyncAliases.Add(address.Name);
+						SetDefaultSyncRepositoryAliases(defaultSyncAliases);
+					}
+				}
 			}
 			addresses.Add(address);
 			SetKnownRepositoryAddresses(addresses);

--- a/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
+++ b/src/LibChorus/VcsDrivers/Mercurial/HgRepository.cs
@@ -1037,7 +1037,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			_progress.WriteVerbose($"Local User: {GetUserIdInUse()}");
 			if (potentialAddresses.Any(a => a is HttpRepositoryPath))
 			{
-				_progress.WriteVerbose($"LanguageForge User: {Settings.Default.LanguageForgeUser}");
+				_progress.WriteVerbose($"Lexbox User: {Settings.Default.LanguageForgeUser}");
 			}
 
 			_progress.WriteVerbose($"Repository URI: {string.Join(Environment.NewLine, potentialAddresses.Select(RepositoryURIForLog))}");
@@ -1519,7 +1519,7 @@ namespace Chorus.VcsDrivers.Mercurial
 			IniSection section = GetDefaultRepositoriesSection(doc);
 			foreach (var alias in aliases)
 			{
-				section.Set(alias, string.Empty); //so we'll have "LanguageForge =", which is weird, but it's the hgrc style
+				section.Set(alias, string.Empty); //so we'll have "Lexbox =", which is weird, but it's the hgrc style
 			}
 			doc.SaveAndGiveMessageIfCannot();
 
@@ -2095,7 +2095,7 @@ namespace Chorus.VcsDrivers.Mercurial
 		public static string DoWorkOfDeterminingProxyConfigParameterString(string httpUrl, IProgress progress)
 		{
 			/* The hg url itself would be more robust for the theoretical possibility of different
-				* proxies for different destinations, but some hg servers (notably language depot) require a login.
+				* proxies for different destinations, but some hg servers (notably Lexbox) require a login.
 				* So we're ignoring what we were given, and just using a known address, for now.
 				*/
 			httpUrl = "http://proxycheck.palaso.org";

--- a/src/LibChorus/VcsDrivers/RepositoryAddress.cs
+++ b/src/LibChorus/VcsDrivers/RepositoryAddress.cs
@@ -68,7 +68,7 @@ namespace Chorus.VcsDrivers
 		/// <summary>
 		/// Creates a new HttpRepositoryPath or DirectoryRepositorySource.
 		/// </summary>
-		/// <param name="name">examples: SIL Language Depot, My Machine, USB Key, Greg</param>
+		/// <param name="name">examples: Lexbox, My Machine, USB Key, Greg</param>
 		/// <param name="uri">
 		/// examples: https://sil.org/chorus, c:\work, UsbKey, //GregSmith/public/language projects
 		/// Note: does not work for ChorusHub

--- a/src/LibChorusTests/VcsDrivers/Mercurial/HgRepositoryTests.cs
+++ b/src/LibChorusTests/VcsDrivers/Mercurial/HgRepositoryTests.cs
@@ -152,5 +152,29 @@ namespace LibChorus.Tests.VcsDrivers.Mercurial
 				}
 			}
 		}
+
+		[Test]
+		public void SetTheOnlyAddressOfThisType_AliasRenamed_MigratesDefaultSyncEntry()
+		{
+			const string oldAlias = "languageForge.org [High bandwidth]";
+			const string newAlias = "Lexbox [High bandwidth]";
+			const string url = "https://hg-public.languageforge.org/tpi";
+
+			using (var tempDir = new TemporaryFolder("HgRepoDefaultSync"))
+			{
+				var repo = new HgRepository(tempDir.Path, _progress);
+				Directory.CreateDirectory(Path.GetDirectoryName(repo.GetPathToHgrc()));
+				repo.SetTheOnlyAddressOfThisType(new HttpRepositoryPath(oldAlias, url, false));
+				repo.SetDefaultSyncRepositoryAliases(new[] { oldAlias });
+
+				// SUT: rename the alias (same address type, e.g. server rebranding)
+				repo.SetTheOnlyAddressOfThisType(new HttpRepositoryPath(newAlias, url, false));
+
+				var defaultAliases = repo.GetDefaultSyncAliases();
+				Assert.That(defaultAliases, Does.Contain(newAlias), "default sync entry should follow the renamed alias");
+				Assert.That(defaultAliases, Does.Not.Contain(oldAlias), "stale default sync entry should be removed");
+				Assert.That(repo.GetRepositoryPathsInHgrc().Select(p => p.Name), Does.Contain(newAlias));
+			}
+		}
 	}
 }

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Threading;
 using System.Windows.Forms;
+using Chorus;
+using L10NSharp;
 
 namespace SampleApp
 {
@@ -12,6 +14,17 @@ namespace SampleApp
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
+
+			LocalizationManager.StrictInitializationMode = false;
+			var installedTranslations = Path.Combine(AppContext.BaseDirectory, "localizations");
+			if (Directory.Exists(Path.Combine(installedTranslations, "Chorus")))
+			{
+				var userTranslations = Path.Combine(
+					Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+					"SIL", "ChorusSampleApp");
+				Directory.CreateDirectory(userTranslations);
+				ChorusSystem.SetUpLocalization("en", installedTranslations, userTranslations);
+			}
 
 			string dataDirectory = Path.Combine(Path.GetTempPath(), "ChorusSampleApp");
 			if(Directory.Exists(dataDirectory ))


### PR DESCRIPTION
Getting lots of confusion from people seeing Language Forge in the UI, especially now that Language forge is in maintenance mode.

User-facing labels, aliases, and error messages now say Lexbox while server URLs and internal settings keys remain on languageforge.org.

<img width="670" height="431" alt="image" src="https://github.com/user-attachments/assets/07ada100-5730-483a-a4b4-94cd140a4b9e" />

one thing I noticed is that the FLEx help still references language depot and language forge. Not sure how we update those, I thought they already were but maybe they didn't make it into the most recent release?

I also fixed launching the sample app and Chorus directly, previously they would crash because localization manager was not setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/389)
<!-- Reviewable:end -->
