### PR TITLE
Fix ChorusMerge plugin discovery on .NET

### DIFF
--- a/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
+++ b/src/LibChorus/FileTypeHandlers/ChorusFileTypeHandlerCollection.cs
@@ -17,6 +17,14 @@ namespace Chorus.FileTypeHandlers
 	public class ChorusFileTypeHandlerCollection
 	{
 		/// <summary>
+		/// When set to a truthy value (1, true, or yes),
+		/// <see cref="CreateWithInstalledHandlers"/> throws if no external plugins are found.
+		/// </summary>
+		public const string kRequirePluginsEnvVarName = "ChorusRequirePlugins";
+
+		private const string PluginSearchPattern = "*-ChorusPlugin.dll";
+
+		/// <summary>
 		/// Gets the list of handlers
 		/// </summary>
 		[ImportMany]
@@ -24,12 +32,17 @@ namespace Chorus.FileTypeHandlers
 
 		private ChorusFileTypeHandlerCollection(
 			Expression<Func<ComposablePartDefinition, bool>> filter = null,
-			string[] additionalAssemblies = null)
+			string[] additionalAssemblies = null,
+			bool requirePlugins = false)
 		{
+			requirePlugins = requirePlugins ||
+				IsTruthy(Environment.GetEnvironmentVariable(kRequirePluginsEnvVarName));
+
 			using (var aggregateCatalog = new AggregateCatalog())
 			{
 				aggregateCatalog.Catalogs.Add(new AssemblyCatalog(Assembly.GetExecutingAssembly()));
-				aggregateCatalog.Catalogs.Add(new DirectoryCatalog(".", "*-ChorusPlugin.dll"));
+				var pluginCatalog = new DirectoryCatalog(AppContext.BaseDirectory, PluginSearchPattern);
+				aggregateCatalog.Catalogs.Add(pluginCatalog);
 				if (additionalAssemblies != null)
 				{
 					foreach (var assemblyPath in additionalAssemblies)
@@ -56,14 +69,26 @@ namespace Chorus.FileTypeHandlers
 						throw new AggregateException(ex.Message, loaderExceptions);
 					}
 				}
+
+				if (requirePlugins &&
+					!pluginCatalog.LoadedFiles.Any() &&
+					(additionalAssemblies == null || additionalAssemblies.Length == 0))
+				{
+					throw new InvalidOperationException(
+						$"No Chorus plugins matching '{PluginSearchPattern}' were found in '{AppContext.BaseDirectory}'. " +
+						$"Set {kRequirePluginsEnvVarName}=0 or pass requirePlugins: false to allow running without plugins.");
+				}
 			}
 		}
 
 		/// <summary/>
 		public static ChorusFileTypeHandlerCollection CreateWithInstalledHandlers(
-			string[] additionalAssemblies = null)
+			string[] additionalAssemblies = null,
+			bool requirePlugins = false)
 		{
-			return new ChorusFileTypeHandlerCollection(additionalAssemblies: additionalAssemblies);
+			return new ChorusFileTypeHandlerCollection(
+				additionalAssemblies: additionalAssemblies,
+				requirePlugins: requirePlugins);
 		}
 
 		/// <summary/>
@@ -91,6 +116,14 @@ namespace Chorus.FileTypeHandlers
 			var handler = Handlers.FirstOrDefault(h => h.CanPresentFile(path));
 			return handler ?? new DefaultFileTypeHandler();
 		}
+
+		private static bool IsTruthy(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return false;
+			return value.Equals("1", StringComparison.OrdinalIgnoreCase)
+				|| value.Equals("true", StringComparison.OrdinalIgnoreCase)
+				|| value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+		}
 	}
 }
-

--- a/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
+++ b/src/LibChorusTests/FileHandlers/ChorusFileTypeHandlerCollectionTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-2022 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -8,6 +9,7 @@ using NUnit.Framework;
 using Chorus.FileTypeHandlers;
 using Chorus.FileTypeHandlers.audio;
 using Chorus.FileTypeHandlers.test;
+using Chorus.Utilities;
 
 namespace LibChorus.Tests.FileHandlers
 {
@@ -25,8 +27,33 @@ namespace LibChorus.Tests.FileHandlers
 				var config = configOutputDir.Name;
 				var frameworkDir = Path.GetFileName(BaseDir);
 				var samplePluginDllPath = Path.Combine(outputDir, "SamplePlugin", config, frameworkDir, "Tests-ChorusPlugin.dll");
+				// Tests-ChorusPlugin is net462-only; reuse that build when exercising other TFMs.
+				if (!File.Exists(samplePluginDllPath))
+					samplePluginDllPath = Path.Combine(outputDir, "SamplePlugin", config, "net462", "Tests-ChorusPlugin.dll");
 				return samplePluginDllPath;
 			}
+		}
+
+		[OneTimeSetUp]
+		public void RemoveLeftoverPluginsFromAppBase()
+		{
+			foreach (var file in Directory.GetFiles(AppContext.BaseDirectory, "*-ChorusPlugin.dll"))
+			{
+				try
+				{
+					File.Delete(file);
+				}
+				catch (IOException)
+				{
+					// Already loaded in this process; throw-when-none tests will Assume away.
+				}
+			}
+		}
+
+		private static void AssumeNoPluginsInAppBase()
+		{
+			Assume.That(!Directory.GetFiles(AppContext.BaseDirectory, "*-ChorusPlugin.dll").Any(),
+				"Plugin already present in app base from a previous run");
 		}
 
 		[Test]
@@ -49,6 +76,83 @@ namespace LibChorus.Tests.FileHandlers
 			var handlers = ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers(
 				new[] { SamplePluginPath }).Handlers;
 			Assert.That(handlers.Select(x => x.GetType().Name), Has.Member("TestAFileTypeHandler"));
+		}
+
+		[Test]
+		[Order(1)]
+		public void CreateWithInstalledHandlers_RequirePlugins_ThrowsWhenNoneFound()
+		{
+			AssumeNoPluginsInAppBase();
+			using (new ShortTermEnvironmentalVariable(
+				ChorusFileTypeHandlerCollection.kRequirePluginsEnvVarName, null))
+			{
+				Assert.That(
+					() => ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers(requirePlugins: true),
+					Throws.TypeOf<InvalidOperationException>()
+						.With.Message.Contains("*-ChorusPlugin.dll")
+						.And.Message.Contains(AppContext.BaseDirectory));
+			}
+		}
+
+		[Test]
+		[Order(1)]
+		public void CreateWithInstalledHandlers_RequirePlugins_ThrowsWhenEnvVarSet()
+		{
+			AssumeNoPluginsInAppBase();
+			using (new ShortTermEnvironmentalVariable(
+				ChorusFileTypeHandlerCollection.kRequirePluginsEnvVarName, "true"))
+			{
+				Assert.That(
+					() => ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers(),
+					Throws.TypeOf<InvalidOperationException>());
+			}
+		}
+
+		[Test]
+		[Order(1)]
+		public void CreateWithInstalledHandlers_RequirePlugins_SucceedsWithAdditionalAssembly()
+		{
+			Assume.That(File.Exists(SamplePluginPath), $"Sample plugin not found at {SamplePluginPath}");
+			using (new ShortTermEnvironmentalVariable(
+				ChorusFileTypeHandlerCollection.kRequirePluginsEnvVarName, null))
+			{
+				Assert.That(
+					() => ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers(
+						new[] { SamplePluginPath }, requirePlugins: true),
+					Throws.Nothing);
+			}
+		}
+
+		[Test]
+		[Order(2)]
+		public void CreateWithInstalledHandlers_FindsPluginsWhenCwdDiffersFromAppBase()
+		{
+			Assume.That(File.Exists(SamplePluginPath), $"Sample plugin not found at {SamplePluginPath}");
+
+			var samplePluginPathname = Path.Combine(AppContext.BaseDirectory, "Tests-ChorusPlugin.dll");
+			if (!File.Exists(samplePluginPathname))
+			{
+				File.Copy(SamplePluginPath, samplePluginPathname, true);
+			}
+
+			var originalCwd = Directory.GetCurrentDirectory();
+			var tempDir = Path.Combine(Path.GetTempPath(), "ChorusPluginDiscoveryCwdTest");
+			Directory.CreateDirectory(tempDir);
+			try
+			{
+				Directory.SetCurrentDirectory(tempDir);
+				using (new ShortTermEnvironmentalVariable(
+					ChorusFileTypeHandlerCollection.kRequirePluginsEnvVarName, null))
+				{
+					var handlers = ChorusFileTypeHandlerCollection.CreateWithInstalledHandlers(
+						requirePlugins: true).Handlers;
+					Assert.That(handlers.Select(x => x.GetType().Name), Has.Member("TestAFileTypeHandler"));
+				}
+			}
+			finally
+			{
+				Directory.SetCurrentDirectory(originalCwd);
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
closes #392
In Lexbox when we run ChorusMerge it doesn't find it's plugins unless we override the cwd between hg calling merge and starting ChorusMerge. This fixes that bug #392 and also introduces a flag to throw when no extra plugins are found. @jasonleenaylor should this be the default? I'm worried that any non FLEx clients would not want this as the default if they don't use plugins.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/393)
<!-- Reviewable:end -->
