### PR TITLE
Match lift-ranges range-element on guid rather than id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Chorus.LibChorus] Match `range-element` in `.lift-ranges` on its `guid` rather than its `id`, so that renaming or respelling a range element merges as an edit instead of a deletion plus an addition
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
 - [SIL.Chorus] Fix collection-modified exception when UsbDrives property is read while background scan thread updates the list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- [SIL.Chorus.LibChorus] Match `range-element` in `.lift-ranges` on its `guid` rather than its `id`, so that renaming or respelling a range element merges as an edit instead of a deletion plus an addition
+- [SIL.Chorus.LibChorus] Match `range-element` on its `guid` rather than its `id`, so that renaming or respelling a range element merges as an edit instead of a deletion plus an addition
 - Prevent S&R to Internet without full URL
 - [SIL.Chorus.LibChorus] Correctly handle & and other special characters in passwords
 - [SIL.Chorus] Fix collection-modified exception when UsbDrives property is read while background scan thread updates the list

--- a/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
+++ b/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
@@ -42,10 +42,10 @@ namespace Chorus.FileTypeHandlers
 			// This element appears to not be in the main lift file, so it will be 'extra', but ought not cause harm.
 			// <range-element
 			//		id [Required, key]
-			// @id holds the possibility's own name, so its value moves whenever that name is renamed or
-			// respelled, while @guid holds a value that identifies the same object for the life of the
-			// project. Prefer @guid, so that a respelled id merges as an edit rather than as a deletion
-			// plus an addition.
+			// @id holds the possibility's own name, so its value moves whenever that name is
+			// renamed or respelled, while @guid holds a value that identifies the same object
+			// for the life of the project. Prefer @guid, so that a respelled id merges as an
+			// edit rather than as a deletion plus an addition.
 			elementStrategy = new ElementStrategy(false)
 			{
 				MergePartnerFinder = new FindByPreferredKeyAttribute("guid", "id")

--- a/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
+++ b/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
@@ -42,9 +42,10 @@ namespace Chorus.FileTypeHandlers
 			// This element appears to not be in the main lift file, so it will be 'extra', but ought not cause harm.
 			// <range-element
 			//		id [Required, key]
-			// The id is the possibility's own name, so it moves whenever that name is renamed or respelled,
-			// while the guid names the same object for the life of the project. Prefer the guid, so that a
-			// respelled id merges as an edit rather than as a deletion plus an addition.
+			// @id holds the possibility's own name, so its value moves whenever that name is renamed or
+			// respelled, while @guid holds a value that identifies the same object for the life of the
+			// project. Prefer @guid, so that a respelled id merges as an edit rather than as a deletion
+			// plus an addition.
 			elementStrategy = new ElementStrategy(false)
 			{
 				MergePartnerFinder = new FindByPreferredKeyAttribute("guid", "id")

--- a/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
+++ b/src/LibChorus/FileTypeHandlers/Lift-Ranges/LiftRangesElementStrategiesMethod.cs
@@ -42,7 +42,14 @@ namespace Chorus.FileTypeHandlers
 			// This element appears to not be in the main lift file, so it will be 'extra', but ought not cause harm.
 			// <range-element
 			//		id [Required, key]
-			LiftBasicElementStrategiesMethod.AddKeyedElementType(mergeStrategies, "range-element", "id", false);
+			// The id is the possibility's own name, so it moves whenever that name is renamed or respelled,
+			// while the guid names the same object for the life of the project. Prefer the guid, so that a
+			// respelled id merges as an edit rather than as a deletion plus an addition.
+			elementStrategy = new ElementStrategy(false)
+			{
+				MergePartnerFinder = new FindByPreferredKeyAttribute("guid", "id")
+			};
+			mergeStrategies.SetStrategy("range-element", elementStrategy);
 			//		parent [Optional, key]
 			//		guid [Optional, string]
 			//		<description> [Optional, multitext] <description> holds zero or more <form> elements

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -15,10 +15,11 @@ namespace Chorus.merge.xml.generic
 	public interface IFindNodeToMerge
 	{
 		/// <summary>
-		/// Should return null if parentToSearchIn is null, and otherwise either null or a child of
-		/// parentToSearchIn. acceptableTargets is a subset (or all) of the children of parentToSearchIn;
-		/// an implementation holding only one possible match may ignore it and return that match, so a
-		/// caller passing a strict subset is responsible for discarding a result outside it.
+		/// Should return null if parentToSearchIn is null, and otherwise either null or a
+		/// child of parentToSearchIn. acceptableTargets is a subset (or all) of the children
+		/// of parentToSearchIn; an implementation holding only one possible match may ignore
+		/// it and return that match, so a caller passing a strict subset is responsible for
+		/// discarding a result outside it.
 		/// </summary>
 		XmlNode GetNodeToMerge(XmlNode nodeToMatch, XmlNode parentToSearchIn, HashSet<XmlNode> acceptableTargets);
 	}
@@ -212,29 +213,25 @@ namespace Chorus.merge.xml.generic
 	}
 
 	/// <summary>
-	/// Search for a matching element on the value of either of two key attributes. An element carrying a
-	/// non-empty value for the preferred key attribute is matched on that value alone; an element carrying
-	/// none is matched on its value for the fallback key attribute. The two groups are never matched against
-	/// each other, so an element whose preferred value finds no partner is not retried against its fallback
-	/// value. An attribute that is present but empty counts as absent throughout.
+	/// Search for a matching element on the value of one of two key attributes: the preferred
+	/// attribute where the element carries a non-empty value for it, the fallback attribute only
+	/// where it does not. The fallback value is not consulted where a non-empty preferred value
+	/// is present.
 	/// </summary>
 	/// <remarks>
-	/// <para>Use this where the fallback key attribute's value is derived from user data, and so can change
-	/// while the object it identifies does not, and the preferred key attribute holds a value that stays with
-	/// that object. Matching on the changeable value alone turns such a change into a deletion plus an
-	/// addition, which discards the other user's edits to the same element and can leave two elements
-	/// standing for one object.</para>
-	/// <para>Elements carrying a preferred value and elements carrying none are matched separately, and never
-	/// against each other. That keeps matching an equivalence relation, so no element can be paired with
-	/// two partners; were an element carrying a preferred value allowed to match one carrying none, a set
-	/// holding both could give one element two partners and merge someone's edit onto an object it was not
-	/// made against.</para>
-	/// <para>The price is that where one revision gives an element a preferred value and another leaves that
-	/// attribute off, the element reads as a deletion plus an addition, and as a removed-versus-edited
-	/// conflict if the other revision also edited it. A writer that starts writing the preferred attribute
-	/// pays that once. Writers that disagree over whether to write it pay it on every merge between them, so
-	/// choose a preferred key attribute only where every writer of the file can be relied on to preserve the
-	/// value it finds.</para>
+	/// <para>Use this where the fallback key attribute's value is derived from user data, and so
+	/// can change while the object it identifies does not, and the preferred key attribute holds
+	/// a value that stays with that object. Matching on the changeable value alone turns such a
+	/// change into a deletion plus an addition.</para>
+	/// <para>Elements carrying a preferred value and elements carrying none are matched
+	/// separately, and never against each other, which keeps matching an equivalence relation:
+	/// no element is paired with two partners, and no edit lands on an object it was not made
+	/// against. An attribute that is present but empty counts as absent throughout.</para>
+	/// <para>The price is that an element whose preferred value one revision writes and another
+	/// omits reads as a deletion plus an addition, and as a removed-versus-edited conflict where
+	/// the other revision edited it. Choose a preferred key attribute only where every writer can
+	/// be relied on to preserve the value it finds; writers that disagree pay that cost on every
+	/// merge between them.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
 	{
@@ -262,8 +259,8 @@ namespace Chorus.merge.xml.generic
 			XmlNode match;
 			if (string.IsNullOrEmpty(preferredKey))
 			{
-				// Only among elements that likewise carry no preferred value, so that this cannot claim
-				// an element that a preferred value already speaks for.
+				// Only among elements that likewise carry no preferred value, so that this
+				// cannot claim an element that a preferred value already speaks for.
 				index.ByFallbackKeyWherePreferredAbsent.TryGetValue(IndexKey(nodeToMatch, fallbackKey), out match);
 				return match; // May be null, which is fine.
 			}
@@ -272,11 +269,10 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// The children of one parent, indexed on (element name, attribute value) for each key attribute this
-		/// finder can match on, so that merging a large element does not rescan its siblings once per child.
-		/// An index is built when its parent is first searched and is never revisited, so a caller that adds
-		/// or removes children between searches of the same parent will still be answered from the children
-		/// it first held.
+		/// The children of one parent, indexed on (element name, attribute value) for each key
+		/// attribute this finder can match on, so siblings are not rescanned once per child.
+		/// Built at the parent's first search and never revisited: children added or removed
+		/// between searches of one parent are not seen.
 		/// </summary>
 		private class ParentIndex
 		{
@@ -308,9 +304,9 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// Unlike a finder with a single key attribute, two children legitimately hold the same fallback
-		/// value here, since a preferred value can still tell them apart. Keep the first, matching how the
-		/// merger resolves siblings it cannot tell apart.
+		/// Unlike a finder with a single key attribute, two children legitimately hold the same
+		/// fallback value here, since a preferred value can still tell them apart. Keep the
+		/// first, matching how the merger resolves siblings it cannot tell apart.
 		/// </summary>
 		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string keyValue)
 		{
@@ -320,9 +316,9 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// A ParentIndex entry is identified by the element name as well as the attribute value, matching the
-		/// tuple <see cref="FindByKeyAttribute"/> indexes on: elements of different names never match, however
-		/// their keys compare.
+		/// A ParentIndex entry is identified by the element name as well as the attribute value,
+		/// matching the tuple <see cref="FindByKeyAttribute"/> indexes on: elements of different
+		/// names never match, however their keys compare.
 		/// </summary>
 		private static Tuple<string, string> IndexKey(XmlNode element, string keyValue)
 		{
@@ -365,7 +361,7 @@ namespace Chorus.merge.xml.generic
 		private bool IsMatch(XmlNode candidate, string soughtPreferredKey, string soughtFallbackKey)
 		{
 			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
-			// One carries a preferred value and the other does not, so they are matched separately.
+			// One carries a preferred value and the other does not, so they are matched apart.
 			if (string.IsNullOrEmpty(soughtPreferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
 				return false;
 			// Both carry one, and it decides alone: the fallback value may have changed.
@@ -384,10 +380,9 @@ namespace Chorus.merge.xml.generic
 		{
 			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
 
-			// Whether the element carries a preferred value decides which key attribute it was matched on, so
-			// that is the attribute whose values are the same. Naming the other one too would accuse an
-			// attribute the match never consulted, and whose values, for two elements sharing a preferred
-			// value, may well differ between them.
+			// Whether the element carries a preferred value decides which key attribute it was
+			// matched on, so that is the attribute whose values are the same; naming the other
+			// would accuse an attribute the match never consulted.
 			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
 			var matchedOnPreferredKey = !string.IsNullOrEmpty(preferredKey);
 			return string.Format("The key attribute '{0}' has values that are the same '{1}'",

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -304,9 +304,8 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// Unlike a finder with a single key attribute, two children legitimately hold the same
-		/// fallback value here, since a preferred value can still tell them apart. Keep the
-		/// first, matching how the merger resolves siblings it cannot tell apart.
+		/// Two children can carry the same key value, which is not an error here: keep the first
+		/// and ignore the rest, matching how the merger resolves siblings it cannot tell apart.
 		/// </summary>
 		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string keyValue)
 		{
@@ -316,9 +315,8 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// A ParentIndex entry is identified by the element name as well as the attribute value,
-		/// matching the tuple <see cref="FindByKeyAttribute"/> indexes on: elements of different
-		/// names never match, however their keys compare.
+		/// The element name is part of the key, so elements of different names never match,
+		/// however their key values compare.
 		/// </summary>
 		private static Tuple<string, string> IndexKey(XmlNode element, string keyValue)
 		{

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -212,26 +212,29 @@ namespace Chorus.merge.xml.generic
 	}
 
 	/// <summary>
-	/// Search for a matching element on either of two key attributes. An element that names the preferred
-	/// key is matched on that key alone; an element that names no preferred key is matched on the fallback
-	/// key. The two groups are never matched against each other, so a preferred key that finds no partner
-	/// is not retried against the fallback key.
+	/// Search for a matching element on the value of either of two key attributes. An element carrying a
+	/// non-empty value for the preferred key attribute is matched on that value alone; an element carrying
+	/// none is matched on its value for the fallback key attribute. The two groups are never matched against
+	/// each other, so an element whose preferred value finds no partner is not retried against its fallback
+	/// value. An attribute that is present but empty counts as absent throughout.
 	/// </summary>
 	/// <remarks>
-	/// <para>Use this where the fallback key is derived from user data, and so can change while the object it
-	/// identifies does not, and the preferred key is one that stays with that object. Matching on the
-	/// changeable key alone turns such a change into a deletion plus an addition, which discards the other
-	/// user's edits to the same element and can leave two elements standing for one object.</para>
-	/// <para>Elements naming the preferred key and elements naming none are matched separately, and never
+	/// <para>Use this where the fallback key attribute's value is derived from user data, and so can change
+	/// while the object it identifies does not, and the preferred key attribute holds a value that stays with
+	/// that object. Matching on the changeable value alone turns such a change into a deletion plus an
+	/// addition, which discards the other user's edits to the same element and can leave two elements
+	/// standing for one object.</para>
+	/// <para>Elements carrying a preferred value and elements carrying none are matched separately, and never
 	/// against each other. That keeps matching an equivalence relation, so no element can be paired with
-	/// two partners; were an element naming the preferred key allowed to match one naming none, a set holding
-	/// both could give one element two partners and merge someone's edit onto an object it was not made
-	/// against.</para>
-	/// <para>The price is that where one revision names the preferred key for an element and another does not,
-	/// the element reads as a deletion plus an addition, and as a removed-versus-edited conflict if the other
-	/// revision also edited it. A writer that starts naming the preferred key pays that once. Writers that
-	/// disagree over whether to name it pay it on every merge between them, so choose a preferred key only
-	/// where every writer of the file can be relied on to keep one it finds.</para>
+	/// two partners; were an element carrying a preferred value allowed to match one carrying none, a set
+	/// holding both could give one element two partners and merge someone's edit onto an object it was not
+	/// made against.</para>
+	/// <para>The price is that where one revision gives an element a preferred value and another leaves that
+	/// attribute off, the element reads as a deletion plus an addition, and as a removed-versus-edited
+	/// conflict if the other revision also edited it. A writer that starts writing the preferred attribute
+	/// pays that once. Writers that disagree over whether to write it pay it on every merge between them, so
+	/// choose a preferred key attribute only where every writer of the file can be relied on to preserve the
+	/// value it finds.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
 	{
@@ -259,8 +262,8 @@ namespace Chorus.merge.xml.generic
 			XmlNode match;
 			if (string.IsNullOrEmpty(preferredKey))
 			{
-				// Only among elements that likewise name none, so that this cannot claim an element
-				// the preferred key already speaks for.
+				// Only among elements that likewise carry no preferred value, so that this cannot claim
+				// an element that a preferred value already speaks for.
 				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
 				return match; // May be null, which is fine.
 			}
@@ -269,15 +272,16 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// The children of one parent, indexed by each key this finder can match on, so that merging a
-		/// large element does not rescan its siblings once per child. An index is built when its parent is
-		/// first searched and is never revisited, so a caller that adds or removes children between
-		/// searches of the same parent will still be answered from the children it first held.
+		/// The children of one parent, indexed on (element name, attribute value) for each key attribute this
+		/// finder can match on, so that merging a large element does not rescan its siblings once per child.
+		/// An index is built when its parent is first searched and is never revisited, so a caller that adds
+		/// or removes children between searches of the same parent will still be answered from the children
+		/// it first held.
 		/// </summary>
 		private class ParentIndex
 		{
 			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByPreferredKey = new Dictionary<Tuple<string, string>, XmlNode>();
-			/// <summary>Only those children that name no preferred key of their own.</summary>
+			/// <summary>Only those children that carry no preferred value of their own.</summary>
 			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKeyAlone = new Dictionary<Tuple<string, string>, XmlNode>();
 		}
 
@@ -304,9 +308,9 @@ namespace Chorus.merge.xml.generic
 		}
 
 		/// <summary>
-		/// Unlike a finder with a single key, duplicate fallback keys are legitimate here, since two
-		/// elements can share the fallback key and still be told apart by the preferred one. Keep the
-		/// first, matching how the merger resolves siblings it cannot tell apart.
+		/// Unlike a finder with a single key attribute, two children legitimately hold the same fallback
+		/// value here, since a preferred value can still tell them apart. Keep the first, matching how the
+		/// merger resolves siblings it cannot tell apart.
 		/// </summary>
 		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string key)
 		{
@@ -351,10 +355,10 @@ namespace Chorus.merge.xml.generic
 		private bool IsMatch(XmlNode candidate, string preferredKey, string fallbackKey)
 		{
 			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
-			// One names the preferred key and the other does not, so they are matched separately.
+			// One carries a preferred value and the other does not, so they are matched separately.
 			if (string.IsNullOrEmpty(preferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
 				return false;
-			// Both name it, and it decides alone: the fallback key may have changed.
+			// Both carry one, and it decides alone: the fallback value may have changed.
 			if (!string.IsNullOrEmpty(preferredKey))
 				return preferredKey == candidatePreferredKey;
 			if (string.IsNullOrEmpty(fallbackKey))
@@ -370,9 +374,10 @@ namespace Chorus.merge.xml.generic
 		{
 			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
 
-			// Whether the element names the preferred key decides which key it was matched on, so that is the
-			// key whose values are the same. Naming the other one too would accuse a key the match never
-			// consulted, and which for two elements sharing a preferred key may well differ between them.
+			// Whether the element carries a preferred value decides which key attribute it was matched on, so
+			// that is the attribute whose values are the same. Naming the other one too would accuse an
+			// attribute the match never consulted, and whose values, for two elements sharing a preferred
+			// value, may well differ between them.
 			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
 			var matchedOnPreferredKey = !string.IsNullOrEmpty(preferredKey);
 			return string.Format("The key attribute '{0}' has values that are the same '{1}'",

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -264,10 +264,10 @@ namespace Chorus.merge.xml.generic
 			{
 				// Only among elements that likewise carry no preferred value, so that this cannot claim
 				// an element that a preferred value already speaks for.
-				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
+				index.ByFallbackKeyWherePreferredAbsent.TryGetValue(IndexKey(nodeToMatch, fallbackKey), out match);
 				return match; // May be null, which is fine.
 			}
-			index.ByPreferredKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, preferredKey), out match);
+			index.ByPreferredKey.TryGetValue(IndexKey(nodeToMatch, preferredKey), out match);
 			return match;
 		}
 
@@ -282,7 +282,7 @@ namespace Chorus.merge.xml.generic
 		{
 			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByPreferredKey = new Dictionary<Tuple<string, string>, XmlNode>();
 			/// <summary>Only those children that carry no preferred value of their own.</summary>
-			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKeyAlone = new Dictionary<Tuple<string, string>, XmlNode>();
+			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKeyWherePreferredAbsent = new Dictionary<Tuple<string, string>, XmlNode>();
 		}
 
 		private ParentIndex GetIndexFor(XmlNode parentToSearchIn)
@@ -302,7 +302,7 @@ namespace Chorus.merge.xml.generic
 				if (!string.IsNullOrEmpty(preferredKey))
 					IndexFirstOnly(index.ByPreferredKey, childNode, preferredKey);
 				else if (!string.IsNullOrEmpty(fallbackKey))
-					IndexFirstOnly(index.ByFallbackKeyAlone, childNode, fallbackKey);
+					IndexFirstOnly(index.ByFallbackKeyWherePreferredAbsent, childNode, fallbackKey);
 			}
 			return index;
 		}
@@ -312,11 +312,21 @@ namespace Chorus.merge.xml.generic
 		/// value here, since a preferred value can still tell them apart. Keep the first, matching how the
 		/// merger resolves siblings it cannot tell apart.
 		/// </summary>
-		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string key)
+		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string keyValue)
 		{
-			var indexKey = new Tuple<string, string>(childNode.Name, key);
+			var indexKey = IndexKey(childNode, keyValue);
 			if (!index.ContainsKey(indexKey))
 				index.Add(indexKey, childNode);
+		}
+
+		/// <summary>
+		/// A ParentIndex entry is identified by the element name as well as the attribute value, matching the
+		/// tuple <see cref="FindByKeyAttribute"/> indexes on: elements of different names never match, however
+		/// their keys compare.
+		/// </summary>
+		private static Tuple<string, string> IndexKey(XmlNode element, string keyValue)
+		{
+			return new Tuple<string, string>(element.Name, keyValue);
 		}
 
 		/// <summary>
@@ -352,18 +362,18 @@ namespace Chorus.merge.xml.generic
 			return matches;
 		}
 
-		private bool IsMatch(XmlNode candidate, string preferredKey, string fallbackKey)
+		private bool IsMatch(XmlNode candidate, string soughtPreferredKey, string soughtFallbackKey)
 		{
 			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
 			// One carries a preferred value and the other does not, so they are matched separately.
-			if (string.IsNullOrEmpty(preferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
+			if (string.IsNullOrEmpty(soughtPreferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
 				return false;
 			// Both carry one, and it decides alone: the fallback value may have changed.
-			if (!string.IsNullOrEmpty(preferredKey))
-				return preferredKey == candidatePreferredKey;
-			if (string.IsNullOrEmpty(fallbackKey))
+			if (!string.IsNullOrEmpty(soughtPreferredKey))
+				return soughtPreferredKey == candidatePreferredKey;
+			if (string.IsNullOrEmpty(soughtFallbackKey))
 				return false;
-			return fallbackKey == XmlUtilities.GetOptionalAttributeString(candidate, _fallbackKeyAttribute);
+			return soughtFallbackKey == XmlUtilities.GetOptionalAttributeString(candidate, _fallbackKeyAttribute);
 		}
 
 		/// <summary>

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -212,16 +212,19 @@ namespace Chorus.merge.xml.generic
 
 	/// <summary>
 	/// Search for a matching element using an optional attribute that identifies it permanently (a guid),
-	/// falling back to an ordinary key attribute when either element lacks that attribute.
+	/// falling back to an ordinary key attribute among the elements that name no such attribute.
 	/// </summary>
 	/// <remarks>
 	/// <para>Use this where the ordinary key is derived from user data, and so can be respelled without the
 	/// underlying object having changed. Matching on such a key alone turns a respelling into a deletion
 	/// plus an addition, which discards the other user's edits to the same element and can leave two
 	/// elements standing for one object.</para>
-	/// <para>Matching is not transitive across a set that mixes elements carrying the permanent key with
-	/// elements lacking it: A(guid G, id X) matches B(guid G, id Y), and B matches C(no guid, id Y), but A
-	/// does not match C. Ambiguity resolution over such a set therefore depends on document order.</para>
+	/// <para>Elements naming a permanent key and elements lacking one are matched separately, and never
+	/// against each other. That keeps matching an equivalence relation, so no element can be paired with
+	/// two partners; were a permanent key allowed to match a bare one, a set holding both could give one
+	/// element two partners and merge someone's edit onto an object it was not made against. The price is
+	/// that a file which starts naming permanent keys for elements that previously had none reads as a
+	/// deletion plus an addition, once.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
 	{
@@ -249,15 +252,12 @@ namespace Chorus.merge.xml.generic
 			XmlNode match;
 			if (string.IsNullOrEmpty(preferredKey))
 			{
-				index.ByFallbackKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
+				// Only among elements that likewise name none, so that this cannot claim an element
+				// the permanent key already speaks for.
+				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
 				return match; // May be null, which is fine.
 			}
-			// The permanent key wins wherever it is present, whatever the document order.
-			if (index.ByPreferredKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, preferredKey), out match))
-				return match;
-			// Only an element naming no permanent key of its own can still be the same object.
-			if (!string.IsNullOrEmpty(fallbackKey))
-				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
+			index.ByPreferredKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, preferredKey), out match);
 			return match;
 		}
 
@@ -268,7 +268,6 @@ namespace Chorus.merge.xml.generic
 		private class ParentIndex
 		{
 			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByPreferredKey = new Dictionary<Tuple<string, string>, XmlNode>();
-			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKey = new Dictionary<Tuple<string, string>, XmlNode>();
 			/// <summary>Only those children that name no preferred key of their own.</summary>
 			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKeyAlone = new Dictionary<Tuple<string, string>, XmlNode>();
 		}
@@ -289,10 +288,7 @@ namespace Chorus.merge.xml.generic
 				var fallbackKey = XmlUtilities.GetOptionalAttributeString(childNode, _fallbackKeyAttribute);
 				if (!string.IsNullOrEmpty(preferredKey))
 					IndexFirstOnly(index.ByPreferredKey, childNode, preferredKey);
-				if (string.IsNullOrEmpty(fallbackKey))
-					continue;
-				IndexFirstOnly(index.ByFallbackKey, childNode, fallbackKey);
-				if (string.IsNullOrEmpty(preferredKey))
+				else if (!string.IsNullOrEmpty(fallbackKey))
 					IndexFirstOnly(index.ByFallbackKeyAlone, childNode, fallbackKey);
 			}
 			return index;
@@ -346,8 +342,11 @@ namespace Chorus.merge.xml.generic
 		private bool IsMatch(XmlNode candidate, string preferredKey, string fallbackKey)
 		{
 			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
-			// When both carry the permanent key it decides on its own, since the fallback key may have moved.
-			if (!string.IsNullOrEmpty(preferredKey) && !string.IsNullOrEmpty(candidatePreferredKey))
+			// One names a permanent key and the other does not, so they are matched separately.
+			if (string.IsNullOrEmpty(preferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
+				return false;
+			// Both name one, and it decides alone: the fallback key may have moved.
+			if (!string.IsNullOrEmpty(preferredKey))
 				return preferredKey == candidatePreferredKey;
 			if (string.IsNullOrEmpty(fallbackKey))
 				return false;

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -215,15 +215,19 @@ namespace Chorus.merge.xml.generic
 	/// falling back to an ordinary key attribute when either element lacks that attribute.
 	/// </summary>
 	/// <remarks>
-	/// Use this where the ordinary key is derived from user data, and so can be respelled without the
+	/// <para>Use this where the ordinary key is derived from user data, and so can be respelled without the
 	/// underlying object having changed. Matching on such a key alone turns a respelling into a deletion
 	/// plus an addition, which discards the other user's edits to the same element and can leave two
-	/// elements standing for one object.
+	/// elements standing for one object.</para>
+	/// <para>Matching is not transitive across a set that mixes elements carrying the permanent key with
+	/// elements lacking it: A(guid G, id X) matches B(guid G, id Y), and B matches C(no guid, id Y), but A
+	/// does not match C. Ambiguity resolution over such a set therefore depends on document order.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
 	{
 		private readonly string _preferredKeyAttribute;
 		private readonly string _fallbackKeyAttribute;
+		private readonly Dictionary<XmlNode, ParentIndex> _indexedParents = new Dictionary<XmlNode, ParentIndex>();
 
 		public FindByPreferredKeyAttribute(string preferredKeyAttribute, string fallbackKeyAttribute)
 		{
@@ -233,15 +237,77 @@ namespace Chorus.merge.xml.generic
 
 		public XmlNode GetNodeToMerge(XmlNode nodeToMatch, XmlNode parentToSearchIn, HashSet<XmlNode> acceptableTargets)
 		{
-			if (parentToSearchIn == null)
+			if (nodeToMatch == null || parentToSearchIn == null)
 				return null;
 
-			foreach (var match in GetMatchingNodes(nodeToMatch, parentToSearchIn))
+			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeToMatch, _preferredKeyAttribute);
+			var fallbackKey = XmlUtilities.GetOptionalAttributeString(nodeToMatch, _fallbackKeyAttribute);
+			if (string.IsNullOrEmpty(preferredKey) && string.IsNullOrEmpty(fallbackKey))
+				return null;
+
+			var index = GetIndexFor(parentToSearchIn);
+			XmlNode match;
+			if (string.IsNullOrEmpty(preferredKey))
 			{
-				if (acceptableTargets.Contains(match))
-					return match;
+				index.ByFallbackKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
+				return match; // May be null, which is fine.
 			}
-			return null;
+			// The permanent key wins wherever it is present, whatever the document order.
+			if (index.ByPreferredKey.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, preferredKey), out match))
+				return match;
+			// Only an element naming no permanent key of its own can still be the same object.
+			if (!string.IsNullOrEmpty(fallbackKey))
+				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
+			return match;
+		}
+
+		/// <summary>
+		/// The children of one parent, indexed by each key this finder can match on, so that merging a
+		/// large element does not rescan its siblings once per child.
+		/// </summary>
+		private class ParentIndex
+		{
+			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByPreferredKey = new Dictionary<Tuple<string, string>, XmlNode>();
+			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKey = new Dictionary<Tuple<string, string>, XmlNode>();
+			/// <summary>Only those children that name no preferred key of their own.</summary>
+			internal readonly Dictionary<Tuple<string, string>, XmlNode> ByFallbackKeyAlone = new Dictionary<Tuple<string, string>, XmlNode>();
+		}
+
+		private ParentIndex GetIndexFor(XmlNode parentToSearchIn)
+		{
+			ParentIndex index;
+			if (_indexedParents.TryGetValue(parentToSearchIn, out index))
+				return index;
+
+			index = new ParentIndex();
+			_indexedParents.Add(parentToSearchIn, index);
+			foreach (XmlNode childNode in parentToSearchIn.ChildNodes)
+			{
+				if (childNode.NodeType != XmlNodeType.Element)
+					continue;
+				var preferredKey = XmlUtilities.GetOptionalAttributeString(childNode, _preferredKeyAttribute);
+				var fallbackKey = XmlUtilities.GetOptionalAttributeString(childNode, _fallbackKeyAttribute);
+				if (!string.IsNullOrEmpty(preferredKey))
+					IndexFirstOnly(index.ByPreferredKey, childNode, preferredKey);
+				if (string.IsNullOrEmpty(fallbackKey))
+					continue;
+				IndexFirstOnly(index.ByFallbackKey, childNode, fallbackKey);
+				if (string.IsNullOrEmpty(preferredKey))
+					IndexFirstOnly(index.ByFallbackKeyAlone, childNode, fallbackKey);
+			}
+			return index;
+		}
+
+		/// <summary>
+		/// Unlike a finder with a single key, duplicate fallback keys are legitimate here, since two
+		/// elements can share a respellable key and still be told apart by the permanent one. Keep the
+		/// first, matching how the merger resolves siblings it cannot tell apart.
+		/// </summary>
+		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string key)
+		{
+			var indexKey = new Tuple<string, string>(childNode.Name, key);
+			if (!index.ContainsKey(indexKey))
+				index.Add(indexKey, childNode);
 		}
 
 		/// <summary>
@@ -296,12 +362,15 @@ namespace Chorus.merge.xml.generic
 		{
 			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
 
+			// Either key can be what made the siblings indistinguishable, and by here it is no longer
+			// known which, so report both rather than claim the guids matched when they may not have.
 			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
+			var fallbackKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _fallbackKeyAttribute);
 			return string.IsNullOrEmpty(preferredKey)
 				? string.Format("The key attribute '{0}' has values that are the same '{1}'",
-					_fallbackKeyAttribute, XmlUtilities.GetOptionalAttributeString(nodeForMessage, _fallbackKeyAttribute))
-				: string.Format("The key attribute '{0}' has values that are the same '{1}'",
-					_preferredKeyAttribute, preferredKey);
+					_fallbackKeyAttribute, fallbackKey)
+				: string.Format("The key attributes '{0}' ('{1}') and '{2}' ('{3}') do not tell these elements apart",
+					_preferredKeyAttribute, preferredKey, _fallbackKeyAttribute, fallbackKey);
 		}
 	}
 

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -15,9 +15,10 @@ namespace Chorus.merge.xml.generic
 	public interface IFindNodeToMerge
 	{
 		/// <summary>
-		/// Should return null if parentToSearchIn is null. Non-null result should be a value in acceptableTargets,
-		/// which will be a subset (or all) of the children of parentToSearchIn; any other result will
-		/// be treated as no match.
+		/// Should return null if parentToSearchIn is null, and otherwise either null or a child of
+		/// parentToSearchIn. acceptableTargets is a subset (or all) of the children of parentToSearchIn;
+		/// an implementation holding only one possible match may ignore it and return that match, so a
+		/// caller passing a strict subset is responsible for discarding a result outside it.
 		/// </summary>
 		XmlNode GetNodeToMerge(XmlNode nodeToMatch, XmlNode parentToSearchIn, HashSet<XmlNode> acceptableTargets);
 	}
@@ -222,9 +223,12 @@ namespace Chorus.merge.xml.generic
 	/// <para>Elements naming a permanent key and elements lacking one are matched separately, and never
 	/// against each other. That keeps matching an equivalence relation, so no element can be paired with
 	/// two partners; were a permanent key allowed to match a bare one, a set holding both could give one
-	/// element two partners and merge someone's edit onto an object it was not made against. The price is
-	/// that a file which starts naming permanent keys for elements that previously had none reads as a
-	/// deletion plus an addition, once.</para>
+	/// element two partners and merge someone's edit onto an object it was not made against.</para>
+	/// <para>The price is that where one revision names a permanent key for an element and another does not,
+	/// the element reads as a deletion plus an addition, and as a removed-versus-edited conflict if the other
+	/// revision also edited it. A writer that starts naming permanent keys pays that once. Writers that
+	/// disagree over whether to name them pay it on every merge between them, so prefer a permanent key only
+	/// where every writer of the file can be relied on to keep one it finds.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
 	{
@@ -263,7 +267,9 @@ namespace Chorus.merge.xml.generic
 
 		/// <summary>
 		/// The children of one parent, indexed by each key this finder can match on, so that merging a
-		/// large element does not rescan its siblings once per child.
+		/// large element does not rescan its siblings once per child. An index is built when its parent is
+		/// first searched and is never revisited, so a caller that adds or removes children between
+		/// searches of the same parent will still be answered from the children it first held.
 		/// </summary>
 		private class ParentIndex
 		{

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -367,15 +367,14 @@ namespace Chorus.merge.xml.generic
 		{
 			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
 
-			// Either key can be what made the siblings indistinguishable, and by here it is no longer
-			// known which, so report both rather than claim the guids matched when they may not have.
+			// Whether the element names a permanent key decides which key it was matched on, so that is the
+			// key whose values are the same. Naming the other one too would accuse a key the match never
+			// consulted, and which for two elements sharing a permanent key may well differ between them.
 			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
-			var fallbackKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _fallbackKeyAttribute);
-			return string.IsNullOrEmpty(preferredKey)
-				? string.Format("The key attribute '{0}' has values that are the same '{1}'",
-					_fallbackKeyAttribute, fallbackKey)
-				: string.Format("The key attributes '{0}' ('{1}') and '{2}' ('{3}') do not tell these elements apart",
-					_preferredKeyAttribute, preferredKey, _fallbackKeyAttribute, fallbackKey);
+			var matchedOnPreferredKey = !string.IsNullOrEmpty(preferredKey);
+			return string.Format("The key attribute '{0}' has values that are the same '{1}'",
+				matchedOnPreferredKey ? _preferredKeyAttribute : _fallbackKeyAttribute,
+				matchedOnPreferredKey ? preferredKey : XmlUtilities.GetOptionalAttributeString(nodeForMessage, _fallbackKeyAttribute));
 		}
 	}
 

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -212,22 +212,25 @@ namespace Chorus.merge.xml.generic
 	}
 
 	/// <summary>
-	/// Search for a matching element using an optional attribute that identifies it permanently (a guid),
-	/// falling back to an ordinary key attribute among the elements that name no such attribute.
+	/// Search for a matching element on either of two key attributes. An element that names the preferred
+	/// key is matched on that key alone; an element that names no preferred key is matched on the fallback
+	/// key. The two groups are never matched against each other, so a preferred key that finds no partner
+	/// is not retried against the fallback key.
 	/// </summary>
 	/// <remarks>
-	/// <para>Use this where the ordinary key is derived from user data, and so can be respelled without the
-	/// underlying object having changed. Matching on such a key alone turns a respelling into a deletion
-	/// plus an addition, which discards the other user's edits to the same element and can leave two
-	/// elements standing for one object.</para>
-	/// <para>Elements naming a permanent key and elements lacking one are matched separately, and never
+	/// <para>Use this where the fallback key is derived from user data, and so can change while the object it
+	/// identifies does not, and the preferred key is one that stays with that object. Matching on the
+	/// changeable key alone turns such a change into a deletion plus an addition, which discards the other
+	/// user's edits to the same element and can leave two elements standing for one object.</para>
+	/// <para>Elements naming the preferred key and elements naming none are matched separately, and never
 	/// against each other. That keeps matching an equivalence relation, so no element can be paired with
-	/// two partners; were a permanent key allowed to match a bare one, a set holding both could give one
-	/// element two partners and merge someone's edit onto an object it was not made against.</para>
-	/// <para>The price is that where one revision names a permanent key for an element and another does not,
+	/// two partners; were an element naming the preferred key allowed to match one naming none, a set holding
+	/// both could give one element two partners and merge someone's edit onto an object it was not made
+	/// against.</para>
+	/// <para>The price is that where one revision names the preferred key for an element and another does not,
 	/// the element reads as a deletion plus an addition, and as a removed-versus-edited conflict if the other
-	/// revision also edited it. A writer that starts naming permanent keys pays that once. Writers that
-	/// disagree over whether to name them pay it on every merge between them, so prefer a permanent key only
+	/// revision also edited it. A writer that starts naming the preferred key pays that once. Writers that
+	/// disagree over whether to name it pay it on every merge between them, so choose a preferred key only
 	/// where every writer of the file can be relied on to keep one it finds.</para>
 	/// </remarks>
 	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
@@ -257,7 +260,7 @@ namespace Chorus.merge.xml.generic
 			if (string.IsNullOrEmpty(preferredKey))
 			{
 				// Only among elements that likewise name none, so that this cannot claim an element
-				// the permanent key already speaks for.
+				// the preferred key already speaks for.
 				index.ByFallbackKeyAlone.TryGetValue(new Tuple<string, string>(nodeToMatch.Name, fallbackKey), out match);
 				return match; // May be null, which is fine.
 			}
@@ -302,7 +305,7 @@ namespace Chorus.merge.xml.generic
 
 		/// <summary>
 		/// Unlike a finder with a single key, duplicate fallback keys are legitimate here, since two
-		/// elements can share a respellable key and still be told apart by the permanent one. Keep the
+		/// elements can share the fallback key and still be told apart by the preferred one. Keep the
 		/// first, matching how the merger resolves siblings it cannot tell apart.
 		/// </summary>
 		private static void IndexFirstOnly(IDictionary<Tuple<string, string>, XmlNode> index, XmlNode childNode, string key)
@@ -348,10 +351,10 @@ namespace Chorus.merge.xml.generic
 		private bool IsMatch(XmlNode candidate, string preferredKey, string fallbackKey)
 		{
 			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
-			// One names a permanent key and the other does not, so they are matched separately.
+			// One names the preferred key and the other does not, so they are matched separately.
 			if (string.IsNullOrEmpty(preferredKey) != string.IsNullOrEmpty(candidatePreferredKey))
 				return false;
-			// Both name one, and it decides alone: the fallback key may have moved.
+			// Both name it, and it decides alone: the fallback key may have changed.
 			if (!string.IsNullOrEmpty(preferredKey))
 				return preferredKey == candidatePreferredKey;
 			if (string.IsNullOrEmpty(fallbackKey))
@@ -367,9 +370,9 @@ namespace Chorus.merge.xml.generic
 		{
 			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
 
-			// Whether the element names a permanent key decides which key it was matched on, so that is the
+			// Whether the element names the preferred key decides which key it was matched on, so that is the
 			// key whose values are the same. Naming the other one too would accuse a key the match never
-			// consulted, and which for two elements sharing a permanent key may well differ between them.
+			// consulted, and which for two elements sharing a preferred key may well differ between them.
 			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
 			var matchedOnPreferredKey = !string.IsNullOrEmpty(preferredKey);
 			return string.Format("The key attribute '{0}' has values that are the same '{1}'",

--- a/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
+++ b/src/LibChorus/merge/xml/generic/FindNodeToMerge.cs
@@ -211,6 +211,101 @@ namespace Chorus.merge.xml.generic
 	}
 
 	/// <summary>
+	/// Search for a matching element using an optional attribute that identifies it permanently (a guid),
+	/// falling back to an ordinary key attribute when either element lacks that attribute.
+	/// </summary>
+	/// <remarks>
+	/// Use this where the ordinary key is derived from user data, and so can be respelled without the
+	/// underlying object having changed. Matching on such a key alone turns a respelling into a deletion
+	/// plus an addition, which discards the other user's edits to the same element and can leave two
+	/// elements standing for one object.
+	/// </remarks>
+	public class FindByPreferredKeyAttribute : IFindMatchingNodesToMerge
+	{
+		private readonly string _preferredKeyAttribute;
+		private readonly string _fallbackKeyAttribute;
+
+		public FindByPreferredKeyAttribute(string preferredKeyAttribute, string fallbackKeyAttribute)
+		{
+			_preferredKeyAttribute = preferredKeyAttribute;
+			_fallbackKeyAttribute = fallbackKeyAttribute;
+		}
+
+		public XmlNode GetNodeToMerge(XmlNode nodeToMatch, XmlNode parentToSearchIn, HashSet<XmlNode> acceptableTargets)
+		{
+			if (parentToSearchIn == null)
+				return null;
+
+			foreach (var match in GetMatchingNodes(nodeToMatch, parentToSearchIn))
+			{
+				if (acceptableTargets.Contains(match))
+					return match;
+			}
+			return null;
+		}
+
+		/// <summary>
+		/// Get all matching nodes, or an empty collection, if there are no matches.
+		/// </summary>
+		/// <returns>A collection of zero, or more, matching nodes.</returns>
+		/// <remarks><paramref name="nodeToMatch" /> may, or may not, be a child of <paramref name="parentToSearchIn"/>.</remarks>
+		public IEnumerable<XmlNode> GetMatchingNodes(XmlNode nodeToMatch, XmlNode parentToSearchIn)
+		{
+			var matches = new List<XmlNode>();
+			if (nodeToMatch == null || parentToSearchIn == null)
+				return matches;
+
+			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeToMatch, _preferredKeyAttribute);
+			var fallbackKey = XmlUtilities.GetOptionalAttributeString(nodeToMatch, _fallbackKeyAttribute);
+			if (string.IsNullOrEmpty(preferredKey) && string.IsNullOrEmpty(fallbackKey))
+				return matches;
+
+			foreach (XmlNode childNode in parentToSearchIn.ChildNodes)
+			{
+				if (childNode.NodeType != XmlNodeType.Element)
+					continue;
+				if (nodeToMatch == childNode)
+				{
+					matches.Add(childNode);
+					continue;
+				}
+				if (childNode.Name != nodeToMatch.Name)
+					continue;
+				if (IsMatch(childNode, preferredKey, fallbackKey))
+					matches.Add(childNode);
+			}
+			return matches;
+		}
+
+		private bool IsMatch(XmlNode candidate, string preferredKey, string fallbackKey)
+		{
+			var candidatePreferredKey = XmlUtilities.GetOptionalAttributeString(candidate, _preferredKeyAttribute);
+			// When both carry the permanent key it decides on its own, since the fallback key may have moved.
+			if (!string.IsNullOrEmpty(preferredKey) && !string.IsNullOrEmpty(candidatePreferredKey))
+				return preferredKey == candidatePreferredKey;
+			if (string.IsNullOrEmpty(fallbackKey))
+				return false;
+			return fallbackKey == XmlUtilities.GetOptionalAttributeString(candidate, _fallbackKeyAttribute);
+		}
+
+		/// <summary>
+		/// Get a basic message that is suitable for use in a warning report where ambiguous nodes are found in the same parent node.
+		/// </summary>
+		/// <returns>A message string or null/empty string, if no message is needed for ambiguous nodes.</returns>
+		public string GetWarningMessageForAmbiguousNodes(XmlNode nodeForMessage)
+		{
+			Guard.AgainstNull(nodeForMessage, "nodeForMessage");
+
+			var preferredKey = XmlUtilities.GetOptionalAttributeString(nodeForMessage, _preferredKeyAttribute);
+			return string.IsNullOrEmpty(preferredKey)
+				? string.Format("The key attribute '{0}' has values that are the same '{1}'",
+					_fallbackKeyAttribute, XmlUtilities.GetOptionalAttributeString(nodeForMessage, _fallbackKeyAttribute))
+				: string.Format("The key attribute '{0}' has values that are the same '{1}'",
+					_preferredKeyAttribute, preferredKey);
+		}
+	}
+
+	/// <summary>
 	/// Assuming the children of the parent to search in form a list (order matters, duplicates allowed), and so do the
 	/// children of the nodeToMatch, find the corresponding object in the list. A corresponding node will have the same key,
 	/// and the same number of preceding siblings with the same key among the acceptableTargets, and the same element name.

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Chorus.FileTypeHandlers;
 using Chorus.merge;
+using Chorus.merge.xml.generic;
 using LibChorus.TestUtilities;
 using NUnit.Framework;
 using SIL.IO;
@@ -290,6 +291,31 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
 				"//range-element/abbrev/form/text[text()='new']", 1);
+		}
+
+		/// <summary>
+		/// An element that names a guid is matched only against elements that likewise name one, so a
+		/// writer that drops the guid a previous writer wrote loses the object's identity: the element
+		/// reads as a deletion and its guid-less replacement as an addition. That is the cost of keeping
+		/// the two sets apart, and a project whose writers disagree over the guid pays it on every merge
+		/// between them.
+		/// </summary>
+		[Test]
+		public void DroppingTheGuidReadsAsADeletionPlusAnAddition()
+		{
+			var common = RangesWithPartOfSpeech("Noun", kPosGuid, "old");
+			// Our writer omits the guid the ancestor names.
+			var ours = RangesWithPartOfSpeech("Noun", null, "old");
+			var theirs = RangesWithPartOfSpeech("Noun", kPosGuid, "new");
+
+			var result = DoMerge(common, ours, theirs, 1, 1);
+
+			_eventListener.AssertFirstConflictType<RemovedVsEditedElementConflict>();
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 2);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element[not(@guid)]/abbrev/form/text[text()='old']", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(string.Format(
+				"//range-element[@guid='{0}']/abbrev/form/text[text()='new']", kPosGuid), 1);
 		}
 
 		/// <summary>

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -7,6 +7,7 @@ using LibChorus.TestUtilities;
 using NUnit.Framework;
 using SIL.IO;
 using SIL.Progress;
+using SIL.TestUtilities;
 
 namespace LibChorus.Tests.FileHandlers.LiftRanges
 {
@@ -249,6 +250,114 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 </lift-ranges>";
 			var result = DoMerge(common, ours, theirs, 1, 0).Replace("\"", "'").Replace("\r\n", "\n");
 			Assert.AreEqual(ours.Replace("\r\n", "\n"), result);
+		}
+
+		/// <summary>
+		/// A range-element id is the possibility's own name, so FLEx respelling names on export
+		/// (LT-22697 normalizes them) moves the id without the possibility having changed.
+		/// </summary>
+		[Test]
+		public void RespelledIdMergesAsAnEditWhenTheGuidIsUnchanged()
+		{
+			var common = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "old");
+			// We upgraded, so our export normalizes the id.
+			var ours = RangesWithPartOfSpeech(kComposedName, kPosGuid, "old");
+			// They did not upgrade, and they edited the abbreviation.
+			var theirs = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "new");
+
+			var result = DoMerge(common, ours, theirs, 0, 2);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				string.Format("//range-element[@guid='{0}' and @id='{1}']", kPosGuid, kComposedName), 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element/abbrev/form/text[text()='new']", 1);
+		}
+
+		/// <summary>
+		/// The guid is optional in LIFT, so a file written without one must still merge on the id.
+		/// </summary>
+		[Test]
+		public void RangeElementWithoutAGuidStillMergesOnItsId()
+		{
+			var common = RangesWithPartOfSpeech("Noun", null, "old");
+			var ours = RangesWithPartOfSpeech("Noun", null, "old");
+			var theirs = RangesWithPartOfSpeech("Noun", null, "new");
+
+			var result = DoMerge(common, ours, theirs, 0, 0);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element/abbrev/form/text[text()='new']", 1);
+		}
+
+		/// <summary>
+		/// Two possibilities that happen to share a name are still two possibilities. Matching them
+		/// on the id would merge them into one and lose a guid.
+		/// </summary>
+		[Test]
+		public void RangeElementsWithDifferentGuidsAreNotMatched()
+		{
+			const string theirGuid = "9c4d3e2b-77a6-4b1e-8d55-6a0f2c3e14bb";
+			const string common =
+@"<?xml version='1.0' encoding='utf-8'?>
+<lift-ranges>
+<range id='grammatical-info' />
+</lift-ranges>";
+			var ours = RangesWithPartOfSpeech("Noun", kPosGuid, "n");
+			var theirs = RangesWithPartOfSpeech("Noun", theirGuid, "n");
+
+			var result = DoMerge(common, ours, theirs, 0, 2);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 2);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				string.Format("//range-element[@guid='{0}']", kPosGuid), 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				string.Format("//range-element[@guid='{0}']", theirGuid), 1);
+		}
+
+		/// <summary>
+		/// A merge done before the guid was preferred could leave one possibility standing as two
+		/// range-elements, spelled differently. Matching on the guid makes them ambiguous siblings,
+		/// which the merger collapses back to one.
+		/// </summary>
+		[Test]
+		public void RangeElementsDuplicatedByAnEarlierMergeCollapseToOne()
+		{
+			var duplicated = string.Format(
+@"<?xml version='1.0' encoding='utf-8'?>
+<lift-ranges>
+<range id='grammatical-info'>
+<range-element id='{0}' guid='{2}'>
+<abbrev><form lang='en'><text>old</text></form></abbrev>
+</range-element>
+<range-element id='{1}' guid='{2}'>
+<abbrev><form lang='en'><text>old</text></form></abbrev>
+</range-element>
+</range>
+</lift-ranges>", kDecomposedName, kComposedName, kPosGuid);
+
+			var result = DoMerge(duplicated, duplicated, duplicated, 0, 0);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
+			Assert.That(_eventListener.Warnings, Is.Not.Empty, "the dropped duplicate should be reported");
+		}
+
+		private const string kDecomposedName = "Compléments";	// e + combining acute
+		private const string kComposedName = "Compléments";	// precomposed e-acute
+		private const string kPosGuid = "e8c4b4b0-1a2f-4f9e-9f39-3f2b0d8f7a11";
+
+		private static string RangesWithPartOfSpeech(string id, string guid, string abbrev)
+		{
+			return string.Format(
+@"<?xml version='1.0' encoding='utf-8'?>
+<lift-ranges>
+<range id='grammatical-info'>
+<range-element id='{0}'{1}>
+<abbrev><form lang='en'><text>{2}</text></form></abbrev>
+</range-element>
+</range>
+</lift-ranges>", id, guid == null ? string.Empty : string.Format(" guid='{0}'", guid), abbrev);
 		}
 
 		private string DoMerge(string commonAncestor, string ourContent, string theirContent,

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -381,7 +381,8 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		/// <summary>
 		/// A merge done before the guid was preferred could leave one possibility standing as two
 		/// range-elements, spelled differently. Matching on the guid makes them ambiguous siblings,
-		/// which the merger collapses back to one.
+		/// which the merger collapses back to one. The warning must name the guid as what the two
+		/// share, since the differing ids are not what made them indistinguishable.
 		/// </summary>
 		[Test]
 		public void RangeElementsDuplicatedByAnEarlierMergeCollapseToOne()
@@ -403,6 +404,9 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
 			Assert.That(_eventListener.Warnings, Is.Not.Empty, "the dropped duplicate should be reported");
+			var warning = _eventListener.Warnings[0].GetFullHumanReadableDescription();
+			Assert.That(warning, Does.Contain("'guid'").And.Contain(kPosGuid), warning);
+			Assert.That(warning, Does.Not.Contain("'id'"), warning);
 		}
 
 		// Built rather than written out, since the two spellings are indistinguishable in source and an

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -277,7 +277,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// The guid is optional in LIFT, so a file written without one must still merge on the id.
+		/// @guid is optional in LIFT, so a file written without one must still merge on its id.
 		/// </summary>
 		[Test]
 		public void RangeElementWithoutAGuidStillMergesOnItsId()
@@ -294,11 +294,32 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// An element that names a guid is matched only against elements that likewise name one, so a
-		/// writer that drops the guid a previous writer wrote loses the object's identity: the element
-		/// reads as a deletion and its guid-less replacement as an addition. That is the cost of keeping
-		/// the two sets apart, and a project whose writers disagree over the guid pays it on every merge
-		/// between them.
+		/// The finder branches on a value, not on the attribute, so @guid='' counts as no guid at
+		/// all: such an element is matched on its @id, and matches one that omits @guid outright,
+		/// rather than reading as a deletion plus an addition.
+		/// </summary>
+		[Test]
+		public void AnEmptyGuidCountsAsNoGuidAtAll()
+		{
+			var common = RangesWithPartOfSpeech("Noun", null, "old");
+			// Our writer emits the attribute but leaves it empty.
+			var ours = RangesWithPartOfSpeech("Noun", "", "old");
+			var theirs = RangesWithPartOfSpeech("Noun", null, "new");
+
+			// Two changes for our added attribute, as in the respelled-id case; none for theirs.
+			var result = DoMerge(common, ours, theirs, 0, 2);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element/abbrev/form/text[text()='new']", 1);
+		}
+
+		/// <summary>
+		/// An element that names a guid is matched only against elements that likewise name
+		/// one, so a writer that drops the guid a previous writer wrote loses the object's
+		/// identity: the element reads as a deletion and its guid-less replacement as an
+		/// addition. That is the cost of keeping the two sets apart, and a project whose
+		/// writers disagree over the guid pays it on every merge between them.
 		/// </summary>
 		[Test]
 		public void DroppingTheGuidReadsAsADeletionPlusAnAddition()
@@ -319,8 +340,8 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// Two possibilities that happen to share a name are still two possibilities. Matching them
-		/// on the id would merge them into one and lose a guid.
+		/// Two possibilities that happen to share a name are still two possibilities.
+		/// Matching them on the id would merge them into one and lose a guid.
 		/// </summary>
 		[Test]
 		public void RangeElementsWithDifferentGuidsAreNotMatched()
@@ -344,8 +365,8 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// A sibling that still carries the old id, written by a tool that omits guids, must not be
-		/// taken as the partner just because it comes first in the file.
+		/// A sibling that still carries the old id, written by a tool that omits guids, must
+		/// not be taken as the partner just because it comes first in the file.
 		/// </summary>
 		[Test]
 		public void GuidMatchIsPreferredOverAnEarlierSiblingMatchingOnTheOldId()
@@ -366,12 +387,12 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 </lift-ranges>", kDecomposedId, kComposedId, kPosGuid);
 			var theirs = RangesWithPartOfSpeech(kDecomposedId, kPosGuid, "new");
 
-			// No conflict: the guid-less sibling is matched only against other guid-less elements, so it
-			// cannot also claim the element the guid already speaks for.
+			// No conflict: the guid-less sibling is matched only against other guid-less
+			// elements, so it cannot also claim the element the guid already speaks for.
 			var result = DoMerge(common, ours, theirs, 0, 3);
 
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 2);
-			// Their edit belongs to the element sharing the guid, not to the one sharing the old id.
+			// Their edit belongs to the element sharing the guid, not the one sharing the old id.
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(string.Format(
 				"//range-element[@guid='{0}']/abbrev/form/text[text()='new']", kPosGuid), 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
@@ -379,11 +400,11 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// A merge done before @guid was preferred could leave one possibility standing as two
-		/// range-elements, spelled differently. Matching on the guid value makes them ambiguous siblings,
-		/// which the merger collapses back to one. The warning must name @guid as the attribute whose
-		/// values are the same, and quote the shared value, since the differing ids are not what made
-		/// them indistinguishable.
+		/// A merge done before @guid was preferred could leave one possibility standing as
+		/// two range-elements, spelled differently. Matching on the guid value makes them
+		/// ambiguous siblings, which the merger collapses back to one. The warning must name
+		/// @guid as the attribute whose values are the same, and quote the shared value,
+		/// since the differing ids are not what made them indistinguishable.
 		/// </summary>
 		[Test]
 		public void RangeElementsDuplicatedByAnEarlierMergeCollapseToOne()
@@ -410,14 +431,17 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			Assert.That(warning, Does.Not.Contain("'id'"), warning);
 		}
 
-		// The two @id values a part of speech named "Compléments" is exported under. Built rather than written
-		// out, since the two spellings are indistinguishable in source and an editor or a text filter that
-		// normalizes on save would silently make them the same string.
+		// The two @id values a part of speech named "Compléments" is exported under. Built
+		// rather than written out, since the two spellings are indistinguishable in source
+		// and an editor or a text filter that normalizes on save would silently make them
+		// the same string.
 		private static readonly string kDecomposedId = "Compléments".Normalize(NormalizationForm.FormD);
 		private static readonly string kComposedId = "Compléments".Normalize(NormalizationForm.FormC);
 		private const string kPosGuid = "e8c4b4b0-1a2f-4f9e-9f39-3f2b0d8f7a11";
 
-		/// <summary>A null <paramref name="posGuidOrNull"/> leaves @guid off the element altogether.</summary>
+		/// <summary>
+		/// A null <paramref name="posGuidOrNull"/> leaves @guid off the element altogether.
+		/// </summary>
 		private static string RangesWithPartOfSpeech(string posId, string posGuidOrNull, string abbrevText)
 		{
 			return string.Format(

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -340,9 +340,9 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 </lift-ranges>", kDecomposedName, kComposedName, kPosGuid);
 			var theirs = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "new");
 
-			// The guid-less sibling genuinely is indistinguishable from the ancestor element under the
-			// fallback rule, so one conflict here is the merger reporting real ambiguity in the input.
-			var result = DoMerge(common, ours, theirs, 1, 4);
+			// No conflict: the guid-less sibling is matched only against other guid-less elements, so it
+			// cannot also claim the element the guid already speaks for.
+			var result = DoMerge(common, ours, theirs, 0, 3);
 
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 2);
 			// Their edit belongs to the element sharing the guid, not to the one sharing the old id.

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -379,10 +379,11 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
-		/// A merge done before the guid was preferred could leave one possibility standing as two
-		/// range-elements, spelled differently. Matching on the guid makes them ambiguous siblings,
-		/// which the merger collapses back to one. The warning must name the guid as what the two
-		/// share, since the differing ids are not what made them indistinguishable.
+		/// A merge done before @guid was preferred could leave one possibility standing as two
+		/// range-elements, spelled differently. Matching on the guid value makes them ambiguous siblings,
+		/// which the merger collapses back to one. The warning must name @guid as the attribute whose
+		/// values are the same, and quote the shared value, since the differing ids are not what made
+		/// them indistinguishable.
 		/// </summary>
 		[Test]
 		public void RangeElementsDuplicatedByAnEarlierMergeCollapseToOne()

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -406,6 +406,13 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		/// @guid as the attribute whose values are the same, and quote the shared value,
 		/// since the differing ids are not what made them indistinguishable.
 		/// </summary>
+		/// <remarks>
+		/// The collapse keeps the first of the pair in document order and discards the other
+		/// outright, so whatever the earlier merge left on the loser goes with it. The two are
+		/// given different content here to pin that cost rather than hide it behind a pair that
+		/// happens to agree. There is no better winner available: this is a sanitizing pass over
+		/// each revision as it is read, with no view of which side wrote which.
+		/// </remarks>
 		[Test]
 		public void RangeElementsDuplicatedByAnEarlierMergeCollapseToOne()
 		{
@@ -414,10 +421,11 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 <lift-ranges>
 <range id='grammatical-info'>
 <range-element id='{0}' guid='{2}'>
-<abbrev><form lang='en'><text>old</text></form></abbrev>
+<abbrev><form lang='en'><text>kept</text></form></abbrev>
 </range-element>
 <range-element id='{1}' guid='{2}'>
-<abbrev><form lang='en'><text>old</text></form></abbrev>
+<abbrev><form lang='en'><text>dropped</text></form></abbrev>
+<label><form lang='en'><text>dropped</text></form></label>
 </range-element>
 </range>
 </lift-ranges>", kDecomposedId, kComposedId, kPosGuid);
@@ -425,6 +433,13 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			var result = DoMerge(duplicated, duplicated, duplicated, 0, 0);
 
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
+			// The loser's content is discarded, not merged into the survivor.
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element/abbrev/form/text[text()='kept']", 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element/abbrev/form/text[text()='dropped']", 0);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range-element/label", 0);
+
 			Assert.That(_eventListener.Warnings, Is.Not.Empty, "the dropped duplicate should be reported");
 			var warning = _eventListener.Warnings[0].GetFullHumanReadableDescription();
 			Assert.That(warning, Does.Contain("'guid'").And.Contain(kPosGuid), warning);

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -261,17 +261,17 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		[Test]
 		public void RespelledIdMergesAsAnEditWhenTheGuidIsUnchanged()
 		{
-			var common = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "old");
+			var common = RangesWithPartOfSpeech(kDecomposedId, kPosGuid, "old");
 			// We upgraded, so our export normalizes the id.
-			var ours = RangesWithPartOfSpeech(kComposedName, kPosGuid, "old");
+			var ours = RangesWithPartOfSpeech(kComposedId, kPosGuid, "old");
 			// They did not upgrade, and they edited the abbreviation.
-			var theirs = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "new");
+			var theirs = RangesWithPartOfSpeech(kDecomposedId, kPosGuid, "new");
 
 			var result = DoMerge(common, ours, theirs, 0, 2);
 
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
-				string.Format("//range-element[@guid='{0}' and @id='{1}']", kPosGuid, kComposedName), 1);
+				string.Format("//range-element[@guid='{0}' and @id='{1}']", kPosGuid, kComposedId), 1);
 			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
 				"//range-element/abbrev/form/text[text()='new']", 1);
 		}
@@ -350,7 +350,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		[Test]
 		public void GuidMatchIsPreferredOverAnEarlierSiblingMatchingOnTheOldId()
 		{
-			var common = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "old");
+			var common = RangesWithPartOfSpeech(kDecomposedId, kPosGuid, "old");
 			// A guid-less element carrying the old id sorts ahead of our respelled one.
 			var ours = string.Format(
 @"<?xml version='1.0' encoding='utf-8'?>
@@ -363,8 +363,8 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 <abbrev><form lang='en'><text>old</text></form></abbrev>
 </range-element>
 </range>
-</lift-ranges>", kDecomposedName, kComposedName, kPosGuid);
-			var theirs = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "new");
+</lift-ranges>", kDecomposedId, kComposedId, kPosGuid);
+			var theirs = RangesWithPartOfSpeech(kDecomposedId, kPosGuid, "new");
 
 			// No conflict: the guid-less sibling is matched only against other guid-less elements, so it
 			// cannot also claim the element the guid already speaks for.
@@ -399,7 +399,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 <abbrev><form lang='en'><text>old</text></form></abbrev>
 </range-element>
 </range>
-</lift-ranges>", kDecomposedName, kComposedName, kPosGuid);
+</lift-ranges>", kDecomposedId, kComposedId, kPosGuid);
 
 			var result = DoMerge(duplicated, duplicated, duplicated, 0, 0);
 
@@ -410,13 +410,15 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			Assert.That(warning, Does.Not.Contain("'id'"), warning);
 		}
 
-		// Built rather than written out, since the two spellings are indistinguishable in source and an
-		// editor or a text filter that normalizes on save would silently make them the same string.
-		private static readonly string kDecomposedName = "Compléments".Normalize(NormalizationForm.FormD);
-		private static readonly string kComposedName = "Compléments".Normalize(NormalizationForm.FormC);
+		// The two @id values a part of speech named "Compléments" is exported under. Built rather than written
+		// out, since the two spellings are indistinguishable in source and an editor or a text filter that
+		// normalizes on save would silently make them the same string.
+		private static readonly string kDecomposedId = "Compléments".Normalize(NormalizationForm.FormD);
+		private static readonly string kComposedId = "Compléments".Normalize(NormalizationForm.FormC);
 		private const string kPosGuid = "e8c4b4b0-1a2f-4f9e-9f39-3f2b0d8f7a11";
 
-		private static string RangesWithPartOfSpeech(string id, string guid, string abbrev)
+		/// <summary>A null <paramref name="posGuidOrNull"/> leaves @guid off the element altogether.</summary>
+		private static string RangesWithPartOfSpeech(string posId, string posGuidOrNull, string abbrevText)
 		{
 			return string.Format(
 @"<?xml version='1.0' encoding='utf-8'?>
@@ -426,7 +428,7 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 <abbrev><form lang='en'><text>{2}</text></form></abbrev>
 </range-element>
 </range>
-</lift-ranges>", id, guid == null ? string.Empty : string.Format(" guid='{0}'", guid), abbrev);
+</lift-ranges>", posId, posGuidOrNull == null ? string.Empty : string.Format(" guid='{0}'", posGuidOrNull), abbrevText);
 		}
 
 		private string DoMerge(string commonAncestor, string ourContent, string theirContent,

--- a/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
+++ b/src/LibChorusTests/FileHandlers/LiftRanges/LiftRangesFileHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Chorus.FileTypeHandlers;
 using Chorus.merge;
 using LibChorus.TestUtilities;
@@ -317,6 +318,41 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 		}
 
 		/// <summary>
+		/// A sibling that still carries the old id, written by a tool that omits guids, must not be
+		/// taken as the partner just because it comes first in the file.
+		/// </summary>
+		[Test]
+		public void GuidMatchIsPreferredOverAnEarlierSiblingMatchingOnTheOldId()
+		{
+			var common = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "old");
+			// A guid-less element carrying the old id sorts ahead of our respelled one.
+			var ours = string.Format(
+@"<?xml version='1.0' encoding='utf-8'?>
+<lift-ranges>
+<range id='grammatical-info'>
+<range-element id='{0}'>
+<abbrev><form lang='en'><text>unrelated</text></form></abbrev>
+</range-element>
+<range-element id='{1}' guid='{2}'>
+<abbrev><form lang='en'><text>old</text></form></abbrev>
+</range-element>
+</range>
+</lift-ranges>", kDecomposedName, kComposedName, kPosGuid);
+			var theirs = RangesWithPartOfSpeech(kDecomposedName, kPosGuid, "new");
+
+			// The guid-less sibling genuinely is indistinguishable from the ancestor element under the
+			// fallback rule, so one conflict here is the merger reporting real ambiguity in the input.
+			var result = DoMerge(common, ours, theirs, 1, 4);
+
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath("//range/range-element", 2);
+			// Their edit belongs to the element sharing the guid, not to the one sharing the old id.
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(string.Format(
+				"//range-element[@guid='{0}']/abbrev/form/text[text()='new']", kPosGuid), 1);
+			AssertThatXmlIn.String(result).HasSpecifiedNumberOfMatchesForXpath(
+				"//range-element[not(@guid)]/abbrev/form/text[text()='unrelated']", 1);
+		}
+
+		/// <summary>
 		/// A merge done before the guid was preferred could leave one possibility standing as two
 		/// range-elements, spelled differently. Matching on the guid makes them ambiguous siblings,
 		/// which the merger collapses back to one.
@@ -343,8 +379,10 @@ namespace LibChorus.Tests.FileHandlers.LiftRanges
 			Assert.That(_eventListener.Warnings, Is.Not.Empty, "the dropped duplicate should be reported");
 		}
 
-		private const string kDecomposedName = "Compléments";	// e + combining acute
-		private const string kComposedName = "Compléments";	// precomposed e-acute
+		// Built rather than written out, since the two spellings are indistinguishable in source and an
+		// editor or a text filter that normalizes on save would silently make them the same string.
+		private static readonly string kDecomposedName = "Compléments".Normalize(NormalizationForm.FormD);
+		private static readonly string kComposedName = "Compléments".Normalize(NormalizationForm.FormC);
 		private const string kPosGuid = "e8c4b4b0-1a2f-4f9e-9f39-3f2b0d8f7a11";
 
 		private static string RangesWithPartOfSpeech(string id, string guid, string abbrev)


### PR DESCRIPTION
## Quick Summary

- Chorus matches `range-element` across revisions by its `@id`, comparing ordinally and
  normalizing nothing.
- But that id **is the possibility's own name**. It moves whenever the name is renamed,
  recapitalized, or respelled. Chorus then sees not "an attribute was edited" but "one
  element deleted, a different element added."
- What that costs, worst first:
  1. If the other user edited the same range-element in the same sync, `DoDeletions`
     raises a `RemovedVsEditedElementConflict` — a conflict note the users did nothing to
     earn.
  2. The merge output then carries **two `<range-element>` with the same `@guid`**, ids
     differing only in the respelling, because our element is an unmatched addition while
     theirs was kept by the conflict.
  3. Whichever side loses, the losing element's `<label>`, `<abbrev>`, `<description>` and
     traits travel with it rather than merging.
- This PR matches on the `guid` FLEx writes on every range-element, and on the `id` only
  among the elements that name no guid, since LIFT makes the guid optional.

## What prompted it

FieldWorks [sillsdev/FieldWorks#1063](https://github.com/sillsdev/FieldWorks/pull/1063)
(LT-22697) fixes a LIFT export defect: several `.lift-ranges` writes emitted FLEx's
in-memory NFD strings while the rest of the export, and the companion `.lift`, are NFC.
The fix normalizes the range-element ids, so **every affected id is respelled once** — and,
because the id is derived from the name at export time rather than stored, respelled on
*every* export by any client that has not yet upgraded. The exporter fix therefore lands on
exactly the weakness above, repeatedly, for as long as a project has a mixed set of FLEx
versions.

Nothing here is specific to normalization. An ordinary rename of a part of speech has always
had the same shape and is fixed by the same change.

## The change

### `FindByPreferredKeyAttribute`

A new finder beside the others in `FindNodeToMerge.cs`, constructed with a preferred key and a
fallback key.

- **Matching rule.** Elements naming a guid and elements lacking one are matched separately and
  never against each other. Two elements naming a guid are partners when the guid agrees,
  whatever their ids say; two naming none are partners when the id agrees, which is what this
  handler did before. Element names must agree too, matching the `(name, key)` tuple
  `FindByKeyAttribute` already uses. Unlike that single-key finder, a duplicate id is kept
  rather than treated as a programming error, since two elements may legitimately share an id
  and still be told apart by their guid; the first is indexed, matching how the merger resolves
  siblings it cannot distinguish.
- **Why the two sets stay apart.** If a guid-bearing element could match a bare one on the id,
  a parent holding both could give a single element two partners — Chorus would merge one
  incoming edit into two siblings, raising a conflict nobody caused and, where our side had not
  also changed, quietly applying someone's edit to a different object. Keeping them apart makes
  matching an equivalence relation, so nothing can be paired twice.
- **What the stricter rule costs.** Where one revision names a guid for an element and another
  does not:
  - The element reads as a deletion plus an addition, and as a `RemovedVsEditedElementConflict`
    if the other revision also edited it — the shape this PR removes for respelling, reached
    instead by dropping a guid.
  - A writer that starts naming guids pays that once, as projects will as their clients upgrade.
  - Writers that persistently disagree over whether to write it pay it on every merge between
    them. FLEx writes a guid on every range-element, so the fallback is for files whose writers
    omit it consistently, not for a mixture.
- **Identity is decided by index, not by position.** `GetNodeToMerge` resolves through the guid
  index, so a sibling that merely still carries the old id cannot win by appearing earlier in
  the file.
- **Indexed per parent.** Each parent's children are indexed once — by guid, and by id among the
  children that name no guid — rather than rescanned for every child, the same reason
  `FindByKeyAttribute` carries an index: a semantic-domain range runs to a couple of thousand
  elements and is walked for ours, theirs, ancestor and the ambiguity pass. An index is built
  when its parent is first searched and never revisited, which the callers here satisfy and
  which the code now says out loud.
- **Implements `IFindMatchingNodesToMerge`**, not just `IFindNodeToMerge`, so
  `XmlMergeService.RemoveAmbiguousChildren` still applies to range-elements. That also means a
  ranges file **already** carrying the duplicated pair, from a merge done before this change,
  has the two collapsed back into one — with a merge warning — the next time it is merged. What
  that collapse discards is trade-off 2 below.
- **One quiet improvement on the ambiguity path.** `FindByKeyAttribute.GetMatchingNodes`
  compares only the key attribute, so differently-named siblings sharing an id could be judged
  ambiguous and one of them dropped. This finder requires the element names to agree, which also
  aligns `GetMatchingNodes` with the tuple `GetNodeToMerge` resolves on.
- **The ambiguity warning names one key, the one that matched.** Whether an element names a guid
  decides which key it was matched on, so that key alone is what its ambiguous siblings share.
  Naming both would accuse a key the match never consulted, and which for two elements sharing a
  guid may well differ between them. The text follows the phrasing `FindByKeyAttribute` already
  uses: `The key attribute 'guid' has values that are the same '…'`.
- **Its documentation says preferred key and fallback key, not guid.** Per review feedback. The
  finder takes any two attribute names, so naming the guid in its summary put the LIFT case into
  `merge/xml/generic`; calling that key permanent claimed something the class neither enforces nor
  checks; and both keys are read with `GetOptionalAttributeString`, so calling only one of them
  optional invented an asymmetry that is not there. The wiring comment and the tests keep the
  guid/id language, which is where the concrete keys belong. The summary also no longer says
  "falling back", which had outlived the separate-sets rule above: an element that names a guid and
  finds no partner is not retried against the `id`.

### `IFindNodeToMerge`

The summary promised that a non-null result is a value in `acceptableTargets` — a contract no
indexed implementation has ever honored, since `FindByKeyAttribute` and the new finder both
answer from their index without consulting the set. It now states what implementations do
guarantee, a child of `parentToSearchIn` or null, and puts the filtering obligation on callers
that pass a strict subset, which is what `MergeChildrenMethod.FindMatchingNode` has always done.

### Wiring

`range-element` is switched to `FindByPreferredKeyAttribute("guid", "id")`. Note that
`AddLiftRangeElementStrategies` is registered by both the ranges handler and the main LIFT
handler, so this also governs any `range-element` appearing inside a `.lift` header's
`<ranges>`. That is intended — the identity argument is the same either way — but it is a wider
surface than the `.lift-ranges` file alone, and only the `.lift-ranges` path has test coverage
here.

## Deliberately not in this PR

- **`<range>` itself.** Its `id` is a stable identifier (`grammatical-info`, `morph-type`)
  rather than user data, and `XmlMergeService.Do3WayMerge` splits the file into records by
  `range/@id` outside the ElementStrategy system. Changing the element strategy alone would put
  the two out of step.
- **`<trait>`.** Keyed on `name`+`value`, so a respelled value is a delete plus an add there
  too, including the `feature-set` trait whose value is a composed feature-structure name.
  - Nothing to prefer instead — `@id` is optional on a trait and FLEx does not write it.
  - Smaller damage anyway — a trait is a leaf that both sides regenerate.
- **The other `OptionalKeyAttrFinder` call sites.** Same prefer-then-fall-back shape, and the
  obvious thing to reuse, but it implements only `IFindNodeToMerge`:
  - Adopting it here would have silently switched ambiguity detection off for range-elements.
  - Making *it* implement `IFindMatchingNodesToMerge` would change behavior for `note`, `field`,
    `relation`, `etymology` and `example` in the LIFT handler — a wider change than this defect
    justifies, and worth doing on its own.
- **Filtering `acceptableTargets` inside the finders.** The documentation is brought in line
  with the implementations rather than the reverse; making every finder honor the set would
  change matching for callers that pass a strict subset, which none of the current ones do.
- **Warning when a merged `<range>` ends up with a repeated `range-element/@id`.** Defensible,
  but it is a new diagnostic needing a post-merge pass over the file rather than anything the
  finder can see, and trade-off 1 below covers what such a file costs its consumers.

## Two behavior trade-offs, for reviewers to weigh

Changing what counts as the same element changes what counts as two elements, in both
directions. Neither direction is free.

### 1. Same id, different guids — now kept apart, so a file can carry a duplicate id

Two range-elements that share an id but hold different guids are now kept apart, where before
they were merged into one and a guid was lost; `RemoveAmbiguousChildren` no longer treats such a
pair as ambiguous either. They are two objects, so separate is right — but a merged ranges file
can now carry a duplicate `range-element/@id`, which is what `<grammatical-info value="…"/>` and
traits are resolved against. What its two consumers do with such a file:

- **The post-merge sort.** `LiftSorter.SortRange` keys its sorted collection through
  `GetUniqueKey`, which appends a numeric suffix rather than throwing on a repeated id. Run
  against the `SIL.Lift` 18.0.0-beta0032 this repo resolves, a ranges file holding two same-id
  elements sorts cleanly and keeps both.
- **FLEx's LIFT import** (read from `sillsdev/FieldWorks@main`):
  - Cannot fail on a duplicate id. Every id-keyed map is written with the indexer
    (`m_dictPos[id] = pos` in `ProcessPartOfSpeech`) or guarded by `ContainsKey`
    (`AddToPossibilityMap`); nothing calls `Add` on a bare range-element id.
  - Resolves each element on its own — guid (`GetPossibilityForGuidIfExisting`), then name and
    abbreviation (`FindMatchingPossibility`), then created. Two same-id elements whose guids the
    project does not know collapse into one possibility if their labels and abbrevs agree, and
    stand as two if they differ: the same dedupe-by-label the merge used to do, moved inside the
    project where a user can see and fix it.
  - Resolves trait and grammatical-info values through the id-keyed `m_dictPos`
    (`FindOrCreatePartOfSpeech`), which for a duplicated id holds the element processed last, so
    such a reference attaches to one of the two deterministically.

Older FLEx versions and WeSay's own `ILexiconMerger` implementation have not been checked. The
cost is bounded either way: a duplicate id is only reachable where two possibilities genuinely
share a name, and it costs a name-based reference landing on one of them, where the old behavior
cost an object its identity outright. `RangeElementsWithDifferentGuidsAreNotMatched` pins the new
shape so it can be argued about rather than discovered.

### 2. Same guid, different ids — now collapsed, and the loser's content goes with it

The mirror image, and the one that drops data. `RemoveAmbiguousChildren` asks the finder for
matches, so two range-elements sharing a guid are now ambiguous siblings: all but the first in
document order are removed, with a merge warning and nothing else. The loser's `<label>`,
`<abbrev>`, `<description>` and traits are discarded, not reconciled into the survivor. It fires
in `MakeRecordDictionary` as each of ours, theirs and ancestor is read, and `DoMerge` writes its
output from those same collapsed records — so a `<range>` that neither side edited is still
rewritten without the duplicate.

Weighing it:

- **This is a redirected drop, not a new one.** On master, `FindByKeyAttribute("id")` makes two
  elements sharing an *id* ambiguous, so master drops one of those with all of its content and
  the same bare warning. The pair master drops can be legitimate — two possibilities that happen
  to share a name, which is trade-off 1 above. The pair this PR drops never is: one guid within
  one `<range>` is one object, written twice. The drop moves off the legitimate case and onto
  the always-malformed one.
- **Nothing better is available at that layer.** `RemoveAmbiguousChildren` is a sanitizing pass
  over each revision as it is read, implementing the `DropAmbiguitiesAndAddErrorNote` option of
  the three the code notes but never built, and it has no view of which side wrote which
  element — so no principled winner to pick beyond document order. Reconciling the pair instead
  is a change to `AmbiguousSiblingPolicy`, worth doing on its own.
- **Keeping both is worse downstream.** FLEx resolves each element by guid first
  (`GetPossibilityForGuidIfExisting`), so a surviving duplicate-guid pair collapses into one
  possibility on import anyway, last-wins and silently. Chorus at least says it happened.
- **Declining to implement `IFindMatchingNodesToMerge`** avoids this entirely, and forfeits
  ambiguity detection for `range-element` altogether — including the same-id protection master
  has today. Rejected for the same reason `OptionalKeyAttrFinder` was.

`RangeElementsDuplicatedByAnEarlierMergeCollapseToOne` gives the two duplicates different
content, so this cost is asserted rather than left to be found later.

## Testing

Seven tests in `LiftRangesFileHandlerTests`:

1. `RespelledIdMergesAsAnEditWhenTheGuidIsUnchanged` — the LT-22697 scenario. We respell the id;
   they edit the abbreviation without upgrading. Asserts one element, our normalized id, and
   their edit surviving, with no conflict.
2. `GuidMatchIsPreferredOverAnEarlierSiblingMatchingOnTheOldId` — a guid-less sibling carrying
   the old id sits ahead of the respelled element. Asserts their edit lands on the element
   sharing the guid, the guid-less sibling keeps its own content, and no conflict is raised.
3. `RangeElementWithoutAGuidStillMergesOnItsId` — the fallback, for writers that omit guids.
4. `AnEmptyGuidCountsAsNoGuidAtAll` — the finder branches on the value, not on the attribute, so
   `guid=''` matches an element that omits the attribute outright.
5. `DroppingTheGuidReadsAsADeletionPlusAnAddition` — the cost of keeping the two sets apart,
   where a writer omits the guid the ancestor names and the other side edits the element.
6. `RangeElementsWithDifferentGuidsAreNotMatched` — trade-off 1.
7. `RangeElementsDuplicatedByAnEarlierMergeCollapseToOne` — trade-off 2, and the recovery path
   for repos already carrying the duplicate. The two duplicates are given different content, so
   the assertions say which survives and that the other's content does not come with it. Asserts
   also that the warning names the shared guid rather than blaming the ids, which differ.

The two Unicode spellings are built with `Normalize(NormalizationForm.FormD/FormC)` rather than
written as literals, since the forms are indistinguishable in source and an editor that
normalizes on save would quietly turn the test into a tautology.

```
dotnet test src/LibChorusTests/LibChorus.Tests.csproj -f net8.0 \
  --filter "FullyQualifiedName~merge.xml|FullyQualifiedName~FileHandlers"

this branch   541 passed, 13 failed
master        535 passed, 13 failed
```

The same 13 fail either way — all `Mercurial location has not been configured` in this
environment, none on a code path this touches. net462 and the full suite have not been run
locally; leaving this as a draft for CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/chorus/394)
<!-- Reviewable:end -->


